### PR TITLE
Do proper cross-compiling with --release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:9-jdk-browsers
+      - image: circleci/openjdk:10-jdk
 
     working_directory: ~/javacord
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'nebula.java-cross-compile' version '0.10.0' apply false
     id 'com.github.johnrengelman.shadow' version '2.0.4' apply false
     id 'me.tatarka.gradle.pom' version '1.0' apply false
     id 'net.researchgate.release' version '2.7.0' apply false
@@ -18,7 +17,6 @@ ext {
 
 allprojects {
     apply plugin: 'java-library'
-    apply plugin: 'nebula.java-cross-compile'
     apply plugin: 'checkstyle'
 
     group = 'org.javacord'
@@ -30,6 +28,11 @@ allprojects {
     tasks.withType(JavaCompile) {
         options.encoding 'UTF-8'
         options.incremental true
+        if (JavaVersion.current().java9Compatible) {
+            afterEvaluate {
+                options.compilerArgs << '--release' << platform.targetCompatibility.majorVersion
+            }
+        }
     }
 
     checkstyle {

--- a/gradle/java9.gradle
+++ b/gradle/java9.gradle
@@ -9,8 +9,6 @@ if (JavaVersion.current().java9Compatible) {
             sourceCompatibility = 9
             targetCompatibility = 9
             afterEvaluate {
-                // undo the effect of nebula.java-cross-compile plugin after it was done, thus in afterEvaluate
-                options.bootstrapClasspath = null
                 // access SourceDirectorySet#asPath in afterEvaluate
                 // or projects get evaluated before all configuration is done
                 options.compilerArgs << '--module-path'


### PR DESCRIPTION
I just learned that the `--release` switch introduced in Java 9 is really awesome in combining
`-source`, `-target` and `-bootclasspath`, not needing to have the JRE against which you want
to cross-compile lying around as the JDK know the old APIs that were present.

So we don't need the `nebula.java-cross-compile` plugin that sets the bootclasspath according to
the `targetCompatibility` but instead can simply use the `--release` parameter.

Building against Java 7 is not supported, as we have minimum Java 8 requirement.
When building against Java 8, no cross-compilation setup is necessary and Java 9 stuff
is suppressed and only a warning printed (was already like that).
When building against Java 9 or newer, the `--release` parameter is set accordingly and
thus the cross-compilation works properly even without the older Java lying around.
This makes it possible to properly build Javacord with only Java 9 or newer being present.