### PR TITLE
Mute, Deaf And Move

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -94,6 +94,7 @@ import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
+import org.javacord.api.listener.user.UserChangeSelfDeafenedListener;
 import org.javacord.api.listener.user.UserChangeSelfMutedListener;
 import org.javacord.api.listener.user.UserChangeStatusListener;
 import org.javacord.api.listener.user.UserStartTypingListener;
@@ -2458,6 +2459,22 @@ public interface DiscordApi {
      * @return A list with all registered user change self-muted listeners.
      */
     List<UserChangeSelfMutedListener> getUserChangeSelfMutedListeners();
+
+    /**
+     * Adds a listener, which listens to user self-deafened changes.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeSelfDeafenedListener> addUserChangeSelfDeafenedListener(
+            UserChangeSelfDeafenedListener listener);
+
+    /**
+     * Gets a list with all registered user change self-deafened listeners.
+     *
+     * @return A list with all registered user change self-deafened listeners.
+     */
+    List<UserChangeSelfDeafenedListener> getUserChangeSelfDeafenedListeners();
 
     /**
      * Adds a listener, which listens to connection losses.

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -92,6 +92,7 @@ import org.javacord.api.listener.server.role.UserRoleRemoveListener;
 import org.javacord.api.listener.user.UserChangeActivityListener;
 import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
+import org.javacord.api.listener.user.UserChangeMutedListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
 import org.javacord.api.listener.user.UserChangeSelfDeafenedListener;
@@ -2475,6 +2476,21 @@ public interface DiscordApi {
      * @return A list with all registered user change self-deafened listeners.
      */
     List<UserChangeSelfDeafenedListener> getUserChangeSelfDeafenedListeners();
+
+    /**
+     * Adds a listener, which listens to user muted changes.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeMutedListener> addUserChangeMutedListener(UserChangeMutedListener listener);
+
+    /**
+     * Gets a list with all registered user change muted listeners.
+     *
+     * @return A list with all registered user change muted listeners.
+     */
+    List<UserChangeMutedListener> getUserChangeMutedListeners();
 
     /**
      * Adds a listener, which listens to connection losses.

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -94,6 +94,7 @@ import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
+import org.javacord.api.listener.user.UserChangeSelfMutedListener;
 import org.javacord.api.listener.user.UserChangeStatusListener;
 import org.javacord.api.listener.user.UserStartTypingListener;
 import org.javacord.api.util.concurrent.ThreadPool;
@@ -2442,6 +2443,21 @@ public interface DiscordApi {
      * @return A list with all registered user change nickname listeners.
      */
     List<UserChangeNicknameListener> getUserChangeNicknameListeners();
+
+    /**
+     * Adds a listener, which listens to user self-muted changes.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeSelfMutedListener> addUserChangeSelfMutedListener(UserChangeSelfMutedListener listener);
+
+    /**
+     * Gets a list with all registered user change self-muted listeners.
+     *
+     * @return A list with all registered user change self-muted listeners.
+     */
+    List<UserChangeSelfMutedListener> getUserChangeSelfMutedListeners();
 
     /**
      * Adds a listener, which listens to connection losses.

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -91,6 +91,7 @@ import org.javacord.api.listener.server.role.UserRoleAddListener;
 import org.javacord.api.listener.server.role.UserRoleRemoveListener;
 import org.javacord.api.listener.user.UserChangeActivityListener;
 import org.javacord.api.listener.user.UserChangeAvatarListener;
+import org.javacord.api.listener.user.UserChangeDeafenedListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeMutedListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
@@ -2491,6 +2492,21 @@ public interface DiscordApi {
      * @return A list with all registered user change muted listeners.
      */
     List<UserChangeMutedListener> getUserChangeMutedListeners();
+
+    /**
+     * Adds a listener, which listens to user deafened changes.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeDeafenedListener> addUserChangeDeafenedListener(UserChangeDeafenedListener listener);
+
+    /**
+     * Gets a list with all registered user change deafened listeners.
+     *
+     * @return A list with all registered user change deafened listeners.
+     */
+    List<UserChangeDeafenedListener> getUserChangeDeafenedListeners();
 
     /**
      * Adds a listener, which listens to connection losses.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
@@ -165,6 +165,19 @@ public interface MessageAuthor extends DiscordEntity {
     }
 
     /**
+     * Checks if the author can move members on the server where the message was sent.
+     * Always returns {@code false} if the author is not a user or the message was not sent on a server.
+     *
+     * @return Whether the author can move members on the server or not.
+     */
+    default boolean canMoveMembersOnServer() {
+        return getMessage()
+                .getServer()
+                .flatMap(server -> asUser().map(server::canMoveMembers))
+                .orElse(false);
+    }
+
+    /**
      * Checks if the author can manage emojis on the server where the message was sent.
      * Always returns {@code false} if the author is not a user or the message was not sent on a server.
      *

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
@@ -139,6 +139,19 @@ public interface MessageAuthor extends DiscordEntity {
     }
 
     /**
+     * Checks if the author can mute members on the server where the message was sent.
+     * Always returns {@code false} if the author is not a user or the message was not sent on a server.
+     *
+     * @return Whether the author can mute members on the server or not.
+     */
+    default boolean canMuteMembersOnServer() {
+        return getMessage()
+                .getServer()
+                .flatMap(server -> asUser().map(server::canMuteMembers))
+                .orElse(false);
+    }
+
+    /**
      * Checks if the author can manage emojis on the server where the message was sent.
      * Always returns {@code false} if the author is not a user or the message was not sent on a server.
      *

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
@@ -152,6 +152,19 @@ public interface MessageAuthor extends DiscordEntity {
     }
 
     /**
+     * Checks if the author can deafen members on the server where the message was sent.
+     * Always returns {@code false} if the author is not a user or the message was not sent on a server.
+     *
+     * @return Whether the author can deafen members on the server or not.
+     */
+    default boolean canDeafenMembersOnServer() {
+        return getMessage()
+                .getServer()
+                .flatMap(server -> asUser().map(server::canDeafenMembers))
+                .orElse(false);
+    }
+
+    /**
      * Checks if the author can manage emojis on the server where the message was sent.
      * Always returns {@code false} if the author is not a user or the message was not sent on a server.
      *

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -136,6 +136,15 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     Optional<String> getNickname(User user);
 
     /**
+     * Gets your self-muted state.
+     *
+     * @return Whether you are self-muted.
+     */
+    default boolean areYouSelfMuted() {
+        return isSelfMuted(getApi().getYourself());
+    }
+
+    /**
      * Gets the self-muted state of the user with the given id.
      *
      * @param userId The id of the user to check.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -85,6 +85,7 @@ import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
+import org.javacord.api.listener.user.UserChangeSelfMutedListener;
 import org.javacord.api.listener.user.UserChangeStatusListener;
 import org.javacord.api.listener.user.UserStartTypingListener;
 import org.javacord.api.util.event.ListenerManager;
@@ -130,6 +131,24 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
      * @return The nickname of the user.
      */
     Optional<String> getNickname(User user);
+
+    /**
+     * Gets the self-muted state of the user with the given id.
+     *
+     * @param userId The id of the user to check.
+     * @return Whether the user with the given id is self-muted.
+     */
+    boolean isSelfMuted(long userId);
+
+    /**
+     * Gets the self-muted state of the given user.
+     *
+     * @param user The user to check.
+     * @return Whether the given user is self-muted.
+     */
+    default boolean isSelfMuted(User user) {
+        return isSelfMuted(user.getId());
+    }
 
     /**
      * Gets the display name of the user on this server.
@@ -2718,6 +2737,21 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
      * @return A list with all registered user change nickname listeners.
      */
     List<UserChangeNicknameListener> getUserChangeNicknameListeners();
+
+    /**
+     * Adds a listener, which listens to user self-muted changes in this server.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeSelfMutedListener> addUserChangeSelfMutedListener(UserChangeSelfMutedListener listener);
+
+    /**
+     * Gets a list with all registered user change self-muted listeners.
+     *
+     * @return A list with all registered user change self-muted listeners.
+     */
+    List<UserChangeSelfMutedListener> getUserChangeSelfMutedListeners();
 
     /**
      * Adds a listener, which listens to server text channel topic changes in this server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1281,6 +1281,30 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     CompletableFuture<Void> reorderRoles(List<Role> roles, String reason);
 
     /**
+     * Mutes yourself locally for the server.
+     *
+     * <p>This cannot be undone by other users. If you want to mute yourself server-sidely, so that others can unmute
+     * you, use {@link #muteYourself()}, {@link #muteUser(User)} or {@link #muteUser(User, String)}.
+     *
+     * @see #muteYourself()
+     * @see #muteUser(User)
+     * @see #muteUser(User, String)
+     */
+    void selfMute();
+
+    /**
+     * Unmutes yourself locally for the server.
+     *
+     * <p>This cannot be undone by other users. If you want to unmute yourself server-sidely, so that others can
+     * mute you, use {@link #unmuteYourself()}, {@link #unmuteUser(User)} or {@link #unmuteUser(User, String)}.
+     *
+     * @see #unmuteYourself()
+     * @see #unmuteUser(User)
+     * @see #unmuteUser(User, String)
+     */
+    void selfUnmute();
+
+    /**
      * Mutes yourself on the server.
      *
      * @return A future to check if the mute was successful.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -190,6 +190,15 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     }
 
     /**
+     * Gets your muted state.
+     *
+     * @return Whether you are muted.
+     */
+    default boolean areYouMuted() {
+        return isMuted(getApi().getYourself());
+    }
+
+    /**
      * Gets the muted state of the user with the given id.
      *
      * @param userId The id of the user to check.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -163,6 +163,15 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     }
 
     /**
+     * Gets your self-deafened state.
+     *
+     * @return Whether you are self-deafened.
+     */
+    default boolean areYouSelfDeafened() {
+        return isSelfDeafened(getApi().getYourself());
+    }
+
+    /**
      * Gets the self-deafened state of the user with the given id.
      *
      * @param userId The id of the user to check.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1317,6 +1317,16 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     CompletableFuture<Void> reorderRoles(List<Role> roles, String reason);
 
     /**
+     * Moves yourself to the given channel on the server.
+     *
+     * @param channel The channel to move the user to.
+     * @return A future to check if the move was successful.
+     */
+    default CompletableFuture<Void> moveYourself(ServerVoiceChannel channel) {
+        return moveUser(getApi().getYourself(), channel);
+    }
+
+    /**
      * Moves the given user to the given channel on the server.
      *
      * @param user The user to move.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -82,6 +82,7 @@ import org.javacord.api.listener.server.role.UserRoleAddListener;
 import org.javacord.api.listener.server.role.UserRoleRemoveListener;
 import org.javacord.api.listener.user.UserChangeActivityListener;
 import org.javacord.api.listener.user.UserChangeAvatarListener;
+import org.javacord.api.listener.user.UserChangeDeafenedListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeMutedListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
@@ -186,6 +187,24 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
      */
     default boolean isMuted(User user) {
         return isMuted(user.getId());
+    }
+
+    /**
+     * Gets the deafened state of the user with the given id.
+     *
+     * @param userId The id of the user to check.
+     * @return Whether the user with the given id is deafened.
+     */
+    boolean isDeafened(long userId);
+
+    /**
+     * Gets the deafened state of the given user.
+     *
+     * @param user The user to check.
+     * @return Whether the given user is deafened.
+     */
+    default boolean isDeafened(User user) {
+        return isDeafened(user.getId());
     }
 
     /**
@@ -2821,6 +2840,21 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
      * @return A list with all registered user change muted listeners.
      */
     List<UserChangeMutedListener> getUserChangeMutedListeners();
+
+    /**
+     * Adds a listener, which listens to user deafened changes in this server.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeDeafenedListener> addUserChangeDeafenedListener(UserChangeDeafenedListener listener);
+
+    /**
+     * Gets a list with all registered user change deafened listeners.
+     *
+     * @return A list with all registered user change deafened listeners.
+     */
+    List<UserChangeDeafenedListener> getUserChangeDeafenedListeners();
 
     /**
      * Adds a listener, which listens to server text channel topic changes in this server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -83,6 +83,7 @@ import org.javacord.api.listener.server.role.UserRoleRemoveListener;
 import org.javacord.api.listener.user.UserChangeActivityListener;
 import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
+import org.javacord.api.listener.user.UserChangeMutedListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
 import org.javacord.api.listener.user.UserChangeSelfDeafenedListener;
@@ -167,6 +168,24 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
      */
     default boolean isSelfDeafened(User user) {
         return isSelfDeafened(user.getId());
+    }
+
+    /**
+     * Gets the muted state of the user with the given id.
+     *
+     * @param userId The id of the user to check.
+     * @return Whether the user with the given id is muted.
+     */
+    boolean isMuted(long userId);
+
+    /**
+     * Gets the muted state of the given user.
+     *
+     * @param user The user to check.
+     * @return Whether the given user is muted.
+     */
+    default boolean isMuted(User user) {
+        return isMuted(user.getId());
     }
 
     /**
@@ -2787,6 +2806,21 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
      * @return A list with all registered user change self-deafened listeners.
      */
     List<UserChangeSelfDeafenedListener> getUserChangeSelfDeafenedListeners();
+
+    /**
+     * Adds a listener, which listens to user muted changes in this server.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeMutedListener> addUserChangeMutedListener(UserChangeMutedListener listener);
+
+    /**
+     * Gets a list with all registered user change muted listeners.
+     *
+     * @return A list with all registered user change muted listeners.
+     */
+    List<UserChangeMutedListener> getUserChangeMutedListeners();
 
     /**
      * Adds a listener, which listens to server text channel topic changes in this server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2178,6 +2178,27 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     }
 
     /**
+     * Checks if the given user can mute members on the server.
+     *
+     * @param user The user to check.
+     * @return Whether the given user can mute members or not.
+     */
+    default boolean canMuteMembers(User user) {
+        return hasAnyPermission(user,
+                                PermissionType.ADMINISTRATOR,
+                                PermissionType.VOICE_MUTE_MEMBERS);
+    }
+
+    /**
+     * Checks if the user of the connected account can mute members on the server.
+     *
+     * @return Whether the user of the connected account can mute members or not.
+     */
+    default boolean canYouMuteMembers() {
+        return canMuteMembers(getApi().getYourself());
+    }
+
+    /**
      * Checks if the given user can manage emojis on the server.
      *
      * @param user The user to check.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2220,6 +2220,27 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     }
 
     /**
+     * Checks if the given user can move members on the server.
+     *
+     * @param user The user to check.
+     * @return Whether the given user can move members or not.
+     */
+    default boolean canMoveMembers(User user) {
+        return hasAnyPermission(user,
+                                PermissionType.ADMINISTRATOR,
+                                PermissionType.VOICE_MOVE_MEMBERS);
+    }
+
+    /**
+     * Checks if the user of the connected account can move members on the server.
+     *
+     * @return Whether the user of the connected account can move members or not.
+     */
+    default boolean canYouMoveMembers() {
+        return canMoveMembers(getApi().getYourself());
+    }
+
+    /**
      * Checks if the given user can manage emojis on the server.
      *
      * @param user The user to check.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -85,6 +85,7 @@ import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
+import org.javacord.api.listener.user.UserChangeSelfDeafenedListener;
 import org.javacord.api.listener.user.UserChangeSelfMutedListener;
 import org.javacord.api.listener.user.UserChangeStatusListener;
 import org.javacord.api.listener.user.UserStartTypingListener;
@@ -148,6 +149,24 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
      */
     default boolean isSelfMuted(User user) {
         return isSelfMuted(user.getId());
+    }
+
+    /**
+     * Gets the self-deafened state of the user with the given id.
+     *
+     * @param userId The id of the user to check.
+     * @return Whether the user with the given id is self-deafened.
+     */
+    boolean isSelfDeafened(long userId);
+
+    /**
+     * Gets the self-deafened state of the given user.
+     *
+     * @param user The user to check.
+     * @return Whether the given user is self-deafened.
+     */
+    default boolean isSelfDeafened(User user) {
+        return isSelfDeafened(user.getId());
     }
 
     /**
@@ -2752,6 +2771,22 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
      * @return A list with all registered user change self-muted listeners.
      */
     List<UserChangeSelfMutedListener> getUserChangeSelfMutedListeners();
+
+    /**
+     * Adds a listener, which listens to user self-deafened changes in this server.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeSelfDeafenedListener> addUserChangeSelfDeafenedListener(
+            UserChangeSelfDeafenedListener listener);
+
+    /**
+     * Gets a list with all registered user change self-deafened listeners.
+     *
+     * @return A list with all registered user change self-deafened listeners.
+     */
+    List<UserChangeSelfDeafenedListener> getUserChangeSelfDeafenedListeners();
 
     /**
      * Adds a listener, which listens to server text channel topic changes in this server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1281,6 +1281,48 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     CompletableFuture<Void> reorderRoles(List<Role> roles, String reason);
 
     /**
+     * Mutes the given user on the server.
+     *
+     * @param user The user to mute.
+     * @return A future to check if the mute was successful.
+     */
+    default CompletableFuture<Void> muteUser(User user) {
+        return createUpdater().setMuted(user, true).update();
+    }
+
+    /**
+     * Mutes the given user on the server.
+     *
+     * @param user The user to mute.
+     * @param reason The audit log reason for this action.
+     * @return A future to check if the mute was successful.
+     */
+    default CompletableFuture<Void> muteUser(User user, String reason) {
+        return createUpdater().setMuted(user, true).setAuditLogReason(reason).update();
+    }
+
+    /**
+     * Unmutes the given user on the server.
+     *
+     * @param user The user to unmute.
+     * @return A future to check if the unmute was successful.
+     */
+    default CompletableFuture<Void> unmuteUser(User user) {
+        return createUpdater().setMuted(user, false).update();
+    }
+
+    /**
+     * Unmutes the given user on the server.
+     *
+     * @param user The user to unmute.
+     * @param reason The audit log reason for this action.
+     * @return A future to check if the unmute was successful.
+     */
+    default CompletableFuture<Void> unmuteUser(User user, String reason) {
+        return createUpdater().setMuted(user, false).setAuditLogReason(reason).update();
+    }
+
+    /**
      * Kicks the given user from the server.
      *
      * @param user The user to kick.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1281,6 +1281,24 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     CompletableFuture<Void> reorderRoles(List<Role> roles, String reason);
 
     /**
+     * Mutes yourself on the server.
+     *
+     * @return A future to check if the mute was successful.
+     */
+    default CompletableFuture<Void> muteYourself() {
+        return muteUser(getApi().getYourself());
+    }
+
+    /**
+     * Unmutes yourself on the server.
+     *
+     * @return A future to check if the unmute was successful.
+     */
+    default CompletableFuture<Void> unmuteYourself() {
+        return unmuteUser(getApi().getYourself());
+    }
+
+    /**
      * Mutes the given user on the server.
      *
      * @param user The user to mute.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1365,6 +1365,30 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     }
 
     /**
+     * Deafens yourself locally for the server.
+     *
+     * <p>This cannot be undone by other users. If you want to deafen yourself server-sidely, so that others can
+     * undeafen you, use {@link #deafenYourself()}, {@link #deafenUser(User)} or {@link #deafenUser(User, String)}.
+     *
+     * @see #deafenYourself()
+     * @see #deafenUser(User)
+     * @see #deafenUser(User, String)
+     */
+    void selfDeafen();
+
+    /**
+     * Undeafens yourself locally for the server.
+     *
+     * <p>This cannot be undone by other users. If you want to undeafen yourself server-sidely, so that others can
+     * deafen you, use {@link #undeafenYourself()}, {@link #undeafenUser(User)} or {@link #undeafenUser(User, String)}.
+     *
+     * @see #undeafenYourself()
+     * @see #undeafenUser(User)
+     * @see #undeafenUser(User, String)
+     */
+    void selfUndeafen();
+
+    /**
      * Deafens yourself on the server.
      *
      * @return A future to check if the deafen was successful.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1365,6 +1365,24 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     }
 
     /**
+     * Deafens yourself on the server.
+     *
+     * @return A future to check if the deafen was successful.
+     */
+    default CompletableFuture<Void> deafenYourself() {
+        return deafenUser(getApi().getYourself());
+    }
+
+    /**
+     * Undeafens yourself on the server.
+     *
+     * @return A future to check if the undeafen was successful.
+     */
+    default CompletableFuture<Void> undeafenYourself() {
+        return undeafenUser(getApi().getYourself());
+    }
+
+    /**
      * Deafens the given user on the server.
      *
      * @param user The user to deafen.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1102,43 +1102,57 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     /**
      * Changes the nickname of the given user.
      *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
+     *
      * @param user The user.
      * @param nickname The new nickname of the user.
      * @return A future to check if the update was successful.
      */
     default CompletableFuture<Void> updateNickname(User user, String nickname) {
-        return updateNickname(user, nickname, null);
+        return createUpdater().setNickname(user, nickname).update();
     }
 
     /**
      * Changes the nickname of the given user.
+     *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
      * @param user The user.
      * @param nickname The new nickname of the user.
      * @param reason The audit log reason for this update.
      * @return A future to check if the update was successful.
      */
-    CompletableFuture<Void> updateNickname(User user, String nickname, String reason);
+    default CompletableFuture<Void> updateNickname(User user, String nickname, String reason) {
+        return createUpdater().setNickname(user, nickname).setAuditLogReason(reason).update();
+    }
 
     /**
      * Removes the nickname of the given user.
+     *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
      * @param user The user.
      * @return A future to check if the update was successful.
      */
     default CompletableFuture<Void> resetNickname(User user) {
-        return updateNickname(user, null);
+        return createUpdater().setNickname(user, null).update();
     }
 
     /**
      * Removes the nickname of the given user.
+     *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
      * @param user The user.
      * @param reason The audit log reason for this update.
      * @return A future to check if the update was successful.
      */
     default CompletableFuture<Void> resetNickname(User user, String reason) {
-        return updateNickname(user, null, reason);
+        return createUpdater().setNickname(user, null).setAuditLogReason(reason).update();
     }
 
     /**
@@ -1213,24 +1227,39 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
      * Updates the roles of a server member.
      * This will replace the roles of the server member with a provided collection.
      *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
+     *
      * @param user The user to update the roles of.
      * @param roles The collection of roles to replace the user's roles.
      * @return A future to check if the update was successful.
      */
     default CompletableFuture<Void> updateRoles(User user, Collection<Role> roles) {
-        return updateRoles(user, roles, null);
+        return createUpdater()
+                .removeAllRolesFromUser(user)
+                .addRolesToUser(user, roles)
+                .update();
     }
 
     /**
      * Updates the roles of a server member.
      * This will replace the roles of the server member with a provided collection.
      *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
+     *
      * @param user The user to update the roles of.
      * @param roles The collection of roles to replace the user's roles.
      * @param reason The audit log reason for this update.
      * @return A future to check if the update was successful.
      */
-    CompletableFuture<Void> updateRoles(User user, Collection<Role> roles, String reason);
+    default CompletableFuture<Void> updateRoles(User user, Collection<Role> roles, String reason) {
+        return createUpdater()
+                .removeAllRolesFromUser(user)
+                .addRolesToUser(user, roles)
+                .setAuditLogReason(reason)
+                .update();
+    }
 
     /**
      * Reorders the roles of the server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2199,6 +2199,27 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     }
 
     /**
+     * Checks if the given user can deafen members on the server.
+     *
+     * @param user The user to check.
+     * @return Whether the given user can deafen members or not.
+     */
+    default boolean canDeafenMembers(User user) {
+        return hasAnyPermission(user,
+                                PermissionType.ADMINISTRATOR,
+                                PermissionType.VOICE_DEAFEN_MEMBERS);
+    }
+
+    /**
+     * Checks if the user of the connected account can deafen members on the server.
+     *
+     * @return Whether the user of the connected account can deafen members or not.
+     */
+    default boolean canYouDeafenMembers() {
+        return canDeafenMembers(getApi().getYourself());
+    }
+
+    /**
      * Checks if the given user can manage emojis on the server.
      *
      * @param user The user to check.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -217,6 +217,15 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     }
 
     /**
+     * Gets your deafened state.
+     *
+     * @return Whether you are deafened.
+     */
+    default boolean areYouDeafened() {
+        return isDeafened(getApi().getYourself());
+    }
+
+    /**
      * Gets the deafened state of the user with the given id.
      *
      * @param userId The id of the user to check.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1281,6 +1281,17 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     CompletableFuture<Void> reorderRoles(List<Role> roles, String reason);
 
     /**
+     * Moves the given user to the given channel on the server.
+     *
+     * @param user The user to move.
+     * @param channel The channel to move the user to.
+     * @return A future to check if the move was successful.
+     */
+    default CompletableFuture<Void> moveUser(User user, ServerVoiceChannel channel) {
+        return createUpdater().setVoiceChannel(user, channel).update();
+    }
+
+    /**
      * Mutes yourself locally for the server.
      *
      * <p>This cannot be undone by other users. If you want to mute yourself server-sidely, so that others can unmute

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -723,7 +723,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the name of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -736,7 +736,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the region of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -749,7 +749,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the explicit content filter level of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -763,7 +763,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the verification level of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -776,7 +776,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the default message notification level of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -790,7 +790,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the afk channel of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -803,7 +803,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Removes the afk channel of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -815,7 +815,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the afk timeout of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -829,7 +829,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     /**
      * Updates the icon of the server.
      * This method assumes the file type is "png"!
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -842,7 +842,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the icon of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -856,7 +856,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the icon of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -869,7 +869,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the icon of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -882,7 +882,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the icon of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -896,7 +896,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     /**
      * Updates the icon of the server.
      * This method assumes the file type is "png"!
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -909,7 +909,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the icon of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -924,7 +924,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     /**
      * Updates the icon of the server.
      * This method assumes the file type is "png"!
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -937,7 +937,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Updates the icon of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -951,7 +951,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
 
     /**
      * Removes the icon of the server.
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -964,7 +964,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     /**
      * Updates the owner of the server.
      * You must be the owner of this server in order to transfer it!
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *
@@ -978,7 +978,7 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     /**
      * Updates the splash of the server.
      * This method assumes the file type is "png"!
-     * 
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link ServerUpdater} from {@link #createUpdater()} which provides a better performance!
      *

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1323,6 +1323,48 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     }
 
     /**
+     * Deafens the given user on the server.
+     *
+     * @param user The user to deafen.
+     * @return A future to check if the deafen was successful.
+     */
+    default CompletableFuture<Void> deafenUser(User user) {
+        return createUpdater().setDeafened(user, true).update();
+    }
+
+    /**
+     * Deafens the given user on the server.
+     *
+     * @param user The user to deafen.
+     * @param reason The audit log reason for this action.
+     * @return A future to check if the deafen was successful.
+     */
+    default CompletableFuture<Void> deafenUser(User user, String reason) {
+        return createUpdater().setDeafened(user, true).setAuditLogReason(reason).update();
+    }
+
+    /**
+     * Undeafens the given user on the server.
+     *
+     * @param user The user to undeafen.
+     * @return A future to check if the undeafen was successful.
+     */
+    default CompletableFuture<Void> undeafenUser(User user) {
+        return createUpdater().setDeafened(user, false).update();
+    }
+
+    /**
+     * Undeafens the given user on the server.
+     *
+     * @param user The user to undeafen.
+     * @param reason The audit log reason for this action.
+     * @return A future to check if the undeafen was successful.
+     */
+    default CompletableFuture<Void> undeafenUser(User user, String reason) {
+        return createUpdater().setDeafened(user, false).setAuditLogReason(reason).update();
+    }
+
+    /**
      * Kicks the given user from the server.
      *
      * @param user The user to kick.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/ServerUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/ServerUpdater.java
@@ -440,8 +440,8 @@ public class ServerUpdater {
      * @param roles The roles which should be added to the server member.
      * @return The current instance in order to chain call methods.
      */
-    public ServerUpdater addAllRolesToUser(User user, Collection<Role> roles) {
-        delegate.addAllRolesToUser(user, roles);
+    public ServerUpdater addRolesToUser(User user, Collection<Role> roles) {
+        delegate.addRolesToUser(user, roles);
         return this;
     }
 
@@ -464,8 +464,19 @@ public class ServerUpdater {
      * @param roles The roles which should be removed from the user.
      * @return The current instance in order to chain call methods.
      */
-    public ServerUpdater removeAllRolesFromUser(User user, Collection<Role> roles) {
-        delegate.removeAllRolesFromUser(user, roles);
+    public ServerUpdater removeRolesFromUser(User user, Collection<Role> roles) {
+        delegate.removeRolesFromUser(user, roles);
+        return this;
+    }
+
+    /**
+     * Queues all roles to be removed from the user.
+     *
+     * @param user The server member the roles should be removed from.
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerUpdater removeAllRolesFromUser(User user) {
+        delegate.removeAllRolesFromUser(user);
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/ServerUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/ServerUpdater.java
@@ -435,6 +435,18 @@ public class ServerUpdater {
     }
 
     /**
+     * Queues a moving a user to a different voice channel.
+     *
+     * @param user The user who should be moved.
+     * @param channel The new voice channel of the user.
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerUpdater setVoiceChannel(User user, ServerVoiceChannel channel) {
+        delegate.setVoiceChannel(user, channel);
+        return this;
+    }
+
+    /**
      * Sets the new order for the server's roles.
      *
      * @param roles An ordered list with the new role positions.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/ServerUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/ServerUpdater.java
@@ -423,6 +423,18 @@ public class ServerUpdater {
     }
 
     /**
+     * Queues a user's deafened state to be updated.
+     *
+     * @param user The user whose deafened state should be updated.
+     * @param deafened The new deafened state of the user.
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerUpdater setDeafened(User user, boolean deafened) {
+        delegate.setDeafened(user, deafened);
+        return this;
+    }
+
+    /**
      * Sets the new order for the server's roles.
      *
      * @param roles An ordered list with the new role positions.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/ServerUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/ServerUpdater.java
@@ -411,6 +411,18 @@ public class ServerUpdater {
     }
 
     /**
+     * Queues a user's muted state to be updated.
+     *
+     * @param user The user whose muted state should be updated.
+     * @param muted The new muted state of the user.
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerUpdater setMuted(User user, boolean muted) {
+        delegate.setMuted(user, muted);
+        return this;
+    }
+
+    /**
      * Sets the new order for the server's roles.
      *
      * @param roles An ordered list with the new role positions.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/internal/ServerUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/internal/ServerUpdaterDelegate.java
@@ -279,6 +279,14 @@ public interface ServerUpdaterDelegate {
     void setDeafened(User user, boolean deafened);
 
     /**
+     * Queues a moving a user to a different voice channel.
+     *
+     * @param user The user who should be moved.
+     * @param channel The new voice channel of the user.
+     */
+    void setVoiceChannel(User user, ServerVoiceChannel channel);
+
+    /**
      * Sets the new order for the server's roles.
      *
      * @param roles An ordered list with the new role positions.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/internal/ServerUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/internal/ServerUpdaterDelegate.java
@@ -283,7 +283,7 @@ public interface ServerUpdaterDelegate {
      * @param user The user to whom the roles should be assigned.
      * @param roles The collection of roles to be assigned.
      */
-    void addAllRolesToUser(User user, Collection<Role> roles);
+    void addRolesToUser(User user, Collection<Role> roles);
 
     /**
      * Queues a role to be removed from the user.
@@ -299,7 +299,14 @@ public interface ServerUpdaterDelegate {
      * @param user The user who should lose the roles.
      * @param roles The collection of roles to be removed.
      */
-    void removeAllRolesFromUser(User user, Collection<Role> roles);
+    void removeRolesFromUser(User user, Collection<Role> roles);
+
+    /**
+     * Queues all roles to be removed from the user.
+     *
+     * @param user The user who should lose the roles.
+     */
+    void removeAllRolesFromUser(User user);
 
     /**
      * Performs the queued updates.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/internal/ServerUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/internal/ServerUpdaterDelegate.java
@@ -263,6 +263,14 @@ public interface ServerUpdaterDelegate {
     void setNickname(User user, String nickname);
 
     /**
+     * Queues a user's muted state to be updated.
+     *
+     * @param user The user whose muted state should be updated.
+     * @param muted The new muted state of the user.
+     */
+    void setMuted(User user, boolean muted);
+
+    /**
      * Sets the new order for the server's roles.
      *
      * @param roles An ordered list with the new role positions.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/internal/ServerUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/internal/ServerUpdaterDelegate.java
@@ -271,6 +271,14 @@ public interface ServerUpdaterDelegate {
     void setMuted(User user, boolean muted);
 
     /**
+     * Queues a user's deafened state to be updated.
+     *
+     * @param user The user whose deafened state should be updated.
+     * @param deafened The new deafened state of the user.
+     */
+    void setDeafened(User user, boolean deafened);
+
+    /**
      * Sets the new order for the server's roles.
      *
      * @param roles An ordered list with the new role positions.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -38,6 +38,7 @@ import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
+import org.javacord.api.listener.user.UserChangeSelfDeafenedListener;
 import org.javacord.api.listener.user.UserChangeSelfMutedListener;
 import org.javacord.api.listener.user.UserChangeStatusListener;
 import org.javacord.api.listener.user.UserStartTypingListener;
@@ -232,6 +233,16 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
      */
     default boolean isSelfMuted(Server server) {
         return server.isSelfMuted(getId());
+    }
+
+    /**
+     * Gets the self-deafened state of the user in the given server.
+     *
+     * @param server The server to check.
+     * @return Whether the user is self-deafened in the given server.
+     */
+    default boolean isSelfDeafened(Server server) {
+        return server.isSelfDeafened(getId());
     }
 
     /**
@@ -625,6 +636,22 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
      * @return A list with all registered user change self-muted listeners.
      */
     List<UserChangeSelfMutedListener> getUserChangeSelfMutedListeners();
+
+    /**
+     * Adds a listener, which listens to self-deafened changes of this user.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeSelfDeafenedListener> addUserChangeSelfDeafenedListener(
+            UserChangeSelfDeafenedListener listener);
+
+    /**
+     * Gets a list with all registered user change self-deafened listeners.
+     *
+     * @return A list with all registered user change self-deafened listeners.
+     */
+    List<UserChangeSelfDeafenedListener> getUserChangeSelfDeafenedListeners();
 
     /**
      * Adds a listener, which listens to this user being added to roles.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -36,6 +36,7 @@ import org.javacord.api.listener.user.UserAttachableListener;
 import org.javacord.api.listener.user.UserChangeActivityListener;
 import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
+import org.javacord.api.listener.user.UserChangeMutedListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
 import org.javacord.api.listener.user.UserChangeSelfDeafenedListener;
@@ -243,6 +244,16 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
      */
     default boolean isSelfDeafened(Server server) {
         return server.isSelfDeafened(getId());
+    }
+
+    /**
+     * Gets the muted state of the user in the given server.
+     *
+     * @param server The server to check.
+     * @return Whether the user is muted in the given server.
+     */
+    default boolean isMuted(Server server) {
+        return server.isMuted(getId());
     }
 
     /**
@@ -652,6 +663,21 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
      * @return A list with all registered user change self-deafened listeners.
      */
     List<UserChangeSelfDeafenedListener> getUserChangeSelfDeafenedListeners();
+
+    /**
+     * Adds a listener, which listens to muted changes of this user.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeMutedListener> addUserChangeMutedListener(UserChangeMutedListener listener);
+
+    /**
+     * Gets a list with all registered user change muted listeners.
+     *
+     * @return A list with all registered user change muted listeners.
+     */
+    List<UserChangeMutedListener> getUserChangeMutedListeners();
 
     /**
      * Adds a listener, which listens to this user being added to roles.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -208,6 +208,18 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
     }
 
     /**
+     * Changes the nickname of the user in the given server.
+     *
+     * @param server The server.
+     * @param nickname The new nickname of the user.
+     * @param reason The audit log reason for this update.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Void> updateNickname(Server server, String nickname, String reason) {
+        return server.updateNickname(this, nickname, reason);
+    }
+
+    /**
      * Removes the nickname of the user in the given server.
      *
      * @param server The server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -230,6 +230,17 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
     }
 
     /**
+     * Removes the nickname of the user in the given server.
+     *
+     * @param server The server.
+     * @param reason The audit log reason for this update.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Void> resetNickname(Server server, String reason) {
+        return server.resetNickname(this, reason);
+    }
+
+    /**
      * Gets the nickname of the user in the given server.
      *
      * @param server The server to check.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -35,6 +35,7 @@ import org.javacord.api.listener.server.role.UserRoleRemoveListener;
 import org.javacord.api.listener.user.UserAttachableListener;
 import org.javacord.api.listener.user.UserChangeActivityListener;
 import org.javacord.api.listener.user.UserChangeAvatarListener;
+import org.javacord.api.listener.user.UserChangeDeafenedListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeMutedListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
@@ -254,6 +255,16 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
      */
     default boolean isMuted(Server server) {
         return server.isMuted(getId());
+    }
+
+    /**
+     * Gets the deafened state of the user in the given server.
+     *
+     * @param server The server to check.
+     * @return Whether the user is deafened in the given server.
+     */
+    default boolean isDeafened(Server server) {
+        return server.isDeafened(getId());
     }
 
     /**
@@ -678,6 +689,21 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
      * @return A list with all registered user change muted listeners.
      */
     List<UserChangeMutedListener> getUserChangeMutedListeners();
+
+    /**
+     * Adds a listener, which listens to deafened changes of this user.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeDeafenedListener> addUserChangeDeafenedListener(UserChangeDeafenedListener listener);
+
+    /**
+     * Gets a list with all registered user change deafened listeners.
+     *
+     * @return A list with all registered user change deafened listeners.
+     */
+    List<UserChangeDeafenedListener> getUserChangeDeafenedListeners();
 
     /**
      * Adds a listener, which listens to this user being added to roles.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -199,6 +199,9 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
     /**
      * Changes the nickname of the user in the given server.
      *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerUpdater} from {@link Server#createUpdater()} which provides a better performance!
+     *
      * @param server The server.
      * @param nickname The new nickname of the user.
      * @return A future to check if the update was successful.
@@ -209,6 +212,9 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
 
     /**
      * Changes the nickname of the user in the given server.
+     *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerUpdater} from {@link Server#createUpdater()} which provides a better performance!
      *
      * @param server The server.
      * @param nickname The new nickname of the user.
@@ -222,6 +228,9 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
     /**
      * Removes the nickname of the user in the given server.
      *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerUpdater} from {@link Server#createUpdater()} which provides a better performance!
+     *
      * @param server The server.
      * @return A future to check if the update was successful.
      */
@@ -231,6 +240,9 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
 
     /**
      * Removes the nickname of the user in the given server.
+     *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerUpdater} from {@link Server#createUpdater()} which provides a better performance!
      *
      * @param server The server.
      * @param reason The audit log reason for this update.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -38,6 +38,7 @@ import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
+import org.javacord.api.listener.user.UserChangeSelfMutedListener;
 import org.javacord.api.listener.user.UserChangeStatusListener;
 import org.javacord.api.listener.user.UserStartTypingListener;
 import org.javacord.api.util.event.ListenerManager;
@@ -221,6 +222,16 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
      */
     default Optional<String> getNickname(Server server) {
         return server.getNickname(this);
+    }
+
+    /**
+     * Gets the self-muted state of the user in the given server.
+     *
+     * @param server The server to check.
+     * @return Whether the user is self-muted in the given server.
+     */
+    default boolean isSelfMuted(Server server) {
+        return server.isSelfMuted(getId());
     }
 
     /**
@@ -599,6 +610,21 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
      * @return A list with all registered user change nickname listeners.
      */
     List<UserChangeNicknameListener> getUserChangeNicknameListeners();
+
+    /**
+     * Adds a listener, which listens to self-muted changes of this user.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<UserChangeSelfMutedListener> addUserChangeSelfMutedListener(UserChangeSelfMutedListener listener);
+
+    /**
+     * Gets a list with all registered user change self-muted listeners.
+     *
+     * @return A list with all registered user change self-muted listeners.
+     */
+    List<UserChangeSelfMutedListener> getUserChangeSelfMutedListeners();
 
     /**
      * Adds a listener, which listens to this user being added to roles.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -263,6 +263,16 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
     }
 
     /**
+     * Moves this user to the given channel.
+     *
+     * @param channel The channel to move the user to.
+     * @return A future to check if the move was successful.
+     */
+    default CompletableFuture<Void> move(ServerVoiceChannel channel) {
+        return channel.getServer().moveUser(this, channel);
+    }
+
+    /**
      * Gets the self-muted state of the user in the given server.
      *
      * @param server The server to check.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -335,6 +335,48 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
     }
 
     /**
+     * Deafens this user on the given server.
+     *
+     * @param server The server to deafen this user on.
+     * @return A future to check if the deafen was successful.
+     */
+    default CompletableFuture<Void> deafen(Server server) {
+        return server.deafenUser(this);
+    }
+
+    /**
+     * Deafens this user on the given server.
+     *
+     * @param server The server to deafen this user on.
+     * @param reason The audit log reason for this action.
+     * @return A future to check if the deafen was successful.
+     */
+    default CompletableFuture<Void> deafen(Server server, String reason) {
+        return server.deafenUser(this, reason);
+    }
+
+    /**
+     * Undeafens this user on the given server.
+     *
+     * @param server The server to undeafen this user on.
+     * @return A future to check if the undeafen was successful.
+     */
+    default CompletableFuture<Void> undeafen(Server server) {
+        return server.undeafenUser(this);
+    }
+
+    /**
+     * Undeafens this user on the given server.
+     *
+     * @param server The server to undeafen this user on.
+     * @param reason The audit log reason for this action.
+     * @return A future to check if the undeafen was successful.
+     */
+    default CompletableFuture<Void> undeafen(Server server, String reason) {
+        return server.undeafenUser(this, reason);
+    }
+
+    /**
      * Gets the deafened state of the user in the given server.
      *
      * @param server The server to check.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -283,6 +283,48 @@ public interface User extends DiscordEntity, Messageable, Mentionable, Updatable
     }
 
     /**
+     * Mutes this user on the given server.
+     *
+     * @param server The server to umute this user on.
+     * @return A future to check if the mute was successful.
+     */
+    default CompletableFuture<Void> mute(Server server) {
+        return server.muteUser(this);
+    }
+
+    /**
+     * Mutes this user on the given server.
+     *
+     * @param server The server to umute this user on.
+     * @param reason The audit log reason for this action.
+     * @return A future to check if the mute was successful.
+     */
+    default CompletableFuture<Void> mute(Server server, String reason) {
+        return server.muteUser(this, reason);
+    }
+
+    /**
+     * Unmutes this user on the given server.
+     *
+     * @param server The server to unumute this user on.
+     * @return A future to check if the unmute was successful.
+     */
+    default CompletableFuture<Void> unmute(Server server) {
+        return server.unmuteUser(this);
+    }
+
+    /**
+     * Unmutes this user on the given server.
+     *
+     * @param server The server to unumute this user on.
+     * @param reason The audit log reason for this action.
+     * @return A future to check if the unmute was successful.
+     */
+    default CompletableFuture<Void> unmute(Server server, String reason) {
+        return server.unmuteUser(this, reason);
+    }
+
+    /**
      * Gets the muted state of the user in the given server.
      *
      * @param server The server to check.

--- a/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeDeafenedEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeDeafenedEvent.java
@@ -1,0 +1,24 @@
+package org.javacord.api.event.user;
+
+import org.javacord.api.event.server.ServerEvent;
+
+/**
+ * A user change deafened event.
+ */
+public interface UserChangeDeafenedEvent extends UserEvent, ServerEvent {
+
+    /**
+     * Gets the new deafened state of the user.
+     *
+     * @return Whether the user is deafened now.
+     */
+    boolean isNewDeafened();
+
+    /**
+     * Gets the old deafened state of the user.
+     *
+     * @return Whether the user was deafened previously.
+     */
+    boolean isOldDeafened();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeMutedEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeMutedEvent.java
@@ -1,0 +1,24 @@
+package org.javacord.api.event.user;
+
+import org.javacord.api.event.server.ServerEvent;
+
+/**
+ * A user change muted event.
+ */
+public interface UserChangeMutedEvent extends UserEvent, ServerEvent {
+
+    /**
+     * Gets the new muted state of the user.
+     *
+     * @return Whether the user is muted now.
+     */
+    boolean isNewMuted();
+
+    /**
+     * Gets the old muted state of the user.
+     *
+     * @return Whether the user was muted previously.
+     */
+    boolean isOldMuted();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeSelfDeafenedEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeSelfDeafenedEvent.java
@@ -1,0 +1,24 @@
+package org.javacord.api.event.user;
+
+import org.javacord.api.event.server.ServerEvent;
+
+/**
+ * A user change self-deafened event.
+ */
+public interface UserChangeSelfDeafenedEvent extends UserEvent, ServerEvent {
+
+    /**
+     * Gets the new self-deafened state of the user.
+     *
+     * @return Whether the user is self-deafened now.
+     */
+    boolean isNewSelfDeafened();
+
+    /**
+     * Gets the old self-deafened state of the user.
+     *
+     * @return Whether the user was self-deafened previously.
+     */
+    boolean isOldSelfDeafened();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeSelfMutedEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeSelfMutedEvent.java
@@ -1,0 +1,24 @@
+package org.javacord.api.event.user;
+
+import org.javacord.api.event.server.ServerEvent;
+
+/**
+ * A user change self-muted event.
+ */
+public interface UserChangeSelfMutedEvent extends UserEvent, ServerEvent {
+
+    /**
+     * Gets the new self-muted state of the user.
+     *
+     * @return Whether the user is self-muted now.
+     */
+    boolean isNewSelfMuted();
+
+    /**
+     * Gets the old self-muted state of the user.
+     *
+     * @return Whether the user was self-muted previously.
+     */
+    boolean isOldSelfMuted();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangeDeafenedListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangeDeafenedListener.java
@@ -1,0 +1,22 @@
+package org.javacord.api.listener.user;
+
+import org.javacord.api.event.user.UserChangeDeafenedEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.server.ServerAttachableListener;
+
+/**
+ * This listener listens to user deafened changes.
+ */
+@FunctionalInterface
+public interface UserChangeDeafenedListener extends ServerAttachableListener, UserAttachableListener,
+                                                    GloballyAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called every time the deafened state of a user is changed on a server.
+     *
+     * @param event The event.
+     */
+    void onUserChangeDeafened(UserChangeDeafenedEvent event);
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangeMutedListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangeMutedListener.java
@@ -1,0 +1,22 @@
+package org.javacord.api.listener.user;
+
+import org.javacord.api.event.user.UserChangeMutedEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.server.ServerAttachableListener;
+
+/**
+ * This listener listens to user muted changes.
+ */
+@FunctionalInterface
+public interface UserChangeMutedListener extends ServerAttachableListener, UserAttachableListener,
+                                                 GloballyAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called every time the muted state of user is changed on a server.
+     *
+     * @param event The event.
+     */
+    void onUserChangeMuted(UserChangeMutedEvent event);
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangeSelfDeafenedListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangeSelfDeafenedListener.java
@@ -1,0 +1,22 @@
+package org.javacord.api.listener.user;
+
+import org.javacord.api.event.user.UserChangeSelfDeafenedEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.server.ServerAttachableListener;
+
+/**
+ * This listener listens to user self-deafened changes.
+ */
+@FunctionalInterface
+public interface UserChangeSelfDeafenedListener extends ServerAttachableListener, UserAttachableListener,
+                                                        GloballyAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called every time a user changed their self-deafened state on a server.
+     *
+     * @param event The event.
+     */
+    void onUserChangeSelfDeafened(UserChangeSelfDeafenedEvent event);
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangeSelfMutedListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangeSelfMutedListener.java
@@ -1,0 +1,22 @@
+package org.javacord.api.listener.user;
+
+import org.javacord.api.event.user.UserChangeSelfMutedEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.server.ServerAttachableListener;
+
+/**
+ * This listener listens to user self-muted changes.
+ */
+@FunctionalInterface
+public interface UserChangeSelfMutedListener extends ServerAttachableListener, UserAttachableListener,
+                                                     GloballyAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called every time a user changed their self-muted state on a server.
+     *
+     * @param event The event.
+     */
+    void onUserChangeSelfMuted(UserChangeSelfMutedEvent event);
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -90,6 +90,7 @@ import org.javacord.api.listener.server.role.UserRoleAddListener;
 import org.javacord.api.listener.server.role.UserRoleRemoveListener;
 import org.javacord.api.listener.user.UserChangeActivityListener;
 import org.javacord.api.listener.user.UserChangeAvatarListener;
+import org.javacord.api.listener.user.UserChangeDeafenedListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeMutedListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
@@ -1887,6 +1888,17 @@ public class DiscordApiImpl implements DiscordApi {
     @Override
     public List<UserChangeMutedListener> getUserChangeMutedListeners() {
         return getListeners(UserChangeMutedListener.class);
+    }
+
+    @Override
+    public ListenerManager<UserChangeDeafenedListener> addUserChangeDeafenedListener(
+            UserChangeDeafenedListener listener) {
+        return addListener(UserChangeDeafenedListener.class, listener);
+    }
+
+    @Override
+    public List<UserChangeDeafenedListener> getUserChangeDeafenedListeners() {
+        return getListeners(UserChangeDeafenedListener.class);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -91,6 +91,7 @@ import org.javacord.api.listener.server.role.UserRoleRemoveListener;
 import org.javacord.api.listener.user.UserChangeActivityListener;
 import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
+import org.javacord.api.listener.user.UserChangeMutedListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
 import org.javacord.api.listener.user.UserChangeSelfDeafenedListener;
@@ -1876,6 +1877,16 @@ public class DiscordApiImpl implements DiscordApi {
     @Override
     public List<UserChangeSelfDeafenedListener> getUserChangeSelfDeafenedListeners() {
         return getListeners(UserChangeSelfDeafenedListener.class);
+    }
+
+    @Override
+    public ListenerManager<UserChangeMutedListener> addUserChangeMutedListener(UserChangeMutedListener listener) {
+        return addListener(UserChangeMutedListener.class, listener);
+    }
+
+    @Override
+    public List<UserChangeMutedListener> getUserChangeMutedListeners() {
+        return getListeners(UserChangeMutedListener.class);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -93,6 +93,7 @@ import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
+import org.javacord.api.listener.user.UserChangeSelfDeafenedListener;
 import org.javacord.api.listener.user.UserChangeSelfMutedListener;
 import org.javacord.api.listener.user.UserChangeStatusListener;
 import org.javacord.api.listener.user.UserStartTypingListener;
@@ -1864,6 +1865,17 @@ public class DiscordApiImpl implements DiscordApi {
     @Override
     public List<UserChangeSelfMutedListener> getUserChangeSelfMutedListeners() {
         return getListeners(UserChangeSelfMutedListener.class);
+    }
+
+    @Override
+    public ListenerManager<UserChangeSelfDeafenedListener> addUserChangeSelfDeafenedListener(
+            UserChangeSelfDeafenedListener listener) {
+        return addListener(UserChangeSelfDeafenedListener.class, listener);
+    }
+
+    @Override
+    public List<UserChangeSelfDeafenedListener> getUserChangeSelfDeafenedListeners() {
+        return getListeners(UserChangeSelfDeafenedListener.class);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -93,6 +93,7 @@ import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
+import org.javacord.api.listener.user.UserChangeSelfMutedListener;
 import org.javacord.api.listener.user.UserChangeStatusListener;
 import org.javacord.api.listener.user.UserStartTypingListener;
 import org.javacord.api.util.concurrent.ThreadPool;
@@ -1852,6 +1853,17 @@ public class DiscordApiImpl implements DiscordApi {
     @Override
     public List<UserChangeNicknameListener> getUserChangeNicknameListeners() {
         return getListeners(UserChangeNicknameListener.class);
+    }
+
+    @Override
+    public ListenerManager<UserChangeSelfMutedListener> addUserChangeSelfMutedListener(
+            UserChangeSelfMutedListener listener) {
+        return addListener(UserChangeSelfMutedListener.class, listener);
+    }
+
+    @Override
+    public List<UserChangeSelfMutedListener> getUserChangeSelfMutedListeners() {
+        return getListeners(UserChangeSelfMutedListener.class);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1087,6 +1087,18 @@ public class ServerImpl implements Server, Cleanupable {
     }
 
     @Override
+    public void selfDeafen() {
+        api.getWebSocketAdapter().sendVoiceStateUpdate(
+                this, getConnectedVoiceChannel(api.getYourself()).orElse(null), null, true);
+    }
+
+    @Override
+    public void selfUndeafen() {
+        api.getWebSocketAdapter().sendVoiceStateUpdate(
+                this, getConnectedVoiceChannel(api.getYourself()).orElse(null), null, false);
+    }
+
+    @Override
     public CompletableFuture<Void> kickUser(User user, String reason) {
         return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.SERVER_MEMBER)
                 .setUrlParameters(getIdAsString(), user.getIdAsString())

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -3,7 +3,6 @@ package org.javacord.core.entity.server;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.AccountType;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.DiscordEntity;
@@ -1029,23 +1028,6 @@ public class ServerImpl implements Server, Cleanupable {
     }
 
     @Override
-    public CompletableFuture<Void> updateNickname(User user, String nickname, String reason) {
-        if (user.isYourself()) {
-            return new RestRequest<Void>(getApi(), RestMethod.PATCH, RestEndpoint.OWN_NICKNAME)
-                    .setUrlParameters(getIdAsString())
-                    .setBody(JsonNodeFactory.instance.objectNode().put("nick", nickname))
-                    .setAuditLogReason(reason)
-                    .execute(result -> null);
-        } else {
-            return new RestRequest<Void>(getApi(), RestMethod.PATCH, RestEndpoint.SERVER_MEMBER)
-                    .setUrlParameters(getIdAsString(), user.getIdAsString())
-                    .setBody(JsonNodeFactory.instance.objectNode().put("nick", nickname))
-                    .setAuditLogReason(reason)
-                    .execute(result -> null);
-        }
-    }
-
-    @Override
     public CompletableFuture<Void> delete() {
         return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.SERVER)
                 .setUrlParameters(getIdAsString())
@@ -1071,20 +1053,6 @@ public class ServerImpl implements Server, Cleanupable {
     public CompletableFuture<Void> removeRoleFromUser(User user, Role role, String reason) {
         return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.SERVER_MEMBER_ROLE)
                 .setUrlParameters(getIdAsString(), user.getIdAsString(), role.getIdAsString())
-                .setAuditLogReason(reason)
-                .execute(result -> null);
-    }
-
-    @Override
-    public CompletableFuture<Void> updateRoles(User user, Collection<Role> roles, String reason) {
-        ObjectNode updateNode = JsonNodeFactory.instance.objectNode();
-        ArrayNode rolesJson = updateNode.putArray("roles");
-        for (Role role : roles) {
-            rolesJson.add(role.getIdAsString());
-        }
-        return new RestRequest<Void>(getApi(), RestMethod.PATCH, RestEndpoint.SERVER_MEMBER)
-                .setUrlParameters(getIdAsString(), user.getIdAsString())
-                .setBody(updateNode)
                 .setAuditLogReason(reason)
                 .execute(result -> null);
     }

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1075,6 +1075,18 @@ public class ServerImpl implements Server, Cleanupable {
     }
 
     @Override
+    public void selfMute() {
+        api.getWebSocketAdapter().sendVoiceStateUpdate(
+                this, getConnectedVoiceChannel(api.getYourself()).orElse(null), true, null);
+    }
+
+    @Override
+    public void selfUnmute() {
+        api.getWebSocketAdapter().sendVoiceStateUpdate(
+                this, getConnectedVoiceChannel(api.getYourself()).orElse(null), false, null);
+    }
+
+    @Override
     public CompletableFuture<Void> kickUser(User user, String reason) {
         return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.SERVER_MEMBER)
                 .setUrlParameters(getIdAsString(), user.getIdAsString())

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerUpdaterDelegateImpl.java
@@ -65,6 +65,11 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
     private final Map<User, Boolean> userMuted = new HashMap<>();
 
     /**
+     * A map with all user deafened states to update.
+     */
+    private final Map<User, Boolean> userDeafened = new HashMap<>();
+
+    /**
      * A list with the new order of the roles.
      */
     private List<Role> newRolesOrder = null;
@@ -347,6 +352,11 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
     }
 
     @Override
+    public void setDeafened(User user, boolean deafened) {
+        userDeafened.put(user, deafened);
+    }
+
+    @Override
     public void reorderRoles(List<Role> roles) {
         newRolesOrder = roles;
     }
@@ -387,6 +397,7 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
         HashSet<User> members = new HashSet<>(userRoles.keySet());
         members.addAll(userNicknames.keySet());
         members.addAll(userMuted.keySet());
+        members.addAll(userDeafened.keySet());
 
         // A list with all tasks
         List<CompletableFuture<?>> tasks = new ArrayList<>();
@@ -421,6 +432,11 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
 
             if (userMuted.containsKey(member)) {
                 updateNode.put("mute", userMuted.get(member));
+                patchMember = true;
+            }
+
+            if (userDeafened.containsKey(member)) {
+                updateNode.put("deaf", userDeafened.get(member));
                 patchMember = true;
             }
 

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerUpdaterDelegateImpl.java
@@ -60,6 +60,11 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
     private final Map<User, String> userNicknames = new HashMap<>();
 
     /**
+     * A map with all user muted states to update.
+     */
+    private final Map<User, Boolean> userMuted = new HashMap<>();
+
+    /**
      * A list with the new order of the roles.
      */
     private List<Role> newRolesOrder = null;
@@ -337,6 +342,11 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
     }
 
     @Override
+    public void setMuted(User user, boolean muted) {
+        userMuted.put(user, muted);
+    }
+
+    @Override
     public void reorderRoles(List<Role> roles) {
         newRolesOrder = roles;
     }
@@ -376,6 +386,7 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
         // A set with all members that get updates
         HashSet<User> members = new HashSet<>(userRoles.keySet());
         members.addAll(userNicknames.keySet());
+        members.addAll(userMuted.keySet());
 
         // A list with all tasks
         List<CompletableFuture<?>> tasks = new ArrayList<>();
@@ -406,6 +417,11 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
                     updateNode.put("nick", (nickname == null) ? "" : nickname);
                     patchMember = true;
                 }
+            }
+
+            if (userMuted.containsKey(member)) {
+                updateNode.put("mute", userMuted.get(member));
+                patchMember = true;
             }
 
             if (patchMember) {

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerUpdaterDelegateImpl.java
@@ -346,7 +346,7 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
     }
 
     @Override
-    public void addAllRolesToUser(User user, Collection<Role> roles) {
+    public void addRolesToUser(User user, Collection<Role> roles) {
         Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new ArrayList<>(server.getRolesOf(u)));
         userRoles.addAll(roles);
     }
@@ -358,9 +358,15 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
     }
 
     @Override
-    public void removeAllRolesFromUser(User user, Collection<Role> roles) {
+    public void removeRolesFromUser(User user, Collection<Role> roles) {
         Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new ArrayList<>(server.getRolesOf(u)));
         userRoles.removeAll(roles);
+    }
+
+    @Override
+    public void removeAllRolesFromUser(User user) {
+        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new ArrayList<>(server.getRolesOf(u)));
+        userRoles.clear();
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
@@ -31,6 +31,7 @@ import org.javacord.api.listener.user.UserAttachableListener;
 import org.javacord.api.listener.user.UserChangeActivityListener;
 import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
+import org.javacord.api.listener.user.UserChangeMutedListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
 import org.javacord.api.listener.user.UserChangeSelfDeafenedListener;
@@ -518,6 +519,17 @@ public class UserImpl implements User, Cleanupable {
     public List<UserChangeSelfDeafenedListener> getUserChangeSelfDeafenedListeners() {
         return ((DiscordApiImpl) getApi())
                 .getObjectListeners(User.class, getId(), UserChangeSelfDeafenedListener.class);
+    }
+
+    @Override
+    public ListenerManager<UserChangeMutedListener> addUserChangeMutedListener(UserChangeMutedListener listener) {
+        return ((DiscordApiImpl) getApi())
+                .addObjectListener(User.class, getId(), UserChangeMutedListener.class, listener);
+    }
+
+    @Override
+    public List<UserChangeMutedListener> getUserChangeMutedListeners() {
+        return ((DiscordApiImpl) getApi()).getObjectListeners(User.class, getId(), UserChangeMutedListener.class);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
@@ -33,6 +33,7 @@ import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
+import org.javacord.api.listener.user.UserChangeSelfDeafenedListener;
 import org.javacord.api.listener.user.UserChangeSelfMutedListener;
 import org.javacord.api.listener.user.UserChangeStatusListener;
 import org.javacord.api.listener.user.UserStartTypingListener;
@@ -504,6 +505,19 @@ public class UserImpl implements User, Cleanupable {
     @Override
     public List<UserChangeSelfMutedListener> getUserChangeSelfMutedListeners() {
         return ((DiscordApiImpl) getApi()).getObjectListeners(User.class, getId(), UserChangeSelfMutedListener.class);
+    }
+
+    @Override
+    public ListenerManager<UserChangeSelfDeafenedListener> addUserChangeSelfDeafenedListener(
+            UserChangeSelfDeafenedListener listener) {
+        return ((DiscordApiImpl) getApi())
+                .addObjectListener(User.class, getId(), UserChangeSelfDeafenedListener.class, listener);
+    }
+
+    @Override
+    public List<UserChangeSelfDeafenedListener> getUserChangeSelfDeafenedListeners() {
+        return ((DiscordApiImpl) getApi())
+                .getObjectListeners(User.class, getId(), UserChangeSelfDeafenedListener.class);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
@@ -30,6 +30,7 @@ import org.javacord.api.listener.server.role.UserRoleRemoveListener;
 import org.javacord.api.listener.user.UserAttachableListener;
 import org.javacord.api.listener.user.UserChangeActivityListener;
 import org.javacord.api.listener.user.UserChangeAvatarListener;
+import org.javacord.api.listener.user.UserChangeDeafenedListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeMutedListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
@@ -530,6 +531,18 @@ public class UserImpl implements User, Cleanupable {
     @Override
     public List<UserChangeMutedListener> getUserChangeMutedListeners() {
         return ((DiscordApiImpl) getApi()).getObjectListeners(User.class, getId(), UserChangeMutedListener.class);
+    }
+
+    @Override
+    public ListenerManager<UserChangeDeafenedListener> addUserChangeDeafenedListener(
+            UserChangeDeafenedListener listener) {
+        return ((DiscordApiImpl) getApi())
+                .addObjectListener(User.class, getId(), UserChangeDeafenedListener.class, listener);
+    }
+
+    @Override
+    public List<UserChangeDeafenedListener> getUserChangeDeafenedListeners() {
+        return ((DiscordApiImpl) getApi()).getObjectListeners(User.class, getId(), UserChangeDeafenedListener.class);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
@@ -33,6 +33,7 @@ import org.javacord.api.listener.user.UserChangeAvatarListener;
 import org.javacord.api.listener.user.UserChangeDiscriminatorListener;
 import org.javacord.api.listener.user.UserChangeNameListener;
 import org.javacord.api.listener.user.UserChangeNicknameListener;
+import org.javacord.api.listener.user.UserChangeSelfMutedListener;
 import org.javacord.api.listener.user.UserChangeStatusListener;
 import org.javacord.api.listener.user.UserStartTypingListener;
 import org.javacord.api.util.event.ListenerManager;
@@ -491,6 +492,18 @@ public class UserImpl implements User, Cleanupable {
     @Override
     public List<UserChangeNicknameListener> getUserChangeNicknameListeners() {
         return ((DiscordApiImpl) getApi()).getObjectListeners(User.class, getId(), UserChangeNicknameListener.class);
+    }
+
+    @Override
+    public ListenerManager<UserChangeSelfMutedListener> addUserChangeSelfMutedListener(
+            UserChangeSelfMutedListener listener) {
+        return ((DiscordApiImpl) getApi())
+                .addObjectListener(User.class, getId(), UserChangeSelfMutedListener.class, listener);
+    }
+
+    @Override
+    public List<UserChangeSelfMutedListener> getUserChangeSelfMutedListeners() {
+        return ((DiscordApiImpl) getApi()).getObjectListeners(User.class, getId(), UserChangeSelfMutedListener.class);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/event/user/ServerUserEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/ServerUserEventImpl.java
@@ -1,0 +1,49 @@
+package org.javacord.core.event.user;
+
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.entity.user.User;
+import org.javacord.api.event.user.TextChannelUserEvent;
+import org.javacord.api.event.user.UserEvent;
+import org.javacord.core.event.server.ServerEventImpl;
+
+import java.util.function.Supplier;
+
+/**
+ * The implementation of {@link TextChannelUserEvent}.
+ */
+public abstract class ServerUserEventImpl extends ServerEventImpl implements UserEvent {
+
+    /**
+     * The supplier for the user of the event.
+     */
+    private final Supplier<User> userSupplier;
+
+    /**
+     * Creates a new server user event.
+     *
+     * @param user The user of the event.
+     * @param server The server of the event.
+     */
+    public ServerUserEventImpl(User user, Server server) {
+        super(server);
+        this.userSupplier = () -> user;
+    }
+
+    /**
+     * Creates a new server user event.
+     *
+     * @param userId The id of the user of the event.
+     * @param server The server of the event.
+     */
+    public ServerUserEventImpl(long userId, Server server) {
+        super(server);
+        // server related events should only get dispatched after all members are cached
+        this.userSupplier = () -> getApi().getCachedUserById(userId).orElseThrow(AssertionError::new);
+    }
+
+    @Override
+    public User getUser() {
+        return userSupplier.get();
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeDeafenedEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeDeafenedEventImpl.java
@@ -1,0 +1,45 @@
+package org.javacord.core.event.user;
+
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.event.user.UserChangeDeafenedEvent;
+
+/**
+ * The implementation of {@link UserChangeDeafenedEvent}.
+ */
+public class UserChangeDeafenedEventImpl extends ServerUserEventImpl implements UserChangeDeafenedEvent {
+
+    /**
+     * The new deafened state of the user.
+     */
+    private final boolean newDeafened;
+
+    /**
+     * The old deafened state of the user.
+     */
+    private final boolean oldDeafened;
+
+    /**
+     * Creates a new user change deafened event.
+     *
+     * @param userId The id of the user of the event.
+     * @param server The server in which the deafened state of the user was changed.
+     * @param newDeafened The new deafened state of the user.
+     * @param oldDeafened The old deafened state of the user.
+     */
+    public UserChangeDeafenedEventImpl(long userId, Server server, boolean newDeafened, boolean oldDeafened) {
+        super(userId, server);
+        this.newDeafened = newDeafened;
+        this.oldDeafened = oldDeafened;
+    }
+
+    @Override
+    public boolean isNewDeafened() {
+        return newDeafened;
+    }
+
+    @Override
+    public boolean isOldDeafened() {
+        return oldDeafened;
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeMutedEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeMutedEventImpl.java
@@ -1,0 +1,45 @@
+package org.javacord.core.event.user;
+
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.event.user.UserChangeMutedEvent;
+
+/**
+ * The implementation of {@link UserChangeMutedEvent}.
+ */
+public class UserChangeMutedEventImpl extends ServerUserEventImpl implements UserChangeMutedEvent {
+
+    /**
+     * The new muted state of the user.
+     */
+    private final boolean newMuted;
+
+    /**
+     * The old muted state of the user.
+     */
+    private final boolean oldMuted;
+
+    /**
+     * Creates a new user change muted event.
+     *
+     * @param userId The id of the user of the event.
+     * @param server The server in which the muted state of the user was changed.
+     * @param newMuted The new muted state of the user.
+     * @param oldMuted The old muted state of the user.
+     */
+    public UserChangeMutedEventImpl(long userId, Server server, boolean newMuted, boolean oldMuted) {
+        super(userId, server);
+        this.newMuted = newMuted;
+        this.oldMuted = oldMuted;
+    }
+
+    @Override
+    public boolean isNewMuted() {
+        return newMuted;
+    }
+
+    @Override
+    public boolean isOldMuted() {
+        return oldMuted;
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeNicknameEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeNicknameEventImpl.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 /**
  * The implementation of {@link UserChangeNicknameEvent}.
  */
-public class UserChangeNicknameEventImpl extends UserEventImpl implements UserChangeNicknameEvent {
+public class UserChangeNicknameEventImpl extends ServerUserEventImpl implements UserChangeNicknameEvent {
 
     /**
      * The new nickname of the user.
@@ -22,11 +22,6 @@ public class UserChangeNicknameEventImpl extends UserEventImpl implements UserCh
     private final String oldNickname;
 
     /**
-     * The server in which the user changed its nickname.
-     */
-    private final Server server;
-
-    /**
      * Creates a new user change nickname event.
      *
      * @param user The user of the event.
@@ -35,15 +30,9 @@ public class UserChangeNicknameEventImpl extends UserEventImpl implements UserCh
      * @param oldNickname The old nickname of the user.
      */
     public UserChangeNicknameEventImpl(User user, Server server, String newNickname, String oldNickname) {
-        super(user);
-        this.server = server;
+        super(user, server);
         this.newNickname = newNickname;
         this.oldNickname = oldNickname;
-    }
-
-    @Override
-    public Server getServer() {
-        return server;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeSelfDeafenedEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeSelfDeafenedEventImpl.java
@@ -1,0 +1,46 @@
+package org.javacord.core.event.user;
+
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.event.user.UserChangeSelfDeafenedEvent;
+
+/**
+ * The implementation of {@link UserChangeSelfDeafenedEvent}.
+ */
+public class UserChangeSelfDeafenedEventImpl extends ServerUserEventImpl implements UserChangeSelfDeafenedEvent {
+
+    /**
+     * The new self-deafened state of the user.
+     */
+    private final boolean newSelfDeafened;
+
+    /**
+     * The old self-deafened state of the user.
+     */
+    private final boolean oldSelfDeafened;
+
+    /**
+     * Creates a new user change self-deafened event.
+     *
+     * @param userId The id of the user of the event.
+     * @param server The server in which the self-deafened state of the user was changed.
+     * @param newSelfDeafened The new self-deafened state of the user.
+     * @param oldSelfDeafened The old self-deafened state of the user.
+     */
+    public UserChangeSelfDeafenedEventImpl(
+            long userId, Server server, boolean newSelfDeafened, boolean oldSelfDeafened) {
+        super(userId, server);
+        this.newSelfDeafened = newSelfDeafened;
+        this.oldSelfDeafened = oldSelfDeafened;
+    }
+
+    @Override
+    public boolean isNewSelfDeafened() {
+        return newSelfDeafened;
+    }
+
+    @Override
+    public boolean isOldSelfDeafened() {
+        return oldSelfDeafened;
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeSelfMutedEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeSelfMutedEventImpl.java
@@ -1,0 +1,45 @@
+package org.javacord.core.event.user;
+
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.event.user.UserChangeSelfMutedEvent;
+
+/**
+ * The implementation of {@link UserChangeSelfMutedEvent}.
+ */
+public class UserChangeSelfMutedEventImpl extends ServerUserEventImpl implements UserChangeSelfMutedEvent {
+
+    /**
+     * The new self-muted state of the user.
+     */
+    private final boolean newSelfMuted;
+
+    /**
+     * The old self-muted state of the user.
+     */
+    private final boolean oldSelfMuted;
+
+    /**
+     * Creates a new user change self-muted event.
+     *
+     * @param userId The id of the user of the event.
+     * @param server The server in which the self-muted state of the user was changed.
+     * @param newSelfMuted The new self-muted state of the user.
+     * @param oldSelfMuted The old self-muted state of the user.
+     */
+    public UserChangeSelfMutedEventImpl(long userId, Server server, boolean newSelfMuted, boolean oldSelfMuted) {
+        super(userId, server);
+        this.newSelfMuted = newSelfMuted;
+        this.oldSelfMuted = oldSelfMuted;
+    }
+
+    @Override
+    public boolean isNewSelfMuted() {
+        return newSelfMuted;
+    }
+
+    @Override
+    public boolean isOldSelfMuted() {
+        return oldSelfMuted;
+    }
+
+}


### PR DESCRIPTION
- Add self-muted state, listeners and events
- Add self-deafened state, listeners and events
- Add muted state, listeners and events
- Add deafened state, listeners and events
- Add User#updateNickname with audit-log reason
- Add User#resetNickname with audit-log reason
- Rename addAllRolesToUser to addRolesToUser, removeAllRolesToUser to removeRolesToUser and add removeAllRolesToUser that removes all roles
- Move the updating of nicknames and roles into ServerUpdater to save REST calls
- Add Server#muteUser, Server#unmuteUser and ServerUpdater#setMuted
- Add Server#deafenUser, Server#undeafenUser and ServerUpdater#setDeafened
- Add Server#muteYourself and Server#unmuteYourself
- Add Server#selfMute and Server#selfUnmute
- Add Server#deafenYourself and Server#undeafenYourself
- Add Server#selfDeafen and Server#selfUndeafen
- Add Server#moveUser and ServerUpdater#setVoiceChannel
- Add Server#areYouSelfMuted
- Add Server#areYouSelfDeafened
- Add Server#areYouMuted
- Add Server#areYouDeafened
- Add Server#moveYourself
- Remove superfluous whitespaces
- Add Server#canMuteMembers, Server#canYouMuteMembers and MessageAuthor#canMuteMembersOnServer
- Add Server#canDeafenMembers, Server#canYouDeafenMembers and MessageAuthor#canDeafenMembersOnServer
- Add Server#canMoveMembers, Server#canYouMoveMembers and MessageAuthor#canMoveMembersOnServer