### PR TITLE
Added Methods: getBotUsers and getHumanUsers

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -561,6 +561,20 @@ public interface DiscordApi {
     Collection<User> getCachedUsers();
 
     /**
+     * Gets a collection with all users that are bots accounts.
+     *
+     * @return A collection of all cached bot-account users.
+     */
+    Collection<User> getCachedBotUsers();
+
+    /**
+     * Gets a collection  with all users that are normal accounts.
+     *
+     * @return A collection of all cached normal-account users.
+     */
+    Collection<User> getCachedHumanUsers();
+
+    /**
      * Gets a cached user by its id.
      *
      * @param id The id of the user.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -284,6 +284,20 @@ public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
     Collection<User> getMembers();
 
     /**
+     * Gets a collection with all members that are bots accounts.
+     *
+     * @return A collection of all bot-account members.
+     */
+    Collection<User> getBotMembers();
+
+    /**
+     * Gets a collection  with all members that are normal accounts.
+     *
+     * @return A collection of all normal-account members.
+     */
+    Collection<User> getHumanMembers();
+
+    /**
      * Gets a member by its id.
      *
      * @param id The id of the member.

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -1193,6 +1193,36 @@ public class DiscordApiImpl implements DiscordApi {
     }
 
     @Override
+    public Collection<User> getCachedBotUsers() {
+        synchronized (users) {
+            return Collections.unmodifiableList(users
+                    .entrySet()
+                    .stream()
+                    .map(Entry::getValue)
+                    .map(Reference::get)
+                    .filter(Objects::nonNull)
+                    .filter(User::isBot)
+                    .collect(Collectors.toList())
+            );
+        }
+    }
+
+    @Override
+    public Collection<User> getCachedHumanUsers() {
+        synchronized (users) {
+            return Collections.unmodifiableList(users
+                    .entrySet()
+                    .stream()
+                    .map(Entry::getValue)
+                    .map(Reference::get)
+                    .filter(Objects::nonNull)
+                    .filter(user -> !user.isBot())
+                    .collect(Collectors.toList())
+            );
+        }
+    }
+
+    @Override
     public MessageSet getCachedMessages() {
         synchronized (messages) {
             return messages.values().stream()

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -123,6 +123,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -896,6 +897,26 @@ public class ServerImpl implements Server, Cleanupable {
     @Override
     public Collection<User> getMembers() {
         return Collections.unmodifiableList(new ArrayList<>(members.values()));
+    }
+
+    @Override
+    public Collection<User> getBotMembers() {
+        return Collections.unmodifiableList(members.entrySet()
+                .stream()
+                .map(Entry::getValue)
+                .filter(User::isBot)
+                .collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public Collection<User> getHumanMembers() {
+        return Collections.unmodifiableList(members.entrySet()
+                .stream()
+                .map(Entry::getValue)
+                .filter(user -> !user.isBot())
+                .collect(Collectors.toList())
+        );
     }
 
     @Override


### PR DESCRIPTION
Thought I'd add these methods for the sake of coverage in terms of being able to get pre-filtered Collections of just Bot-Accounts or other way around.