### PR TITLE
Permissions on channel creation

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/Permissionable.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/Permissionable.java
@@ -1,11 +1,11 @@
 package org.javacord.api.entity;
 
 /**
- * An entity that can hold permissions.
+ * An entity that can be granted permissions.
  *
  * <p>Specifically, these are {@link org.javacord.api.entity.permission.Role}s and
  * {@link org.javacord.api.entity.user.User}s. See their respective documentations
  * on how to retrieve granted permissions.
  */
-public interface Permissionable extends DiscordEntity {
+public interface Permissionable {
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/Permissionable.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/Permissionable.java
@@ -1,0 +1,11 @@
+package org.javacord.api.entity;
+
+/**
+ * An entity that can hold permissions.
+ *
+ * <p>Specifically, these are {@link org.javacord.api.entity.permission.Role}s and
+ * {@link org.javacord.api.entity.user.User}s. See their respective documentations
+ * on how to retrieve granted permissions.
+ */
+public interface Permissionable extends DiscordEntity {
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ChannelCategoryBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ChannelCategoryBuilder.java
@@ -9,7 +9,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class is used to create new channel categories.
  */
-public class ChannelCategoryBuilder {
+public class ChannelCategoryBuilder extends ServerChannelBuilder {
 
     /**
      * The channel category delegate used by this instance.
@@ -25,23 +25,13 @@ public class ChannelCategoryBuilder {
         delegate = DelegateFactory.createChannelCategoryBuilderDelegate(server);
     }
 
-    /**
-     * Sets the reason for this creation. This reason will be visible in the audit log entry(s).
-     *
-     * @param reason The reason for this update.
-     * @return The current instance in order to chain call methods.
-     */
+    @Override
     public ChannelCategoryBuilder setAuditLogReason(String reason) {
         delegate.setAuditLogReason(reason);
         return this;
     }
 
-    /**
-     * Sets the name of the channel.
-     *
-     * @param name The name of the channel.
-     * @return The current instance in order to chain call methods.
-     */
+    @Override
     public ChannelCategoryBuilder setName(String name) {
         delegate.setName(name);
         return this;

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.permission.PermissionState;
@@ -114,20 +115,13 @@ public interface ServerChannel extends Channel, Nameable {
     }
 
     /**
-     * Gets the overwritten permissions of a user in this channel.
+     * Gets the overwritten permissions of an entity in this channel.
      *
-     * @param user The user.
-     * @return The overwritten permissions of a user.
+     * @param <T> The type of permissionable discord entity.
+     * @param permissionable The permissionable entity.
+     * @return The overwritten permissions of an entity.
      */
-    Permissions getOverwrittenPermissions(User user);
-
-    /**
-     * Gets the overwritten permissions of a role in this channel.
-     *
-     * @param role The role.
-     * @return The overwritten permissions of a role.
-     */
-    Permissions getOverwrittenPermissions(Role role);
+    <T extends Permissionable & DiscordEntity> Permissions getOverwrittenPermissions(T permissionable);
 
     /**
      * Gets the overwritten permissions in this channel.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
@@ -1,7 +1,7 @@
 package org.javacord.api.entity.channel;
 
-import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Nameable;
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.permission.PermissionState;
 import org.javacord.api.entity.permission.PermissionType;
 import org.javacord.api.entity.permission.Permissions;
@@ -134,8 +134,9 @@ public interface ServerChannel extends Channel, Nameable {
      *
      * @return The overwritten permissions.
      */
-    default Map<DiscordEntity, Permissions> getOverwrittenPermissions() {
-        Map<DiscordEntity, Permissions> result = new HashMap<>(getOverwrittenRolePermissions());
+    default Map<Permissionable, Permissions> getOverwrittenPermissions() {
+        Map<Permissionable, Permissions> result = new HashMap<>();
+        result.putAll(getOverwrittenRolePermissions());
         result.putAll(getOverwrittenUserPermissions());
         return Collections.unmodifiableMap(result);
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelBuilder.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerChannelBuilderDelegate;
 import org.javacord.api.entity.permission.Permissions;
@@ -46,11 +47,13 @@ public class ServerChannelBuilder {
     /**
      * Adds a permission overwrite for the given entity.
      *
+     * @param <T> The type of entity to hold the permission, usually <code>User</code> or <code>Role</code>
      * @param permissionable The entity whose permissions should be overwritten.
      * @param permissions The permission overwrites.
      * @return The current instance in order to chain call methods.
      */
-    public ServerChannelBuilder addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+    public <T extends Permissionable & DiscordEntity> ServerChannelBuilder addPermissionOverwrite(
+            T permissionable, Permissions permissions) {
         delegate.addPermissionOverwrite(permissionable, permissions);
         return this;
     }
@@ -58,10 +61,12 @@ public class ServerChannelBuilder {
     /**
      * Removes a permission overwrite for the given entity.
      *
+     * @param <T> The type of entity to hold the permission, usually <code>User</code> or <code>Role</code>
      * @param permissionable The entity which permission overwrite should be removed.
      * @return The current instance in order to chain call methods.
      */
-    public ServerChannelBuilder removePermissionOverwrite(Permissionable permissionable) {
+    public <T extends Permissionable & DiscordEntity> ServerChannelBuilder removePermissionOverwrite(
+            T permissionable) {
         delegate.removePermissionOverwrite(permissionable);
         return this;
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelBuilder.java
@@ -1,6 +1,8 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerChannelBuilderDelegate;
+import org.javacord.api.entity.permission.Permissions;
 
 /**
  * This class is used to create new server channels.
@@ -49,6 +51,29 @@ public class ServerChannelBuilder {
      */
     public ServerChannelBuilder setCategory(ChannelCategory category) {
         delegate.setCategory(category);
+        return this;
+    }
+
+    /**
+     * Adds a permission overwrite for the given entity.
+     *
+     * @param permissionable The entity whose permissions should be overwritten.
+     * @param permissions The permission overwrites.
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerChannelBuilder addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+        delegate.addPermissionOverwrite(permissionable, permissions);
+        return this;
+    }
+
+    /**
+     * Removes a permission overwrite for the given entity.
+     *
+     * @param permissionable The entity which permission overwrite should be removed.
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerChannelBuilder removePermissionOverwrite(Permissionable permissionable) {
+        delegate.removePermissionOverwrite(permissionable);
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelBuilder.java
@@ -44,17 +44,6 @@ public class ServerChannelBuilder {
     }
 
     /**
-     * Sets the category of the channel.
-     *
-     * @param category The category of the channel.
-     * @return The current instance in order to chain call methods.
-     */
-    public ServerChannelBuilder setCategory(ChannelCategory category) {
-        delegate.setCategory(category);
-        return this;
-    }
-
-    /**
      * Adds a permission overwrite for the given entity.
      *
      * @param permissionable The entity whose permissions should be overwritten.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelBuilder.java
@@ -1,0 +1,55 @@
+package org.javacord.api.entity.channel;
+
+import org.javacord.api.entity.channel.internal.ServerChannelBuilderDelegate;
+
+/**
+ * This class is used to create new server channels.
+ */
+public class ServerChannelBuilder {
+
+    /**
+     * The server channel delegate used by this instance.
+     */
+    private final ServerChannelBuilderDelegate delegate;
+
+    /**
+     * Creates a new server channel builder without delegate.
+     */
+    protected ServerChannelBuilder() {
+        delegate = null;
+    }
+
+    /**
+     * Sets the reason for this creation. This reason will be visible in the audit log entry(s).
+     *
+     * @param reason The reason for this update.
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerChannelBuilder setAuditLogReason(String reason) {
+        delegate.setAuditLogReason(reason);
+        return this;
+    }
+
+    /**
+     * Sets the name of the channel.
+     *
+     * @param name The name of the channel.
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerChannelBuilder setName(String name) {
+        delegate.setName(name);
+        return this;
+    }
+
+    /**
+     * Sets the category of the channel.
+     *
+     * @param category The category of the channel.
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerChannelBuilder setCategory(ChannelCategory category) {
+        delegate.setCategory(category);
+        return this;
+    }
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelUpdater.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerChannelUpdaterDelegate;
 import org.javacord.api.entity.permission.Permissions;
@@ -71,11 +72,13 @@ public class ServerChannelUpdater {
     /**
      * Adds a permission overwrite for the given entity.
      *
+     * @param <T> The type of entity to hold the permission, usually <code>User</code> or <code>Role</code>
      * @param permissionable The entity whose permissions should be overwritten.
      * @param permissions The permission overwrites.
      * @return The current instance in order to chain call methods.
      */
-    public ServerChannelUpdater addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+    public <T extends Permissionable & DiscordEntity> ServerChannelUpdater addPermissionOverwrite(
+            T permissionable, Permissions permissions) {
         delegate.addPermissionOverwrite(permissionable, permissions);
         return this;
     }
@@ -83,10 +86,11 @@ public class ServerChannelUpdater {
     /**
      * Removes a permission overwrite for the given entity.
      *
+     * @param <T> The type of entity to hold the permission, usually <code>User</code> or <code>Role</code>
      * @param permissionable The entity which permission overwrite should be removed.
      * @return The current instance in order to chain call methods.
      */
-    public ServerChannelUpdater removePermissionOverwrite(Permissionable permissionable) {
+    public <T extends Permissionable & DiscordEntity> ServerChannelUpdater removePermissionOverwrite(T permissionable) {
         delegate.removePermissionOverwrite(permissionable);
         return this;
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelUpdater.java
@@ -1,9 +1,8 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerChannelUpdaterDelegate;
 import org.javacord.api.entity.permission.Permissions;
-import org.javacord.api.entity.permission.Role;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.util.internal.DelegateFactory;
 
 import java.util.concurrent.CompletableFuture;
@@ -70,48 +69,25 @@ public class ServerChannelUpdater {
     }
 
     /**
-     * Adds a permission overwrite for the given user.
+     * Adds a permission overwrite for the given entity.
      *
-     * @param user The user whose permissions should be overwritten.
+     * @param permissionable The entity whose permissions should be overwritten.
      * @param permissions The permission overwrites.
      * @return The current instance in order to chain call methods.
      */
-    public ServerChannelUpdater addPermissionOverwrite(User user, Permissions permissions) {
-        delegate.addPermissionOverwrite(user, permissions);
+    public ServerChannelUpdater addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+        delegate.addPermissionOverwrite(permissionable, permissions);
         return this;
     }
 
     /**
-     * Adds a permission overwrite for the given role.
+     * Removes a permission overwrite for the given entity.
      *
-     * @param role The role which permissions should be overwritten.
-     * @param permissions The permission overwrites.
+     * @param permissionable The entity which permission overwrite should be removed.
      * @return The current instance in order to chain call methods.
      */
-    public ServerChannelUpdater addPermissionOverwrite(Role role, Permissions permissions) {
-        delegate.addPermissionOverwrite(role, permissions);
-        return this;
-    }
-
-    /**
-     * Removes a permission overwrite for the given user.
-     *
-     * @param user The user whose permission overwrite should be removed.
-     * @return The current instance in order to chain call methods.
-     */
-    public ServerChannelUpdater removePermissionOverwrite(User user) {
-        delegate.removePermissionOverwrite(user);
-        return this;
-    }
-
-    /**
-     * Removes a permission overwrite for the given role.
-     *
-     * @param role The role which permission overwrite should be removed.
-     * @return The current instance in order to chain call methods.
-     */
-    public ServerChannelUpdater removePermissionOverwrite(Role role) {
-        delegate.removePermissionOverwrite(role);
+    public ServerChannelUpdater removePermissionOverwrite(Permissionable permissionable) {
+        delegate.removePermissionOverwrite(permissionable);
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelBuilder.java
@@ -50,7 +50,12 @@ public class ServerTextChannelBuilder extends ServerChannelBuilder {
         return this;
     }
 
-    @Override
+    /**
+     * Sets the category of the channel.
+     *
+     * @param category The category of the channel.
+     * @return The current instance in order to chain call methods.
+     */
     public ServerTextChannelBuilder setCategory(ChannelCategory category) {
         delegate.setCategory(category);
         return this;

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelBuilder.java
@@ -9,7 +9,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class is used to create new server text channels.
  */
-public class ServerTextChannelBuilder {
+public class ServerTextChannelBuilder extends ServerChannelBuilder {
 
     /**
      * The server text channel delegate used by this instance.
@@ -25,23 +25,13 @@ public class ServerTextChannelBuilder {
         delegate = DelegateFactory.createServerTextChannelBuilderDelegate(server);
     }
 
-    /**
-     * Sets the reason for this creation. This reason will be visible in the audit log entry(s).
-     *
-     * @param reason The reason for this update.
-     * @return The current instance in order to chain call methods.
-     */
+    @Override
     public ServerTextChannelBuilder setAuditLogReason(String reason) {
         delegate.setAuditLogReason(reason);
         return this;
     }
 
-    /**
-     * Sets the name of the channel.
-     *
-     * @param name The name of the channel.
-     * @return The current instance in order to chain call methods.
-     */
+    @Override
     public ServerTextChannelBuilder setName(String name) {
         delegate.setName(name);
         return this;
@@ -58,12 +48,7 @@ public class ServerTextChannelBuilder {
         return this;
     }
 
-    /**
-     * Sets the category of the channel.
-     *
-     * @param category The category of the channel.
-     * @return The current instance in order to chain call methods.
-     */
+    @Override
     public ServerTextChannelBuilder setCategory(ChannelCategory category) {
         delegate.setCategory(category);
         return this;

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelBuilder.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerTextChannelBuilderDelegate;
 import org.javacord.api.entity.permission.Permissions;
@@ -62,13 +63,15 @@ public class ServerTextChannelBuilder extends ServerChannelBuilder {
     }
 
     @Override
-    public ServerTextChannelBuilder addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+    public <T extends Permissionable & DiscordEntity> ServerTextChannelBuilder addPermissionOverwrite(
+            T permissionable, Permissions permissions) {
         delegate.addPermissionOverwrite(permissionable, permissions);
         return this;
     }
 
     @Override
-    public ServerTextChannelBuilder removePermissionOverwrite(Permissionable permissionable) {
+    public <T extends Permissionable & DiscordEntity> ServerTextChannelBuilder removePermissionOverwrite(
+            T permissionable) {
         delegate.removePermissionOverwrite(permissionable);
         return this;
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelBuilder.java
@@ -1,6 +1,8 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerTextChannelBuilderDelegate;
+import org.javacord.api.entity.permission.Permissions;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.util.internal.DelegateFactory;
 
@@ -51,6 +53,18 @@ public class ServerTextChannelBuilder extends ServerChannelBuilder {
     @Override
     public ServerTextChannelBuilder setCategory(ChannelCategory category) {
         delegate.setCategory(category);
+        return this;
+    }
+
+    @Override
+    public ServerTextChannelBuilder addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+        delegate.addPermissionOverwrite(permissionable, permissions);
+        return this;
+    }
+
+    @Override
+    public ServerTextChannelBuilder removePermissionOverwrite(Permissionable permissionable) {
+        delegate.removePermissionOverwrite(permissionable);
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelUpdater.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerTextChannelUpdaterDelegate;
 import org.javacord.api.entity.permission.Permissions;
@@ -88,13 +89,15 @@ public class ServerTextChannelUpdater extends ServerChannelUpdater {
     }
 
     @Override
-    public ServerTextChannelUpdater addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+    public <T extends Permissionable & DiscordEntity> ServerTextChannelUpdater addPermissionOverwrite(
+            T permissionable, Permissions permissions) {
         delegate.addPermissionOverwrite(permissionable, permissions);
         return this;
     }
 
     @Override
-    public ServerTextChannelUpdater removePermissionOverwrite(Permissionable permissionable) {
+    public <T extends Permissionable & DiscordEntity> ServerTextChannelUpdater removePermissionOverwrite(
+            T permissionable) {
         delegate.removePermissionOverwrite(permissionable);
         return this;
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelUpdater.java
@@ -1,9 +1,8 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerTextChannelUpdaterDelegate;
 import org.javacord.api.entity.permission.Permissions;
-import org.javacord.api.entity.permission.Role;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.util.internal.DelegateFactory;
 
 import java.util.concurrent.CompletableFuture;
@@ -89,26 +88,14 @@ public class ServerTextChannelUpdater extends ServerChannelUpdater {
     }
 
     @Override
-    public ServerTextChannelUpdater addPermissionOverwrite(User user, Permissions permissions) {
-        delegate.addPermissionOverwrite(user, permissions);
+    public ServerTextChannelUpdater addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+        delegate.addPermissionOverwrite(permissionable, permissions);
         return this;
     }
 
     @Override
-    public ServerTextChannelUpdater addPermissionOverwrite(Role role, Permissions permissions) {
-        delegate.addPermissionOverwrite(role, permissions);
-        return this;
-    }
-
-    @Override
-    public ServerTextChannelUpdater removePermissionOverwrite(User user) {
-        delegate.removePermissionOverwrite(user);
-        return this;
-    }
-
-    @Override
-    public ServerTextChannelUpdater removePermissionOverwrite(Role role) {
-        delegate.removePermissionOverwrite(role);
+    public ServerTextChannelUpdater removePermissionOverwrite(Permissionable permissionable) {
+        delegate.removePermissionOverwrite(permissionable);
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelBuilder.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerVoiceChannelBuilderDelegate;
 import org.javacord.api.entity.permission.Permissions;
@@ -74,13 +75,15 @@ public class ServerVoiceChannelBuilder extends ServerChannelBuilder {
     }
 
     @Override
-    public ServerVoiceChannelBuilder addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+    public <T extends Permissionable & DiscordEntity> ServerVoiceChannelBuilder addPermissionOverwrite(
+            T permissionable, Permissions permissions) {
         delegate.addPermissionOverwrite(permissionable, permissions);
         return this;
     }
 
     @Override
-    public ServerVoiceChannelBuilder removePermissionOverwrite(Permissionable permissionable) {
+    public <T extends Permissionable & DiscordEntity> ServerVoiceChannelBuilder removePermissionOverwrite(
+            T permissionable) {
         delegate.removePermissionOverwrite(permissionable);
         return this;
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelBuilder.java
@@ -1,6 +1,8 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerVoiceChannelBuilderDelegate;
+import org.javacord.api.entity.permission.Permissions;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.util.internal.DelegateFactory;
 
@@ -62,6 +64,18 @@ public class ServerVoiceChannelBuilder extends ServerChannelBuilder {
      */
     public ServerVoiceChannelBuilder setUserlimit(int userlimit) {
         delegate.setUserlimit(userlimit);
+        return this;
+    }
+
+    @Override
+    public ServerVoiceChannelBuilder addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+        delegate.addPermissionOverwrite(permissionable, permissions);
+        return this;
+    }
+
+    @Override
+    public ServerVoiceChannelBuilder removePermissionOverwrite(Permissionable permissionable) {
+        delegate.removePermissionOverwrite(permissionable);
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelBuilder.java
@@ -39,7 +39,13 @@ public class ServerVoiceChannelBuilder extends ServerChannelBuilder {
         return this;
     }
 
-    @Override
+
+    /**
+     * Sets the category of the channel.
+     *
+     * @param category The category of the channel.
+     * @return The current instance in order to chain call methods.
+     */
     public ServerVoiceChannelBuilder setCategory(ChannelCategory category) {
         delegate.setCategory(category);
         return this;

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelBuilder.java
@@ -9,7 +9,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class is used to create new server voice channels.
  */
-public class ServerVoiceChannelBuilder {
+public class ServerVoiceChannelBuilder extends ServerChannelBuilder {
 
     /**
      * The server text channel delegate used by this instance.
@@ -25,34 +25,19 @@ public class ServerVoiceChannelBuilder {
         delegate = DelegateFactory.createServerVoiceChannelBuilderDelegate(server);
     }
 
-    /**
-     * Sets the reason for this creation. This reason will be visible in the audit log entry(s).
-     *
-     * @param reason The reason for this update.
-     * @return The current instance in order to chain call methods.
-     */
+    @Override
     public ServerVoiceChannelBuilder setAuditLogReason(String reason) {
         delegate.setAuditLogReason(reason);
         return this;
     }
 
-    /**
-     * Sets the name of the channel.
-     *
-     * @param name The name of the channel.
-     * @return The current instance in order to chain call methods.
-     */
+    @Override
     public ServerVoiceChannelBuilder setName(String name) {
         delegate.setName(name);
         return this;
     }
 
-    /**
-     * Sets the category of the channel.
-     *
-     * @param category The category of the channel.
-     * @return The current instance in order to chain call methods.
-     */
+    @Override
     public ServerVoiceChannelBuilder setCategory(ChannelCategory category) {
         delegate.setCategory(category);
         return this;

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelUpdater.java
@@ -1,9 +1,8 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerVoiceChannelUpdaterDelegate;
 import org.javacord.api.entity.permission.Permissions;
-import org.javacord.api.entity.permission.Role;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.util.internal.DelegateFactory;
 
 import java.util.concurrent.CompletableFuture;
@@ -99,26 +98,14 @@ public class ServerVoiceChannelUpdater extends ServerChannelUpdater {
     }
 
     @Override
-    public ServerVoiceChannelUpdater addPermissionOverwrite(User user, Permissions permissions) {
-        delegate.addPermissionOverwrite(user, permissions);
+    public ServerVoiceChannelUpdater addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+        delegate.addPermissionOverwrite(permissionable, permissions);
         return this;
     }
 
     @Override
-    public ServerVoiceChannelUpdater addPermissionOverwrite(Role role, Permissions permissions) {
-        delegate.addPermissionOverwrite(role, permissions);
-        return this;
-    }
-
-    @Override
-    public ServerVoiceChannelUpdater removePermissionOverwrite(User user) {
-        delegate.removePermissionOverwrite(user);
-        return this;
-    }
-
-    @Override
-    public ServerVoiceChannelUpdater removePermissionOverwrite(Role role) {
-        delegate.removePermissionOverwrite(role);
+    public ServerVoiceChannelUpdater removePermissionOverwrite(Permissionable permissionable) {
+        delegate.removePermissionOverwrite(permissionable);
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannelUpdater.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerVoiceChannelUpdaterDelegate;
 import org.javacord.api.entity.permission.Permissions;
@@ -98,13 +99,15 @@ public class ServerVoiceChannelUpdater extends ServerChannelUpdater {
     }
 
     @Override
-    public ServerVoiceChannelUpdater addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+    public <T extends Permissionable & DiscordEntity> ServerVoiceChannelUpdater addPermissionOverwrite(
+            T permissionable, Permissions permissions) {
         delegate.addPermissionOverwrite(permissionable, permissions);
         return this;
     }
 
     @Override
-    public ServerVoiceChannelUpdater removePermissionOverwrite(Permissionable permissionable) {
+    public <T extends Permissionable & DiscordEntity> ServerVoiceChannelUpdater removePermissionOverwrite(
+            T permissionable) {
         delegate.removePermissionOverwrite(permissionable);
         return this;
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ChannelCategoryBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ChannelCategoryBuilderDelegate.java
@@ -9,21 +9,7 @@ import java.util.concurrent.CompletableFuture;
  * This class is internally used by the {@link ChannelCategoryBuilder} to create channel categories.
  * You usually don't want to interact with this object.
  */
-public interface ChannelCategoryBuilderDelegate {
-
-    /**
-     * Sets the reason for this creation. This reason will be visible in the audit log entry(s).
-     *
-     * @param reason The reason for this update.
-     */
-    void setAuditLogReason(String reason);
-
-    /**
-     * Sets the name of the channel.
-     *
-     * @param name The name of the channel.
-     */
-    void setName(String name);
+public interface ChannelCategoryBuilderDelegate extends ServerChannelBuilderDelegate {
 
     /**
      * Creates the channel category.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelBuilderDelegate.java
@@ -1,7 +1,9 @@
 package org.javacord.api.entity.channel.internal;
 
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.ServerChannelBuilder;
+import org.javacord.api.entity.permission.Permissions;
 
 /**
  * This class is internally used by the {@link ServerChannelBuilder} to create server channels.
@@ -30,4 +32,18 @@ public interface ServerChannelBuilderDelegate {
      */
     void setCategory(ChannelCategory category);
 
+    /**
+     * Adds a permission overwrite for the given entity.
+     *
+     * @param permissionable The entity whose permissions should be overwritten.
+     * @param permissions The permission overwrites.
+     */
+    void addPermissionOverwrite(Permissionable permissionable, Permissions permissions);
+
+    /**
+     * Removes a permission overwrite for the given entity.
+     *
+     * @param permissionable The entity whose permission overwrite should be removed.
+     */
+    void removePermissionOverwrite(Permissionable permissionable);
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelBuilderDelegate.java
@@ -1,0 +1,33 @@
+package org.javacord.api.entity.channel.internal;
+
+import org.javacord.api.entity.channel.ChannelCategory;
+import org.javacord.api.entity.channel.ServerChannelBuilder;
+
+/**
+ * This class is internally used by the {@link ServerChannelBuilder} to create server channels.
+ * You usually don't want to interact with this object.
+ */
+public interface ServerChannelBuilderDelegate {
+
+    /**
+     * Sets the reason for this creation. This reason will be visible in the audit log entry(s).
+     *
+     * @param reason The reason for this update.
+     */
+    void setAuditLogReason(String reason);
+
+    /**
+     * Sets the name of the channel.
+     *
+     * @param name The name of the channel.
+     */
+    void setName(String name);
+
+    /**
+     * Sets the category of the channel.
+     *
+     * @param category The category of the channel.
+     */
+    void setCategory(ChannelCategory category);
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelBuilderDelegate.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel.internal;
 
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.ServerChannelBuilder;
 import org.javacord.api.entity.permission.Permissions;
@@ -27,15 +28,17 @@ public interface ServerChannelBuilderDelegate {
     /**
      * Adds a permission overwrite for the given entity.
      *
+     * @param <T> The type of entity to hold the permission, usually <code>User</code> or <code>Role</code>
      * @param permissionable The entity whose permissions should be overwritten.
      * @param permissions The permission overwrites.
      */
-    void addPermissionOverwrite(Permissionable permissionable, Permissions permissions);
+    <T extends Permissionable & DiscordEntity> void addPermissionOverwrite(T permissionable, Permissions permissions);
 
     /**
      * Removes a permission overwrite for the given entity.
      *
+     * @param <T> The type of entity to hold the permission, usually <code>User</code> or <code>Role</code>
      * @param permissionable The entity whose permission overwrite should be removed.
      */
-    void removePermissionOverwrite(Permissionable permissionable);
+    <T extends Permissionable & DiscordEntity> void removePermissionOverwrite(T permissionable);
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelBuilderDelegate.java
@@ -1,7 +1,6 @@
 package org.javacord.api.entity.channel.internal;
 
 import org.javacord.api.entity.Permissionable;
-import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.ServerChannelBuilder;
 import org.javacord.api.entity.permission.Permissions;
 
@@ -24,13 +23,6 @@ public interface ServerChannelBuilderDelegate {
      * @param name The name of the channel.
      */
     void setName(String name);
-
-    /**
-     * Sets the category of the channel.
-     *
-     * @param category The category of the channel.
-     */
-    void setCategory(ChannelCategory category);
 
     /**
      * Adds a permission overwrite for the given entity.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelUpdaterDelegate.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel.internal;
 
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.ServerChannelUpdater;
@@ -39,17 +40,19 @@ public interface ServerChannelUpdaterDelegate {
     /**
      * Adds a permission overwrite for the given entity.
      *
+     * @param <T> The type of entity to hold the permission, usually <code>User</code> or <code>Role</code>
      * @param permissionable The entity whose permissions should be overwritten.
      * @param permissions The permission overwrites.
      */
-    void addPermissionOverwrite(Permissionable permissionable, Permissions permissions);
+    <T extends Permissionable & DiscordEntity> void addPermissionOverwrite(T permissionable, Permissions permissions);
 
     /**
      * Removes a permission overwrite for the given entity.
      *
+     * @param <T> The type of entity to hold the permission, usually <code>User</code> or <code>Role</code>
      * @param permissionable The entity whose permission overwrite should be removed.
      */
-    void removePermissionOverwrite(Permissionable permissionable);
+    <T extends Permissionable & DiscordEntity> void removePermissionOverwrite(T permissionable);
 
     /**
      * Performs the queued updates.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerChannelUpdaterDelegate.java
@@ -1,10 +1,9 @@
 package org.javacord.api.entity.channel.internal;
 
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.ServerChannelUpdater;
 import org.javacord.api.entity.permission.Permissions;
-import org.javacord.api.entity.permission.Role;
-import org.javacord.api.entity.user.User;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -38,34 +37,19 @@ public interface ServerChannelUpdaterDelegate {
     void setRawPosition(int rawPosition);
 
     /**
-     * Adds a permission overwrite for the given user.
+     * Adds a permission overwrite for the given entity.
      *
-     * @param user The user whose permissions should be overwritten.
+     * @param permissionable The entity whose permissions should be overwritten.
      * @param permissions The permission overwrites.
      */
-    void addPermissionOverwrite(User user, Permissions permissions);
+    void addPermissionOverwrite(Permissionable permissionable, Permissions permissions);
 
     /**
-     * Adds a permission overwrite for the given role.
+     * Removes a permission overwrite for the given entity.
      *
-     * @param role The role which permissions should be overwritten.
-     * @param permissions The permission overwrites.
+     * @param permissionable The entity whose permission overwrite should be removed.
      */
-    void addPermissionOverwrite(Role role, Permissions permissions);
-
-    /**
-     * Removes a permission overwrite for the given user.
-     *
-     * @param user The user whose permission overwrite should be removed.
-     */
-    void removePermissionOverwrite(User user);
-
-    /**
-     * Removes a permission overwrite for the given role.
-     *
-     * @param role The role which permission overwrite should be removed.
-     */
-    void removePermissionOverwrite(Role role);
+    void removePermissionOverwrite(Permissionable permissionable);
 
     /**
      * Performs the queued updates.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerTextChannelBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerTextChannelBuilderDelegate.java
@@ -1,6 +1,5 @@
 package org.javacord.api.entity.channel.internal;
 
-import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.ServerTextChannel;
 import org.javacord.api.entity.channel.ServerTextChannelBuilder;
 
@@ -10,21 +9,7 @@ import java.util.concurrent.CompletableFuture;
  * This class is internally used by the {@link ServerTextChannelBuilder} to create server text channels.
  * You usually don't want to interact with this object.
  */
-public interface ServerTextChannelBuilderDelegate {
-
-    /**
-     * Sets the reason for this creation. This reason will be visible in the audit log entry(s).
-     *
-     * @param reason The reason for this update.
-     */
-    void setAuditLogReason(String reason);
-
-    /**
-     * Sets the name of the channel.
-     *
-     * @param name The name of the channel.
-     */
-    void setName(String name);
+public interface ServerTextChannelBuilderDelegate extends ServerChannelBuilderDelegate {
 
     /**
      * Sets the topic of the channel.
@@ -32,13 +17,6 @@ public interface ServerTextChannelBuilderDelegate {
      * @param topic The topic of the channel.
      */
     void setTopic(String topic);
-
-    /**
-     * Sets the category of the channel.
-     *
-     * @param category The category of the channel.
-     */
-    void setCategory(ChannelCategory category);
 
     /**
      * Creates the server text channel.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerTextChannelBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerTextChannelBuilderDelegate.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel.internal;
 
+import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.ServerTextChannel;
 import org.javacord.api.entity.channel.ServerTextChannelBuilder;
 
@@ -17,6 +18,13 @@ public interface ServerTextChannelBuilderDelegate extends ServerChannelBuilderDe
      * @param topic The topic of the channel.
      */
     void setTopic(String topic);
+
+    /**
+     * Sets the category of the channel.
+     *
+     * @param category The category of the channel.
+     */
+    void setCategory(ChannelCategory category);
 
     /**
      * Creates the server text channel.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerVoiceChannelBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerVoiceChannelBuilderDelegate.java
@@ -1,6 +1,5 @@
 package org.javacord.api.entity.channel.internal;
 
-import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.ServerVoiceChannel;
 import org.javacord.api.entity.channel.ServerVoiceChannelBuilder;
 
@@ -10,28 +9,7 @@ import java.util.concurrent.CompletableFuture;
  * This class is internally used by the {@link ServerVoiceChannelBuilder} to create server voice channels.
  * You usually don't want to interact with this object.
  */
-public interface ServerVoiceChannelBuilderDelegate {
-
-    /**
-     * Sets the reason for this creation. This reason will be visible in the audit log entry(s).
-     *
-     * @param reason The reason for this update.
-     */
-    void setAuditLogReason(String reason);
-
-    /**
-     * Sets the name of the channel.
-     *
-     * @param name The name of the channel.
-     */
-    void setName(String name);
-
-    /**
-     * Sets the category of the channel.
-     *
-     * @param category The category of the channel.
-     */
-    void setCategory(ChannelCategory category);
+public interface ServerVoiceChannelBuilderDelegate extends ServerChannelBuilderDelegate {
 
     /**
      * Sets the bitrate of the channel.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerVoiceChannelBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerVoiceChannelBuilderDelegate.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel.internal;
 
+import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.ServerVoiceChannel;
 import org.javacord.api.entity.channel.ServerVoiceChannelBuilder;
 
@@ -24,6 +25,13 @@ public interface ServerVoiceChannelBuilderDelegate extends ServerChannelBuilderD
      * @param userlimit The user limit of the channel.
      */
     void setUserlimit(int userlimit);
+
+    /**
+     * Sets the category of the channel.
+     *
+     * @param category The category of the channel.
+     */
+    void setCategory(ChannelCategory category);
 
     /**
      * Creates the server voice channel.

--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
@@ -3,6 +3,7 @@ package org.javacord.api.entity.permission;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Mentionable;
 import org.javacord.api.entity.Nameable;
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.UpdatableFromCache;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.server.ServerUpdater;
@@ -31,7 +32,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class represents a Discord role, e.g. "moderator".
  */
-public interface Role extends DiscordEntity, Mentionable, Nameable, UpdatableFromCache<Role> {
+public interface Role extends DiscordEntity, Mentionable, Nameable, Permissionable, UpdatableFromCache<Role> {
 
     /**
      * Gets the server of the role.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -6,6 +6,7 @@ import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.Mentionable;
 import org.javacord.api.entity.Nameable;
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.UpdatableFromCache;
 import org.javacord.api.entity.activity.Activity;
 import org.javacord.api.entity.channel.GroupChannel;
@@ -60,7 +61,8 @@ import java.util.stream.Collectors;
 /**
  * This class represents a user.
  */
-public interface User extends DiscordEntity, Messageable, Nameable, Mentionable, UpdatableFromCache<User> {
+public interface User extends DiscordEntity, Messageable, Nameable, Mentionable, Permissionable,
+        UpdatableFromCache<User> {
 
     @Override
     default String getMentionTag() {

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ChannelCategoryBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ChannelCategoryBuilderDelegateImpl.java
@@ -1,6 +1,7 @@
 package org.javacord.core.entity.channel;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.internal.ChannelCategoryBuilderDelegate;
 import org.javacord.core.entity.server.ServerImpl;
@@ -13,22 +14,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * The implementation of {@link ChannelCategoryBuilderDelegate}.
  */
-public class ChannelCategoryBuilderDelegateImpl implements ChannelCategoryBuilderDelegate {
-
-    /**
-     * The server of the channel.
-     */
-    private final ServerImpl server;
-
-    /**
-     * The reason for the creation.
-     */
-    private String reason = null;
-
-    /**
-     * The name of the channel.
-     */
-    private String name = null;
+public class ChannelCategoryBuilderDelegateImpl extends ServerChannelBuilderDelegateImpl
+        implements ChannelCategoryBuilderDelegate {
 
     /**
      * Creates a new channel category builder delegate.
@@ -36,27 +23,17 @@ public class ChannelCategoryBuilderDelegateImpl implements ChannelCategoryBuilde
      * @param server The server of the channel category.
      */
     public ChannelCategoryBuilderDelegateImpl(ServerImpl server) {
-        this.server = server;
-    }
-
-    @Override
-    public void setAuditLogReason(String reason) {
-        this.reason = reason;
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
+        super(server);
     }
 
     @Override
     public CompletableFuture<ChannelCategory> create() {
-        if (name == null) {
-            throw new IllegalStateException("Name is no optional parameter!");
-        }
+        ObjectNode body = JsonNodeFactory.instance.objectNode()
+                .put("type", 4);
+        super.prepareBody(body);
         return new RestRequest<ChannelCategory>(server.getApi(), RestMethod.POST, RestEndpoint.SERVER_CHANNEL)
                 .setUrlParameters(server.getIdAsString())
-                .setBody(JsonNodeFactory.instance.objectNode().put("type", 4).put("name", name))
+                .setBody(body)
                 .setAuditLogReason(reason)
                 .execute(result -> server.getOrCreateChannelCategory(result.getJsonBody()));
     }

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelBuilderDelegateImpl.java
@@ -3,7 +3,6 @@ package org.javacord.core.entity.channel;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.entity.Permissionable;
-import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.internal.ServerChannelBuilderDelegate;
 import org.javacord.api.entity.permission.Permissions;
 import org.javacord.api.entity.permission.Role;
@@ -34,11 +33,6 @@ public class ServerChannelBuilderDelegateImpl implements ServerChannelBuilderDel
     private String name = null;
 
     /**
-     * The category of the channel.
-     */
-    private ChannelCategory category = null;
-
-    /**
      * The overwritten user permissions.
      */
     private final Map<Long, Permissions> overwrittenUserPermissions = new HashMap<>();
@@ -60,11 +54,6 @@ public class ServerChannelBuilderDelegateImpl implements ServerChannelBuilderDel
     @Override
     public void setName(String name) {
         this.name = name;
-    }
-
-    @Override
-    public void setCategory(ChannelCategory category) {
-        this.category = category;
     }
 
     @Override
@@ -90,9 +79,6 @@ public class ServerChannelBuilderDelegateImpl implements ServerChannelBuilderDel
             throw new IllegalStateException("Name is no optional parameter!");
         }
         body.put("name", name);
-        if (category != null) {
-            body.put("parent_id", category.getIdAsString());
-        }
         ArrayNode permissionOverwrites = null;
         if (overwrittenUserPermissions.size() + overwrittenRolePermissions.size() > 0) {
             permissionOverwrites = body.putArray("permission_overwrites");

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelBuilderDelegateImpl.java
@@ -1,0 +1,61 @@
+package org.javacord.core.entity.channel;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.entity.channel.ChannelCategory;
+import org.javacord.api.entity.channel.internal.ServerChannelBuilderDelegate;
+import org.javacord.core.entity.server.ServerImpl;
+
+/**
+ * The implementation of {@link ServerChannelBuilderDelegate}.
+ */
+public class ServerChannelBuilderDelegateImpl implements ServerChannelBuilderDelegate {
+
+    /**
+     * The server of the channel.
+     */
+    protected final ServerImpl server;
+
+    /**
+     * The reason for the creation.
+     */
+    protected String reason = null;
+
+    /**
+     * The name of the channel.
+     */
+    private String name = null;
+
+    /**
+     * The category of the channel.
+     */
+    private ChannelCategory category = null;
+
+    protected ServerChannelBuilderDelegateImpl(ServerImpl server) {
+        this.server = server;
+    }
+
+    @Override
+    public void setAuditLogReason(String reason) {
+        this.reason = reason;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void setCategory(ChannelCategory category) {
+        this.category = category;
+    }
+
+    protected void prepareBody(ObjectNode body) {
+        if (name == null) {
+            throw new IllegalStateException("Name is no optional parameter!");
+        }
+        body.put("name", name);
+        if (category != null) {
+            body.put("parent_id", category.getIdAsString());
+        }
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelBuilderDelegateImpl.java
@@ -2,6 +2,7 @@ package org.javacord.core.entity.channel;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.internal.ServerChannelBuilderDelegate;
 import org.javacord.api.entity.permission.Permissions;
@@ -57,7 +58,8 @@ public class ServerChannelBuilderDelegateImpl implements ServerChannelBuilderDel
     }
 
     @Override
-    public void addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+    public <T extends Permissionable & DiscordEntity> void addPermissionOverwrite(T permissionable,
+                                                                                  Permissions permissions) {
         if (permissionable instanceof Role) {
             overwrittenRolePermissions.put(permissionable.getId(), permissions);
         } else if (permissionable instanceof User) {
@@ -66,7 +68,7 @@ public class ServerChannelBuilderDelegateImpl implements ServerChannelBuilderDel
     }
 
     @Override
-    public void removePermissionOverwrite(Permissionable permissionable) {
+    public <T extends Permissionable & DiscordEntity> void removePermissionOverwrite(T permissionable) {
         if (permissionable instanceof Role) {
             overwrittenRolePermissions.remove(permissionable.getId());
         } else if (permissionable instanceof User) {

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelImpl.java
@@ -3,6 +3,7 @@ package org.javacord.core.entity.channel;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.DiscordEntity;
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.permission.PermissionState;
 import org.javacord.api.entity.permission.PermissionType;
@@ -311,13 +312,14 @@ public abstract class ServerChannelImpl implements ServerChannel, InternalChanne
     }
 
     @Override
-    public Permissions getOverwrittenPermissions(User user) {
-        return overwrittenUserPermissions.getOrDefault(user.getId(), PermissionsImpl.EMPTY_PERMISSIONS);
-    }
-
-    @Override
-    public Permissions getOverwrittenPermissions(Role role) {
-        return overwrittenRolePermissions.getOrDefault(role.getId(), PermissionsImpl.EMPTY_PERMISSIONS);
+    public <T extends Permissionable & DiscordEntity> Permissions getOverwrittenPermissions(T permissionable) {
+        Map<Long, Permissions> permissionsMap = Collections.emptyMap();
+        if (permissionable instanceof User) {
+            permissionsMap = overwrittenUserPermissions;
+        } else if (permissionable instanceof Role) {
+            permissionsMap = overwrittenRolePermissions;
+        }
+        return permissionsMap.getOrDefault(permissionable.getId(), PermissionsImpl.EMPTY_PERMISSIONS);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelUpdaterDelegateImpl.java
@@ -3,6 +3,7 @@ package org.javacord.core.entity.channel;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.internal.ServerChannelUpdaterDelegate;
@@ -77,7 +78,8 @@ public class ServerChannelUpdaterDelegateImpl implements ServerChannelUpdaterDel
     }
 
     @Override
-    public void addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
+    public <T extends Permissionable & DiscordEntity> void addPermissionOverwrite(T permissionable,
+                                                                                  Permissions permissions) {
         populatePermissionOverwrites();
         if (permissionable instanceof Role) {
             overwrittenRolePermissions.put(permissionable.getId(), permissions);
@@ -87,7 +89,7 @@ public class ServerChannelUpdaterDelegateImpl implements ServerChannelUpdaterDel
     }
 
     @Override
-    public void removePermissionOverwrite(Permissionable permissionable) {
+    public <T extends Permissionable & DiscordEntity> void removePermissionOverwrite(T permissionable) {
         populatePermissionOverwrites();
         if (permissionable instanceof Role) {
             overwrittenRolePermissions.remove(permissionable.getId());

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelUpdaterDelegateImpl.java
@@ -3,6 +3,7 @@ package org.javacord.core.entity.channel;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.entity.Permissionable;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.internal.ServerChannelUpdaterDelegate;
 import org.javacord.api.entity.permission.Permissions;
@@ -76,27 +77,23 @@ public class ServerChannelUpdaterDelegateImpl implements ServerChannelUpdaterDel
     }
 
     @Override
-    public void addPermissionOverwrite(User user, Permissions permissions) {
+    public void addPermissionOverwrite(Permissionable permissionable, Permissions permissions) {
         populatePermissionOverwrites();
-        overwrittenUserPermissions.put(user.getId(), permissions);
+        if (permissionable instanceof Role) {
+            overwrittenRolePermissions.put(permissionable.getId(), permissions);
+        } else if (permissionable instanceof User) {
+            overwrittenUserPermissions.put(permissionable.getId(), permissions);
+        }
     }
 
     @Override
-    public void addPermissionOverwrite(Role role, Permissions permissions) {
+    public void removePermissionOverwrite(Permissionable permissionable) {
         populatePermissionOverwrites();
-        overwrittenRolePermissions.put(role.getId(), permissions);
-    }
-
-    @Override
-    public void removePermissionOverwrite(User user) {
-        populatePermissionOverwrites();
-        overwrittenUserPermissions.remove(user.getId());
-    }
-
-    @Override
-    public void removePermissionOverwrite(Role role) {
-        populatePermissionOverwrites();
-        overwrittenRolePermissions.remove(role.getId());
+        if (permissionable instanceof Role) {
+            overwrittenRolePermissions.remove(permissionable.getId());
+        } else if (permissionable instanceof User) {
+            overwrittenUserPermissions.remove(permissionable.getId());
+        }
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelBuilderDelegateImpl.java
@@ -2,6 +2,7 @@ package org.javacord.core.entity.channel;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.ServerTextChannel;
 import org.javacord.api.entity.channel.internal.ServerTextChannelBuilderDelegate;
 import org.javacord.core.entity.server.ServerImpl;
@@ -23,6 +24,11 @@ public class ServerTextChannelBuilderDelegateImpl extends ServerChannelBuilderDe
     private String topic = null;
 
     /**
+     * The category of the channel.
+     */
+    private ChannelCategory category = null;
+
+    /**
      * Creates a new server text channel builder delegate.
      *
      * @param server The server of the server text channel.
@@ -37,12 +43,20 @@ public class ServerTextChannelBuilderDelegateImpl extends ServerChannelBuilderDe
     }
 
     @Override
+    public void setCategory(ChannelCategory category) {
+        this.category = category;
+    }
+
+    @Override
     public CompletableFuture<ServerTextChannel> create() {
         ObjectNode body = JsonNodeFactory.instance.objectNode();
         body.put("type", 0);
         super.prepareBody(body);
         if (topic != null) {
             body.put("topic", topic);
+        }
+        if (category != null) {
+            body.put("parent_id", category.getIdAsString());
         }
         return new RestRequest<ServerTextChannel>(server.getApi(), RestMethod.POST, RestEndpoint.SERVER_CHANNEL)
                 .setUrlParameters(server.getIdAsString())

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelBuilderDelegateImpl.java
@@ -2,7 +2,6 @@ package org.javacord.core.entity.channel;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.ServerTextChannel;
 import org.javacord.api.entity.channel.internal.ServerTextChannelBuilderDelegate;
 import org.javacord.core.entity.server.ServerImpl;
@@ -15,22 +14,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * The implementation of {@link ServerTextChannelBuilderDelegate}.
  */
-public class ServerTextChannelBuilderDelegateImpl implements ServerTextChannelBuilderDelegate {
-
-    /**
-     * The server of the channel.
-     */
-    private final ServerImpl server;
-
-    /**
-     * The reason for the creation.
-     */
-    private String reason = null;
-
-    /**
-     * The name of the channel.
-     */
-    private String name = null;
+public class ServerTextChannelBuilderDelegateImpl extends ServerChannelBuilderDelegateImpl
+        implements ServerTextChannelBuilderDelegate {
 
     /**
      * The topic of the channel.
@@ -38,27 +23,12 @@ public class ServerTextChannelBuilderDelegateImpl implements ServerTextChannelBu
     private String topic = null;
 
     /**
-     * The category of the channel.
-     */
-    private ChannelCategory category = null;
-
-    /**
      * Creates a new server text channel builder delegate.
      *
      * @param server The server of the server text channel.
      */
     public ServerTextChannelBuilderDelegateImpl(ServerImpl server) {
-        this.server = server;
-    }
-
-    @Override
-    public void setAuditLogReason(String reason) {
-        this.reason = reason;
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
+        super(server);
     }
 
     @Override
@@ -67,21 +37,10 @@ public class ServerTextChannelBuilderDelegateImpl implements ServerTextChannelBu
     }
 
     @Override
-    public void setCategory(ChannelCategory category) {
-        this.category = category;
-    }
-
-    @Override
     public CompletableFuture<ServerTextChannel> create() {
         ObjectNode body = JsonNodeFactory.instance.objectNode();
         body.put("type", 0);
-        if (name == null) {
-            throw new IllegalStateException("Name is no optional parameter!");
-        }
-        body.put("name", name);
-        if (category != null) {
-            body.put("parent_id", category.getIdAsString());
-        }
+        super.prepareBody(body);
         if (topic != null) {
             body.put("topic", topic);
         }

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerVoiceChannelBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerVoiceChannelBuilderDelegateImpl.java
@@ -2,6 +2,7 @@ package org.javacord.core.entity.channel;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.ServerVoiceChannel;
 import org.javacord.api.entity.channel.internal.ServerVoiceChannelBuilderDelegate;
 import org.javacord.core.entity.server.ServerImpl;
@@ -28,6 +29,11 @@ public class ServerVoiceChannelBuilderDelegateImpl extends ServerChannelBuilderD
     private Integer userlimit = null;
 
     /**
+     * The category of the channel.
+     */
+    private ChannelCategory category = null;
+
+    /**
      * Creates a new server voice channel builder delegate.
      *
      * @param server The server of the server voice channel.
@@ -47,6 +53,11 @@ public class ServerVoiceChannelBuilderDelegateImpl extends ServerChannelBuilderD
     }
 
     @Override
+    public void setCategory(ChannelCategory category) {
+        this.category = category;
+    }
+
+    @Override
     public CompletableFuture<ServerVoiceChannel> create() {
         ObjectNode body = JsonNodeFactory.instance.objectNode();
         body.put("type", 2);
@@ -58,12 +69,14 @@ public class ServerVoiceChannelBuilderDelegateImpl extends ServerChannelBuilderD
         if (userlimit != null) {
             body.put("user_limit", (int) userlimit);
         }
+        if (category != null) {
+            body.put("parent_id", category.getIdAsString());
+        }
         return new RestRequest<ServerVoiceChannel>(server.getApi(), RestMethod.POST, RestEndpoint.SERVER_CHANNEL)
                 .setUrlParameters(server.getIdAsString())
                 .setBody(body)
                 .setAuditLogReason(reason)
                 .execute(result -> server.getOrCreateServerVoiceChannel(result.getJsonBody()));
     }
-
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerVoiceChannelBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerVoiceChannelBuilderDelegateImpl.java
@@ -2,7 +2,6 @@ package org.javacord.core.entity.channel;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.ServerVoiceChannel;
 import org.javacord.api.entity.channel.internal.ServerVoiceChannelBuilderDelegate;
 import org.javacord.core.entity.server.ServerImpl;
@@ -15,22 +14,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * The implementation of {@link ServerVoiceChannelBuilderDelegate}.
  */
-public class ServerVoiceChannelBuilderDelegateImpl implements ServerVoiceChannelBuilderDelegate {
-
-    /**
-     * The server of the channel.
-     */
-    private final ServerImpl server;
-
-    /**
-     * The reason for the creation.
-     */
-    private String reason = null;
-
-    /**
-     * The name of the channel.
-     */
-    private String name = null;
+public class ServerVoiceChannelBuilderDelegateImpl extends ServerChannelBuilderDelegateImpl
+        implements ServerVoiceChannelBuilderDelegate {
 
     /**
      * The bitrate of the channel.
@@ -43,32 +28,12 @@ public class ServerVoiceChannelBuilderDelegateImpl implements ServerVoiceChannel
     private Integer userlimit = null;
 
     /**
-     * The category of the channel.
-     */
-    private ChannelCategory category = null;
-
-    /**
      * Creates a new server voice channel builder delegate.
      *
      * @param server The server of the server voice channel.
      */
     public ServerVoiceChannelBuilderDelegateImpl(ServerImpl server) {
-        this.server = server;
-    }
-
-    @Override
-    public void setAuditLogReason(String reason) {
-        this.reason = reason;
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @Override
-    public void setCategory(ChannelCategory category) {
-        this.category = category;
+        super(server);
     }
 
     @Override
@@ -85,13 +50,8 @@ public class ServerVoiceChannelBuilderDelegateImpl implements ServerVoiceChannel
     public CompletableFuture<ServerVoiceChannel> create() {
         ObjectNode body = JsonNodeFactory.instance.objectNode();
         body.put("type", 2);
-        if (name == null) {
-            throw new IllegalStateException("Name is no optional parameter!");
-        }
-        body.put("name", name);
-        if (category != null) {
-            body.put("parent_id", category.getIdAsString());
-        }
+        super.prepareBody(body);
+
         if (bitrate != null) {
             body.put("bitrate", (int) bitrate);
         }


### PR DESCRIPTION
From the todo channel.

Major changes are

- Introduced the `Permissionable` interface for entities that can be granted permissions (currently `User` and `Role`)
- Reworked the server channel builders in order to reduce duplication of both code and documentation
- Included the possibility to set permission overrides on channel creation.