### PR TITLE
Rename TextChannel#deleteAll to deleteMessages and Message#deleteAll and UncachedMessageUtil#deleteAll to delete

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/TextChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/TextChannel.java
@@ -261,8 +261,8 @@ public interface TextChannel extends Channel, Messageable, TextChannelAttachable
      * @param messages The messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    default CompletableFuture<Void> deleteAll(Iterable<Message> messages) {
-        return deleteAll(StreamSupport.stream(messages.spliterator(), false).mapToLong(Message::getId).toArray());
+    default CompletableFuture<Void> deleteMessages(Iterable<Message> messages) {
+        return deleteMessages(StreamSupport.stream(messages.spliterator(), false).mapToLong(Message::getId).toArray());
     }
 
     /**
@@ -274,8 +274,8 @@ public interface TextChannel extends Channel, Messageable, TextChannelAttachable
      * @param messageIds The ids of the messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    default CompletableFuture<Void> deleteAll(long... messageIds) {
-        return Message.deleteAll(getApi(), getId(), messageIds);
+    default CompletableFuture<Void> deleteMessages(long... messageIds) {
+        return Message.delete(getApi(), getId(), messageIds);
     }
 
     /**
@@ -287,7 +287,7 @@ public interface TextChannel extends Channel, Messageable, TextChannelAttachable
      * @param messageIds The ids of the messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    default CompletableFuture<Void> deleteAll(String... messageIds) {
+    default CompletableFuture<Void> deleteMessages(String... messageIds) {
         long[] messageLongIds = Arrays.stream(messageIds).filter(s -> {
             try {
                 //noinspection ResultOfMethodCallIgnored
@@ -297,7 +297,7 @@ public interface TextChannel extends Channel, Messageable, TextChannelAttachable
                 return false;
             }
         }).mapToLong(Long::parseLong).toArray();
-        return deleteAll(messageLongIds);
+        return deleteMessages(messageLongIds);
     }
 
     /**
@@ -309,8 +309,8 @@ public interface TextChannel extends Channel, Messageable, TextChannelAttachable
      * @param messages The messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    default CompletableFuture<Void> deleteAll(Message... messages) {
-        return deleteAll(Arrays.stream(messages).mapToLong(Message::getId).toArray());
+    default CompletableFuture<Void> deleteMessages(Message... messages) {
+        return deleteMessages(Arrays.stream(messages).mapToLong(Message::getId).toArray());
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -131,8 +131,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param messageIds The ids of the messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    static CompletableFuture<Void> deleteAll(DiscordApi api, long channelId, long... messageIds) {
-        return api.getUncachedMessageUtil().deleteAll(channelId, messageIds);
+    static CompletableFuture<Void> delete(DiscordApi api, long channelId, long... messageIds) {
+        return api.getUncachedMessageUtil().delete(channelId, messageIds);
     }
 
     /**
@@ -146,8 +146,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param messageIds The ids of the messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    static CompletableFuture<Void> deleteAll(DiscordApi api, String channelId, String... messageIds) {
-        return api.getUncachedMessageUtil().deleteAll(channelId, messageIds);
+    static CompletableFuture<Void> delete(DiscordApi api, String channelId, String... messageIds) {
+        return api.getUncachedMessageUtil().delete(channelId, messageIds);
     }
 
     /**
@@ -160,8 +160,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param messages The messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    static CompletableFuture<Void> deleteAll(DiscordApi api, Message... messages) {
-        return api.getUncachedMessageUtil().deleteAll(messages);
+    static CompletableFuture<Void> delete(DiscordApi api, Message... messages) {
+        return api.getUncachedMessageUtil().delete(messages);
     }
 
     /**
@@ -174,8 +174,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param messages The messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    static CompletableFuture<Void> deleteAll(DiscordApi api, Iterable<Message> messages) {
-        return api.getUncachedMessageUtil().deleteAll(messages);
+    static CompletableFuture<Void> delete(DiscordApi api, Iterable<Message> messages) {
+        return api.getUncachedMessageUtil().delete(messages);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageSet.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageSet.java
@@ -43,7 +43,7 @@ public interface MessageSet extends NavigableSet<Message> {
         return CompletableFuture.allOf(
                 stream().collect(Collectors.groupingBy(DiscordEntity::getApi, Collectors.toList()))
                         .entrySet().stream()
-                        .map(entry -> Message.deleteAll(entry.getKey(), entry.getValue()))
+                        .map(entry -> Message.delete(entry.getKey(), entry.getValue()))
                         .toArray(CompletableFuture[]::new));
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
@@ -61,7 +61,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      * @param messageIds The ids of the messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    CompletableFuture<Void> deleteAll(long channelId, long... messageIds);
+    CompletableFuture<Void> delete(long channelId, long... messageIds);
 
     /**
      * Deletes multiple messages at once.
@@ -73,7 +73,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      * @param messageIds The ids of the messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    CompletableFuture<Void> deleteAll(String channelId, String... messageIds);
+    CompletableFuture<Void> delete(String channelId, String... messageIds);
 
     /**
      * Deletes multiple messages at once.
@@ -84,7 +84,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      * @param messages The messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    CompletableFuture<Void> deleteAll(Message... messages);
+    CompletableFuture<Void> delete(Message... messages);
 
     /**
      * Deletes multiple messages at once.
@@ -95,7 +95,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      * @param messages The messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    CompletableFuture<Void> deleteAll(Iterable<Message> messages);
+    CompletableFuture<Void> delete(Iterable<Message> messages);
 
     /**
      * Updates the content of the message.

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
@@ -78,7 +78,7 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
     }
 
     @Override
-    public CompletableFuture<Void> deleteAll(long channelId, long... messageIds) {
+    public CompletableFuture<Void> delete(long channelId, long... messageIds) {
         // split by younger than two weeks / older than two weeks
         Instant twoWeeksAgo = Instant.now().minus(14, ChronoUnit.DAYS);
         Map<Boolean, List<Long>> messageIdsByAge = Arrays.stream(messageIds).distinct().boxed()
@@ -116,7 +116,7 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
     }
 
     @Override
-    public CompletableFuture<Void> deleteAll(String channelId, String... messageIds) {
+    public CompletableFuture<Void> delete(String channelId, String... messageIds) {
         long[] messageLongIds = Arrays.stream(messageIds).filter(s -> {
             try {
                 //noinspection ResultOfMethodCallIgnored
@@ -126,24 +126,24 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
                 return false;
             }
         }).mapToLong(Long::parseLong).toArray();
-        return deleteAll(Long.parseLong(channelId), messageLongIds);
+        return delete(Long.parseLong(channelId), messageLongIds);
     }
 
     @Override
-    public CompletableFuture<Void> deleteAll(Message... messages) {
+    public CompletableFuture<Void> delete(Message... messages) {
         return CompletableFuture.allOf(
                 Arrays.stream(messages)
                         .collect(Collectors.groupingBy(message -> message.getChannel().getId(),
                                 Collectors.mapping(Message::getId, Collectors.toList())))
                         .entrySet().stream()
-                        .map(entry -> deleteAll(entry.getKey(),
+                        .map(entry -> delete(entry.getKey(),
                                 entry.getValue().stream().mapToLong(Long::longValue).toArray()))
                         .toArray(CompletableFuture[]::new));
     }
 
     @Override
-    public CompletableFuture<Void> deleteAll(Iterable<Message> messages) {
-        return deleteAll(StreamSupport.stream(messages.spliterator(), false).toArray(Message[]::new));
+    public CompletableFuture<Void> delete(Iterable<Message> messages) {
+        return delete(StreamSupport.stream(messages.spliterator(), false).toArray(Message[]::new));
     }
 
     @Override


### PR DESCRIPTION
Basically the same we did for `addAllRolesToUser` and `removeAllRolesFromUser`.
If you give a list it is not really "all", but delete what I give you.
`MessageSet#deleteAll` of course stays unchanged.
For the `TextChannel` I made it clear what is deleted by naming it `deleteMessages`, for the others it is clear from the classname that we handle messages, so I just used `delete`.