### PR TITLE
Replaced self-closing paragraph tag of JavaDocs

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/permission/RoleImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/permission/RoleImpl.java
@@ -272,7 +272,7 @@ public class RoleImpl implements Role {
     /**
      * {@inheritDoc}
      *
-     * <p/><b><i>Implementation note:</i></b> Only roles from the same server can be compared
+     * <p><b><i>Implementation note:</i></b> Only roles from the same server can be compared
      *
      * @throws IllegalArgumentException If the roles are on different servers.
      */


### PR DESCRIPTION
This tag causes the build to fail on some machines.