### PR TITLE
Buffered Image With Filename

### DIFF
--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -6,6 +6,8 @@ subprojects {
         testImplementation 'org.spockframework:spock-core:1.1-groovy-2.4'
 
         testRuntimeOnly 'org.apache.logging.log4j:log4j-core:2.11.0'
+        testRuntimeOnly 'net.bytebuddy:byte-buddy:1.8.17'
+        testRuntimeOnly 'org.objenesis:objenesis'
     }
 
     // we don't need aggregation from multiple runs and it prevents caching of the task

--- a/javacord-core/src/main/java/org/javacord/core/util/FileContainer.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/FileContainer.java
@@ -79,7 +79,7 @@ public class FileContainer {
         fileAsUrl = null;
         fileAsByteArray = null;
         fileAsInputStream = null;
-        fileTypeOrName = type;
+        setFileTypeOrName(type);
     }
 
     /**
@@ -166,6 +166,9 @@ public class FileContainer {
      */
     public void setFileTypeOrName(String type) {
         fileTypeOrName = type;
+        if ((fileAsBufferedImage != null) && !ImageIO.getImageWritersByFormatName(getFileType()).hasNext()) {
+            throw new IllegalArgumentException(String.format("No image writer found for format \"%s\"", getFileType()));
+        }
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/util/FileContainer.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/FileContainer.java
@@ -249,7 +249,7 @@ public class FileContainer {
         try {
             if (fileAsBufferedImage != null) {
                 ByteArrayOutputStream os = new ByteArrayOutputStream();
-                ImageIO.write(fileAsBufferedImage, fileTypeOrName, os);
+                ImageIO.write(fileAsBufferedImage, getFileType(), os);
                 future.complete(new ByteArrayInputStream(os.toByteArray()));
                 return future;
             }

--- a/javacord-core/src/test/groovy/org/javacord/core/util/FileContainerTest.groovy
+++ b/javacord-core/src/test/groovy/org/javacord/core/util/FileContainerTest.groovy
@@ -1,0 +1,20 @@
+package org.javacord.core.util
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.awt.image.BufferedImage
+
+@Subject(FileContainer)
+class FileContainerTest extends Specification {
+
+    def 'converting FileContainer with BufferedImage to byte array returns some bytes'() {
+        given:
+            def image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB)
+            def fileContainer = new FileContainer(image, 'file.png')
+
+        expect:
+            fileContainer.asByteArray(null).join()
+    }
+
+}

--- a/javacord-core/src/test/groovy/org/javacord/core/util/FileContainerTest.groovy
+++ b/javacord-core/src/test/groovy/org/javacord/core/util/FileContainerTest.groovy
@@ -17,4 +17,25 @@ class FileContainerTest extends Specification {
             fileContainer.asByteArray(null).join()
     }
 
+    def 'creating FileContainer with BufferedImage and unsupported file format throws exception'() {
+        when:
+            new FileContainer(Stub(BufferedImage), 'file.txt')
+
+        then:
+            IllegalArgumentException iae = thrown()
+            iae.message == 'No image writer found for format "txt"'
+    }
+
+    def 'configuring FileContainer with BufferedImage with unsupported file format throws exception'() {
+        given:
+            def fileContainer = new FileContainer(Stub(BufferedImage), 'file.png')
+
+        when:
+            fileContainer.setFileTypeOrName 'file.txt'
+
+        then:
+            IllegalArgumentException iae = thrown()
+            iae.message == 'No image writer found for format "txt"'
+    }
+
 }


### PR DESCRIPTION
- Use file type, not file name to encode a buffered image
- Throw exception when an unsupported filetype is used for a file container with a buffered image