### PR TITLE
Fix Role#isHigherThan, Server#canKickUser and Server#canBanUser

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
@@ -32,7 +32,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class represents a Discord role, e.g. "moderator".
  */
-public interface Role extends DiscordEntity, Mentionable, Nameable, Permissionable, UpdatableFromCache<Role> {
+public interface Role extends DiscordEntity, Mentionable, Nameable, Permissionable, Comparable<Role>,
+                              UpdatableFromCache<Role> {
 
     /**
      * Gets the server of the role.
@@ -259,17 +260,6 @@ public interface Role extends DiscordEntity, Mentionable, Nameable, Permissionab
     @Override
     default String getMentionTag() {
         return "<@&" + getIdAsString() + ">";
-    }
-
-    /**
-     * Checks if the this role is higher than the given role.
-     * Always returns <code>true</code> if the roles are on different servers.
-     *
-     * @param role The role to check.
-     * @return Whether the this role is higher than the given role or not.
-     */
-    default boolean isHigherThan(Role role) {
-        return role.getServer() != getServer() || role.getPosition() <= getPosition();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2357,7 +2357,7 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
         Optional<Role> otherRole = getHighestRole(userToKick);
         // otherRole empty => userToKick is not on the server => kick is allowed as Discord allows it
         boolean userToKickOnServer = otherRole.isPresent();
-        return !userToKickOnServer || ownRole.isHigherThan(otherRole.get());
+        return !userToKickOnServer || (ownRole.compareTo(otherRole.get()) > 0);
     }
 
     /**
@@ -2415,7 +2415,7 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
         Optional<Role> otherRole = getHighestRole(userToBan);
         // otherRole empty => userToBan is not on the server => ban is allowed
         boolean userToBanOnServer = otherRole.isPresent();
-        return !userToBanOnServer || ownRole.isHigherThan(otherRole.get());
+        return !userToBanOnServer || (ownRole.compareTo(otherRole.get()) > 0);
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/entity/permission/RoleImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/permission/RoleImpl.java
@@ -30,6 +30,7 @@ import org.javacord.core.util.rest.RestRequest;
 import java.awt.Color;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,10 @@ import java.util.stream.Collectors;
  * The implementation of {@link Role}.
  */
 public class RoleImpl implements Role {
+
+    private static final Comparator<Role> ROLE_COMPARATOR = Comparator
+            .comparingInt(Role::getPosition)
+            .thenComparing(Comparator.comparing(Role::getId).reversed());
 
     /**
      * The discord api instance.
@@ -262,6 +267,21 @@ public class RoleImpl implements Role {
         return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.ROLE)
                 .setUrlParameters(getServer().getIdAsString(), getIdAsString())
                 .execute(result -> null);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p/><b><i>Implementation note:</i></b> Only roles from the same server can be compared
+     *
+     * @throws IllegalArgumentException If the roles are on different servers.
+     */
+    @Override
+    public int compareTo(Role role) {
+        if (!role.getServer().equals(getServer())) {
+            throw new IllegalArgumentException("Only roles from the same server can be compared for order");
+        }
+        return ROLE_COMPARATOR.compare(this, role);
     }
 
     @Override


### PR DESCRIPTION
There were some errors in role comparision, user-kickability and user-banability calculations.

# Role#isHigherThan

Before:
- Roles on different servers => true
- Roles have same position => true

After
- Roles on different servers => IllegalArgumentException
- Roles have same position => false



# Server#canKickUser and Server#canBanUser

Before:
- User to do the kick has generally right to kick / ban => false
- User to do the kick is server owner => still role order was considered

After:
- User to do the kick does not have generally right to kick / ban => false
- User to do the kick is server owner => true