### PR TITLE
Nameable interface

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/ApplicationInfo.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/ApplicationInfo.java
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletableFuture;
  * Represents the information of an application (aka. bot).
  * This class won't get updated after being fetched!
  */
-public interface ApplicationInfo {
+public interface ApplicationInfo extends Nameable {
 
     /**
      * Gets the client id of the application.

--- a/javacord-api/src/main/java/org/javacord/api/entity/ApplicationInfo.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/ApplicationInfo.java
@@ -18,13 +18,6 @@ public interface ApplicationInfo extends Nameable {
     long getClientId();
 
     /**
-     * Gets the name of the application.
-     *
-     * @return The name of the application.
-     */
-    String getName();
-
-    /**
      * Gets the description of the application.
      *
      * @return The description of the application.

--- a/javacord-api/src/main/java/org/javacord/api/entity/Nameable.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/Nameable.java
@@ -1,0 +1,14 @@
+package org.javacord.api.entity;
+
+/**
+ * This class represents an entity which has a name.
+ */
+public interface Nameable {
+
+    /**
+     * Gets the name of the entity.
+     *
+     * @return The name of the entity.
+     */
+    String getName();
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/Region.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/Region.java
@@ -3,7 +3,7 @@ package org.javacord.api.entity;
 /**
  * This enum represents a valid region for a server.
  */
-public enum Region {
+public enum Region implements Nameable {
 
     // "Normal" regions
     AMSTERDAM("amsterdam", "Amsterdam", false),

--- a/javacord-api/src/main/java/org/javacord/api/entity/Region.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/Region.java
@@ -72,6 +72,7 @@ public enum Region implements Nameable {
      *
      * @return The name of the region.
      */
+    @Override
     public String getName() {
         return name;
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/activity/Activity.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/activity/Activity.java
@@ -1,12 +1,14 @@
 package org.javacord.api.entity.activity;
 
+import org.javacord.api.entity.Nameable;
+
 import java.time.Instant;
 import java.util.Optional;
 
 /**
  * This class represents a activity as it is displayed in Discord.
  */
-public interface Activity {
+public interface Activity extends Nameable {
 
     /**
      * Gets the type of the activity.

--- a/javacord-api/src/main/java/org/javacord/api/entity/activity/Activity.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/activity/Activity.java
@@ -18,13 +18,6 @@ public interface Activity extends Nameable {
     ActivityType getType();
 
     /**
-     * Gets the name of the activity.
-     *
-     * @return The name of the activity.
-     */
-    String getName();
-
-    /**
      * Gets the streaming url of the activity.
      *
      * @return The streaming url of the activity.

--- a/javacord-api/src/main/java/org/javacord/api/entity/auditlog/AuditLogChangeType.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/auditlog/AuditLogChangeType.java
@@ -1,9 +1,11 @@
 package org.javacord.api.entity.auditlog;
 
+import org.javacord.api.entity.Nameable;
+
 /**
  * This class represents an audit log change type (sometimes also called key).
  */
-public enum AuditLogChangeType {
+public enum AuditLogChangeType implements Nameable {
 
     NAME("name"),
     ICON("icon_hash"),

--- a/javacord-api/src/main/java/org/javacord/api/entity/auditlog/AuditLogChangeType.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/auditlog/AuditLogChangeType.java
@@ -73,6 +73,7 @@ public enum AuditLogChangeType implements Nameable {
      *
      * @return The name of the type.
      */
+    @Override
     public String getName() {
         return name;
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
@@ -1,6 +1,7 @@
 package org.javacord.api.entity.channel;
 
 import org.javacord.api.entity.DiscordEntity;
+import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.permission.PermissionState;
 import org.javacord.api.entity.permission.PermissionType;
 import org.javacord.api.entity.permission.Permissions;
@@ -31,7 +32,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class represents a server channel.
  */
-public interface ServerChannel extends Channel {
+public interface ServerChannel extends Channel, Nameable {
 
     /**
      * Gets the name of the channel.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
@@ -35,13 +35,6 @@ import java.util.concurrent.CompletableFuture;
 public interface ServerChannel extends Channel, Nameable {
 
     /**
-     * Gets the name of the channel.
-     *
-     * @return The name of the channel.
-     */
-    String getName();
-
-    /**
      * Gets the server of the channel.
      *
      * @return The server of the channel.

--- a/javacord-api/src/main/java/org/javacord/api/entity/emoji/CustomEmoji.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/emoji/CustomEmoji.java
@@ -2,6 +2,7 @@ package org.javacord.api.entity.emoji;
 
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
+import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.UpdatableFromCache;
 
 import java.util.Optional;
@@ -11,7 +12,7 @@ import java.util.Optional;
  * If it's an unknown custom emoji, the object won't be unique and won't receive any updates!
  * Only {@link KnownCustomEmoji} receive updates!
  */
-public interface CustomEmoji extends DiscordEntity, Emoji, UpdatableFromCache<KnownCustomEmoji> {
+public interface CustomEmoji extends DiscordEntity, Nameable,  Emoji, UpdatableFromCache<KnownCustomEmoji> {
 
     /**
      * Gets the name of the emoji.

--- a/javacord-api/src/main/java/org/javacord/api/entity/emoji/CustomEmoji.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/emoji/CustomEmoji.java
@@ -15,13 +15,6 @@ import java.util.Optional;
 public interface CustomEmoji extends DiscordEntity, Nameable,  Emoji, UpdatableFromCache<KnownCustomEmoji> {
 
     /**
-     * Gets the name of the emoji.
-     *
-     * @return The name of the emoji.
-     */
-    String getName();
-
-    /**
      * Gets the image of the emoji.
      *
      * @return The image of the emoji.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
@@ -4,6 +4,7 @@ import org.javacord.api.AccountType;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
+import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.channel.Categorizable;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
@@ -15,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class represents either a user or a webhook.
  */
-public interface MessageAuthor extends DiscordEntity {
+public interface MessageAuthor extends DiscordEntity, Nameable {
 
     /**
      * Gets the message.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
@@ -26,13 +26,6 @@ public interface MessageAuthor extends DiscordEntity, Nameable {
     Message getMessage();
 
     /**
-     * Gets the name of the author.
-     *
-     * @return The name of the author.
-     */
-    String getName();
-
-    /**
      * Gets the display name of the author.
      *
      * @return The display name of the author.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedAuthor.java
@@ -1,12 +1,14 @@
 package org.javacord.api.entity.message.embed;
 
+import org.javacord.api.entity.Nameable;
+
 import java.net.URL;
 import java.util.Optional;
 
 /**
  * This interface represents an embed author.
  */
-public interface EmbedAuthor {
+public interface EmbedAuthor extends Nameable {
 
     /**
      * Gets the name of the author.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedAuthor.java
@@ -11,13 +11,6 @@ import java.util.Optional;
 public interface EmbedAuthor extends Nameable {
 
     /**
-     * Gets the name of the author.
-     *
-     * @return The name of the author.
-     */
-    String getName();
-
-    /**
      * Gets the url of the author.
      *
      * @return The url of the author.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedField.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedField.java
@@ -1,9 +1,11 @@
 package org.javacord.api.entity.message.embed;
 
+import org.javacord.api.entity.Nameable;
+
 /**
  * This interface represents an embed field.
  */
-public interface EmbedField {
+public interface EmbedField extends Nameable {
 
     /**
      * Gets the name of the field.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedField.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedField.java
@@ -8,13 +8,6 @@ import org.javacord.api.entity.Nameable;
 public interface EmbedField extends Nameable {
 
     /**
-     * Gets the name of the field.
-     *
-     * @return The name of the field.
-     */
-    String getName();
-
-    /**
      * Gets the value of the field.
      *
      * @return The value of the field.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedProvider.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedProvider.java
@@ -1,11 +1,13 @@
 package org.javacord.api.entity.message.embed;
 
+import org.javacord.api.entity.Nameable;
+
 import java.net.URL;
 
 /**
  * This interface represents an embed provider.
  */
-public interface EmbedProvider {
+public interface EmbedProvider extends Nameable {
 
     /**
      * Gets the name of the provider.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedProvider.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedProvider.java
@@ -10,13 +10,6 @@ import java.net.URL;
 public interface EmbedProvider extends Nameable {
 
     /**
-     * Gets the name of the provider.
-     *
-     * @return The name of the provider.
-     */
-    String getName();
-
-    /**
      * Gets the url of the provider.
      *
      * @return The url of the provider.

--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
@@ -2,6 +2,7 @@ package org.javacord.api.entity.permission;
 
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Mentionable;
+import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.UpdatableFromCache;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.server.ServerUpdater;
@@ -30,7 +31,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class represents a Discord role, e.g. "moderator".
  */
-public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Role> {
+public interface Role extends DiscordEntity, Mentionable, Nameable, UpdatableFromCache<Role> {
 
     /**
      * Gets the server of the role.

--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
@@ -41,13 +41,6 @@ public interface Role extends DiscordEntity, Mentionable, Nameable, UpdatableFro
     Server getServer();
 
     /**
-     * Gets the name of the role.
-     *
-     * @return The name of the role.
-     */
-    String getName();
-
-    /**
      * Gets the position of the role.
      *
      * @return The position of the role.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2,6 +2,7 @@ package org.javacord.api.entity.server;
 
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
+import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.Region;
 import org.javacord.api.entity.UpdatableFromCache;
 import org.javacord.api.entity.auditlog.AuditLog;
@@ -113,7 +114,7 @@ import java.util.stream.Collectors;
 /**
  * The class represents a Discord server, sometimes also called guild.
  */
-public interface Server extends DiscordEntity, UpdatableFromCache<Server> {
+public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Server> {
 
     /**
      * Gets the name of the server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -117,13 +117,6 @@ import java.util.stream.Collectors;
 public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Server> {
 
     /**
-     * Gets the name of the server.
-     *
-     * @return The name of the server.
-     */
-    String getName();
-
-    /**
      * Gets the region of the server.
      *
      * @return The region of the server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -5,6 +5,7 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.Mentionable;
+import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.UpdatableFromCache;
 import org.javacord.api.entity.activity.Activity;
 import org.javacord.api.entity.channel.GroupChannel;
@@ -59,7 +60,7 @@ import java.util.stream.Collectors;
 /**
  * This class represents a user.
  */
-public interface User extends DiscordEntity, Messageable, Mentionable, UpdatableFromCache<User> {
+public interface User extends DiscordEntity, Messageable, Nameable, Mentionable, UpdatableFromCache<User> {
 
     @Override
     default String getMentionTag() {

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -77,13 +77,6 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
     }
 
     /**
-     * Gets the name of the user.
-     *
-     * @return The name of the user.
-     */
-    String getName();
-
-    /**
      * Gets the discriminator of the user.
      *
      * @return The discriminator of the user.


### PR DESCRIPTION
Based on #311 by @depressingIllusion, original PR has been rebased and squashed into a single commit

Redundant declarations of `public String getName()` have been left where they updated the methods javadoc.