### PR TITLE
Release Process Improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ import org.ajoberstar.grgit.Grgit
 
 plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.4' apply false
-    id 'me.tatarka.gradle.pom' version '1.0' apply false
     id 'net.researchgate.release' version '2.7.0' apply false
     id 'org.ajoberstar.grgit' version '2.3.0' apply false
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -148,6 +148,7 @@ release {
     tagTemplate = 'v$version'
     buildTasks = ['buildAll']
     git {
+        requireBranch = 'development'
         signTag = true
     }
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,9 +1,13 @@
 import io.codearte.gradle.nexus.BaseStagingTask
 import io.codearte.gradle.nexus.NexusStagingPlugin
+import org.ajoberstar.grgit.Grgit
 import wooga.gradle.github.publish.GithubPublishPlugin
 import wooga.gradle.github.publish.tasks.GithubPublish
 
 import javax.naming.ConfigurationException
+
+import static java.text.MessageFormat.format
+import static net.researchgate.release.ReleasePlugin.RELEASE_GROUP
 
 buildscript {
     repositories {
@@ -12,6 +16,8 @@ buildscript {
     dependencies {
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0'
         classpath 'gradle.plugin.net.wooga.gradle:atlas-github:1.0.1'
+        classpath 'net.researchgate:gradle-release:2.7.0'
+        classpath 'org.ajoberstar:grgit:2.3.0'
     }
 }
 
@@ -152,6 +158,27 @@ release {
         signTag = true
     }
 }
+
+task checkMergeNeeded() {
+    group RELEASE_GROUP
+    description 'Checks to see if there are any unmerged commits on branch "master".'
+    doLast {
+        def grgit = Grgit.open(dir: "$rootDir/.git")
+        try {
+            grgit.fetch remote: 'origin'
+            def unmergedCommits = grgit.log(includes: ['origin/master'], excludes: ['HEAD']).size()
+            if (unmergedCommits) {
+                throw new IllegalStateException(format('There {0,choice,' +
+                        '1#is one unmerged commit|' +
+                        '1<are {0,number,integer} unmerged commits} on "master".',
+                        unmergedCommits))
+            }
+        } finally {
+            grgit?.close()
+        }
+    }
+}
+beforeReleaseBuild.dependsOn checkMergeNeeded
 
 afterReleaseBuild.dependsOn allprojects.tasks*.withType(PublishToMavenRepository), closeRepository
 

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,6 +1,7 @@
 import io.codearte.gradle.nexus.BaseStagingTask
 import io.codearte.gradle.nexus.NexusStagingPlugin
 import org.ajoberstar.grgit.Grgit
+import org.kohsuke.github.GitHub
 import wooga.gradle.github.publish.GithubPublishPlugin
 import wooga.gradle.github.publish.tasks.GithubPublish
 
@@ -18,6 +19,7 @@ buildscript {
         classpath 'gradle.plugin.net.wooga.gradle:atlas-github:1.0.1'
         classpath 'net.researchgate:gradle-release:2.7.0'
         classpath 'org.ajoberstar:grgit:2.3.0'
+        classpath 'org.kohsuke:github-api:1.93'
     }
 }
 
@@ -184,10 +186,25 @@ afterReleaseBuild.dependsOn allprojects.tasks*.withType(PublishToMavenRepository
 
 apply plugin: GithubPublishPlugin
 
+def githubRepositoryName
+def gitDir = file("$rootDir/.git")
+if (gitDir.directory) {
+    def grgit
+    try {
+        grgit = Grgit.open(dir: "$rootDir/.git")
+        def originUrl = grgit.remote.list().find { it.name == 'origin' }.url
+        githubRepositoryName = (originUrl =~ /git@github\.com:(.*?)\.git/)[0][1]
+    } catch (Exception ignored) {
+    } finally {
+        grgit?.close()
+    }
+}
+githubRepositoryName = githubRepositoryName ?: 'Javacord/Javacord'
+
+def tagNameSupplier = { rootProject.plugins.findPlugin('net.researchgate.release').tagName() }
 githubPublish {
     enabled releaseVersion
-    repositoryName 'Javacord/Javacord'
-    def tagNameSupplier = { rootProject.plugins.findPlugin('net.researchgate.release').tagName() }
+    repositoryName githubRepositoryName
     tagName tagNameSupplier
     releaseName tagNameSupplier
     body rootProject.file('.github/release_body_template.md').text
@@ -198,3 +215,23 @@ githubPublish {
 afterReleaseBuild.dependsOn tasks.withType(GithubPublish)
 
 preTagCommit.dependsOn updateReadme
+
+task createPullRequestForReleaseTag() {
+    group RELEASE_GROUP
+    description 'Creates a PR from the release tag to the branch "master".'
+    doLast {
+        def tagName = tagNameSupplier.call()
+        def grgit = Grgit.open(dir: "$rootDir/.git")
+        try {
+            def tagSha = grgit.tag.list().find { it.name == tagName }.commit.id
+            def repository = GitHub.connectUsingOAuth(project.'github.token').getRepository(githubRepositoryName)
+            def branchName = tagName - ~/^v/
+            repository.createRef "refs/heads/$branchName", tagSha
+            repository.createPullRequest "Merge release $tagName into branch master", branchName, 'master', null
+        } finally {
+            grgit?.close()
+        }
+    }
+}
+
+createReleaseTag.finalizedBy createPullRequestForReleaseTag


### PR DESCRIPTION
- Release from branch 'development' instead of 'master'
- Check that there are no unmerged commits on branch 'master' before creating the release
- Remove unused Gradle plugin
- Create a PR to merge the release tag to branch master on release

With this you have two more post-release tasks,
- accpeting the PR
- deleting the PR branch (you can only open a PR from a branch and if you delete the branch, the PR gets closed automatically)