### PR TITLE
Add slowmode support.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannel.java
@@ -102,6 +102,48 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
         return createUpdater().removeCategory().update();
     }
 
+    /**
+     * Gets the delay for slowmode.
+     *
+     * @return The delay in seconds.
+     */
+    int getSlowmodeDelayInSeconds();
+
+    /**
+     * Check whether slowmode is activated for this channel.
+     *
+     * @return Whether this channel enforces a slowmode.
+     */
+    default boolean hasSlowmode() {
+        return getSlowmodeDelayInSeconds() == 0;
+    }
+
+    /**
+     * Set a slowmode for this channel.
+     *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerTextChannelUpdater} from {@link #createUpdater()} which provides a better performance!
+     *
+     * @param delay The slowmode delay in seconds.
+     *
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Void> updateSlowmodeDelayInSeconds(int delay) {
+        return createUpdater().setSlowmodeDelayInSeconds(delay).update();
+    }
+
+    /**
+     * Deactivate slowmode for this channel.
+     *
+     * <p>If you want to update several settings at once, it's recommended to use the
+     * {@link ServerTextChannelUpdater} from {@link #createUpdater()} which provides a better performance!
+     *
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Void> unsetSlowmode() {
+        return createUpdater().unsetSlowmode().update();
+    }
+
     @Override
     default Optional<ServerTextChannel> getCurrentCachedInstance() {
         return getApi().getServerById(getServer().getId()).flatMap(server -> server.getTextChannelById(getId()));

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelBuilder.java
@@ -62,6 +62,17 @@ public class ServerTextChannelBuilder extends ServerChannelBuilder {
         return this;
     }
 
+    /**
+     * Sets the slowmode of the channel.
+     *
+     * @param delay The delay in seconds.
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerTextChannelBuilder setSlowmodeDelayInSeconds(int delay) {
+        delegate.setSlowmodeDelayInSeconds(delay);
+        return this;
+    }
+
     @Override
     public <T extends Permissionable & DiscordEntity> ServerTextChannelBuilder addPermissionOverwrite(
             T permissionable, Permissions permissions) {

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannelUpdater.java
@@ -70,6 +70,26 @@ public class ServerTextChannelUpdater extends ServerChannelUpdater {
         return this;
     }
 
+    /**
+     * Set the delay for slowmode.
+     *
+     * @param delay The delay in seconds.
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerTextChannelUpdater setSlowmodeDelayInSeconds(int delay) {
+        delegate.setSlowmodeDelayinSeconds(delay);
+        return this;
+    }
+
+    /**
+     * Unset the slowmode.
+     *
+     * @return The current instance in order to chain call methods.
+     */
+    public ServerTextChannelUpdater unsetSlowmode() {
+        return this.setSlowmodeDelayInSeconds(0);
+    }
+
     @Override
     public ServerTextChannelUpdater setAuditLogReason(String reason) {
         delegate.setAuditLogReason(reason);

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerTextChannelBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerTextChannelBuilderDelegate.java
@@ -27,10 +27,16 @@ public interface ServerTextChannelBuilderDelegate extends ServerChannelBuilderDe
     void setCategory(ChannelCategory category);
 
     /**
+     * Sets the slowmode delay of the channel.
+     *
+     * @param delay The delay in seconds.
+     */
+    void setSlowmodeDelayInSeconds(int delay);
+
+    /**
      * Creates the server text channel.
      *
      * @return The created text channel.
      */
     CompletableFuture<ServerTextChannel> create();
-
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerTextChannelUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ServerTextChannelUpdaterDelegate.java
@@ -35,4 +35,11 @@ public interface ServerTextChannelUpdaterDelegate extends ServerChannelUpdaterDe
      */
     void removeCategory();
 
+    /**
+     * Sets the slowmode delay.
+     *
+     * @param delay The delay in seconds.
+     */
+    void setSlowmodeDelayinSeconds(int delay);
+
 }

--- a/javacord-api/src/main/java/org/javacord/api/event/channel/server/text/ServerTextChannelChangeSlowmodeEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/channel/server/text/ServerTextChannelChangeSlowmodeEvent.java
@@ -1,0 +1,26 @@
+package org.javacord.api.event.channel.server.text;
+
+/**
+ * An event signalling a change in the slowmode settings for a channel.
+ */
+public interface ServerTextChannelChangeSlowmodeEvent extends ServerTextChannelEvent {
+
+    /**
+     * Gets the old delay of the channel.
+     *
+     * <p>A delay of 0 means that the channel has not been in slowmode before.
+     *
+     * @return The delay in seconds.
+     */
+    int getOldDelayInSeconds();
+
+    /**
+     * Gets the new delay of the channel.
+     *
+     * <p>A delay of 0 means that the channel is no longer in slowmode.
+     *
+     * @return The delay in seconds.
+     */
+    int getNewDelayInSeconds();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/channel/server/text/ServerTextChannelChangeSlowmodeListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/channel/server/text/ServerTextChannelChangeSlowmodeListener.java
@@ -1,0 +1,22 @@
+package org.javacord.api.listener.channel.server.text;
+
+import org.javacord.api.event.channel.server.text.ServerTextChannelChangeSlowmodeEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.server.ServerAttachableListener;
+
+/**
+ * This listener listens to server text channel slowmode delay changes.
+ */
+@FunctionalInterface
+public interface ServerTextChannelChangeSlowmodeListener extends ServerAttachableListener,
+        ServerTextChannelAttachableListener, GloballyAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called every time a server text channel's slowmode delay changes.
+     *
+     * @param event The event.
+     */
+    void onServerTextChannelChangeSlowmodeDelay(ServerTextChannelChangeSlowmodeEvent event);
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelBuilderDelegateImpl.java
@@ -29,6 +29,16 @@ public class ServerTextChannelBuilderDelegateImpl extends ServerChannelBuilderDe
     private ChannelCategory category = null;
 
     /**
+     * The slowmode delay of the channel.
+     */
+    private int delay;
+
+    /**
+     * Whether the delay has been modified from the original value.
+     */
+    private boolean delayModified;
+
+    /**
      * Creates a new server text channel builder delegate.
      *
      * @param server The server of the server text channel.
@@ -48,6 +58,12 @@ public class ServerTextChannelBuilderDelegateImpl extends ServerChannelBuilderDe
     }
 
     @Override
+    public void setSlowmodeDelayInSeconds(int delay) {
+        this.delay = delay;
+        delayModified = true;
+    }
+
+    @Override
     public CompletableFuture<ServerTextChannel> create() {
         ObjectNode body = JsonNodeFactory.instance.objectNode();
         body.put("type", 0);
@@ -57,6 +73,9 @@ public class ServerTextChannelBuilderDelegateImpl extends ServerChannelBuilderDe
         }
         if (category != null) {
             body.put("parent_id", category.getIdAsString());
+        }
+        if (delayModified) {
+            body.put("rate_limit_per_user", delay);
         }
         return new RestRequest<ServerTextChannel>(server.getApi(), RestMethod.POST, RestEndpoint.SERVER_CHANNEL)
                 .setUrlParameters(server.getIdAsString())

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelImpl.java
@@ -42,6 +42,11 @@ public class ServerTextChannelImpl extends ServerChannelImpl
     private volatile String topic;
 
     /**
+     * The slowmode delay of the channel.
+     */
+    private volatile int delay;
+
+    /**
      * Creates a new server text channel object.
      *
      * @param api The discord api instance.
@@ -53,6 +58,7 @@ public class ServerTextChannelImpl extends ServerChannelImpl
         nsfw = data.has("nsfw") && data.get("nsfw").asBoolean();
         parentId = Long.valueOf(data.has("parent_id") ? data.get("parent_id").asText("-1") : "-1");
         topic = data.has("topic") && !data.get("topic").isNull() ? data.get("topic").asText() : "";
+        delay = data.has("rate_limit_per_user") ? data.get("rate_limit_per_user").asInt(0) : 0;
         messageCache = new MessageCacheImpl(
                 api, api.getDefaultMessageCacheCapacity(), api.getDefaultMessageCacheStorageTimeInSeconds(),
                 api.isDefaultAutomaticMessageCacheCleanupEnabled());
@@ -83,6 +89,20 @@ public class ServerTextChannelImpl extends ServerChannelImpl
      */
     public void setParentId(long parentId) {
         this.parentId = parentId;
+    }
+
+    /**
+     * Sets the slowmode delay of the channel.
+     *
+     * @param delay The delay in seconds.
+     */
+    public void setSlowmodeDelayInSeconds(int delay) {
+        this.delay = delay;
+    }
+
+    @Override
+    public int getSlowmodeDelayInSeconds() {
+        return delay;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelUpdaterDelegateImpl.java
@@ -32,6 +32,16 @@ public class ServerTextChannelUpdaterDelegateImpl extends ServerChannelUpdaterDe
     protected boolean modifyCategory = false;
 
     /**
+     * The slowmode delay.
+     */
+    protected int delay = 0;
+
+    /**
+     * Whether the slowmode delay should be modified or not.
+     */
+    protected boolean modifyDelay = false;
+
+    /**
      * Creates a new server text channel updater delegate.
      *
      * @param channel The channel to update.
@@ -62,6 +72,12 @@ public class ServerTextChannelUpdaterDelegateImpl extends ServerChannelUpdaterDe
     }
 
     @Override
+    public void setSlowmodeDelayinSeconds(int delay) {
+        this.delay = delay;
+        this.modifyDelay = true;
+    }
+
+    @Override
     protected boolean prepareUpdateBody(ObjectNode body) {
         boolean patchChannel = super.prepareUpdateBody(body);
         if (topic != null) {
@@ -74,6 +90,10 @@ public class ServerTextChannelUpdaterDelegateImpl extends ServerChannelUpdaterDe
         }
         if (modifyCategory) {
             body.put("parent_id", category == null ? null : category.getIdAsString());
+            patchChannel = true;
+        }
+        if (modifyDelay) {
+            body.put("rate_limit_per_user", delay);
             patchChannel = true;
         }
         return patchChannel;

--- a/javacord-core/src/main/java/org/javacord/core/event/channel/server/text/ServerTextChannelChangeSlowmodeEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/channel/server/text/ServerTextChannelChangeSlowmodeEventImpl.java
@@ -1,0 +1,43 @@
+package org.javacord.core.event.channel.server.text;
+
+import org.javacord.api.entity.channel.ServerTextChannel;
+import org.javacord.api.event.channel.server.text.ServerTextChannelChangeSlowmodeEvent;
+
+/**
+ * The implementation for the ServerTextChannelChangeSlowmodeEvent.
+ */
+public class ServerTextChannelChangeSlowmodeEventImpl extends ServerTextChannelEventImpl
+        implements ServerTextChannelChangeSlowmodeEvent {
+
+    /**
+     * The old delay of the channel.
+     */
+    private final int oldDelay;
+    /**
+     * The new delay of the channel.
+     */
+    private final int newDelay;
+
+    /**
+     * Creates a new server text channel change slowmode event.
+     *
+     * @param channel The channel of the event.
+     * @param oldDelay The old delay of the channel.
+     * @param newDelay The new delay of the channel.
+     */
+    public ServerTextChannelChangeSlowmodeEventImpl(ServerTextChannel channel, int oldDelay, int newDelay) {
+        super(channel);
+        this.oldDelay = oldDelay;
+        this.newDelay = newDelay;
+    }
+
+    @Override
+    public int getOldDelayInSeconds() {
+        return oldDelay;
+    }
+
+    @Override
+    public int getNewDelayInSeconds() {
+        return newDelay;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelUpdateHandler.java
@@ -14,6 +14,7 @@ import org.javacord.api.event.channel.server.ServerChannelChangeNameEvent;
 import org.javacord.api.event.channel.server.ServerChannelChangeNsfwFlagEvent;
 import org.javacord.api.event.channel.server.ServerChannelChangeOverwrittenPermissionsEvent;
 import org.javacord.api.event.channel.server.ServerChannelChangePositionEvent;
+import org.javacord.api.event.channel.server.text.ServerTextChannelChangeSlowmodeEvent;
 import org.javacord.api.event.channel.server.text.ServerTextChannelChangeTopicEvent;
 import org.javacord.api.event.channel.server.voice.ServerVoiceChannelChangeBitrateEvent;
 import org.javacord.api.event.channel.server.voice.ServerVoiceChannelChangeUserLimitEvent;
@@ -28,6 +29,7 @@ import org.javacord.core.event.channel.server.ServerChannelChangeNameEventImpl;
 import org.javacord.core.event.channel.server.ServerChannelChangeNsfwFlagEventImpl;
 import org.javacord.core.event.channel.server.ServerChannelChangeOverwrittenPermissionsEventImpl;
 import org.javacord.core.event.channel.server.ServerChannelChangePositionEventImpl;
+import org.javacord.core.event.channel.server.text.ServerTextChannelChangeSlowmodeEventImpl;
 import org.javacord.core.event.channel.server.text.ServerTextChannelChangeTopicEventImpl;
 import org.javacord.core.event.channel.server.voice.ServerVoiceChannelChangeBitrateEventImpl;
 import org.javacord.core.event.channel.server.voice.ServerVoiceChannelChangeUserLimitEventImpl;
@@ -250,6 +252,18 @@ public class ChannelUpdateHandler extends PacketHandler {
 
                 api.getEventDispatcher().dispatchServerChannelChangeNsfwFlagEvent(
                         (DispatchQueueSelector) channel.getServer(), null, channel.getServer(), channel, event);
+            }
+
+            int oldSlowmodeDelay = channel.getSlowmodeDelayInSeconds();
+            int newSlowmodeDelay = jsonChannel.get("rate_limit_per_user").asInt(0);
+            if (oldSlowmodeDelay != newSlowmodeDelay) {
+                channel.setSlowmodeDelayInSeconds(newSlowmodeDelay);
+                ServerTextChannelChangeSlowmodeEvent event =
+                        new ServerTextChannelChangeSlowmodeEventImpl(channel, oldSlowmodeDelay, newSlowmodeDelay);
+
+                api.getEventDispatcher().dispatchServerTextChannelChangeSlowmodeEvent(
+                        (DispatchQueueSelector) channel.getServer(), channel.getServer(), channel, event
+                );
             }
         });
     }


### PR DESCRIPTION
As of the latest update, discord officially supports slow mode, aka a per-user per-channel ratelimit.

This PR provides the ability to view and edit the slow mode settings

- [x] `ServerTextChannelUpdater`
- [x] `ServerTextChannel`
- [x] `ServerTextChannelBuilder`
- [x] Event and Listener
- [x] `ChannelUpdateHandler`

~~I have not yet tested this functionality and will do as soon as I have the time. In the meanwhile I'm putting this up for preview (and also maybe someone else decides to test it before I get to it and saves me the trouble)~~