### PR TITLE
Do not send requests after DiscordApi#disconnect was called or the OkHttp threads hang again with Java 9+

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -420,6 +420,9 @@ public class DiscordApiImpl implements DiscordApi, InternalGloballyAttachableLis
      * @return The used http client.
      */
     public OkHttpClient getHttpClient() {
+        if (disconnectCalled) {
+            throw new IllegalStateException("disconnect was called already");
+        }
         return httpClient;
     }
 
@@ -1078,10 +1081,10 @@ public class DiscordApiImpl implements DiscordApi, InternalGloballyAttachableLis
                     // shutdown thread pool if within one minute no disconnect event was dispatched
                     threadPool.getDaemonScheduler().schedule(threadPool::shutdown, 1, TimeUnit.MINUTES);
                 }
+                disconnectCalled = true;
                 httpClient.dispatcher().executorService().shutdown();
                 httpClient.connectionPool().evictAll();
             }
-            disconnectCalled = true;
         }
     }
 


### PR DESCRIPTION
This happens for example when you have an evaluate command where you directly after the evaluate send a message with the result and then issue the `disconnect` via your evaluate command, as that request undoes the workaround for clean shutdown. With a delay of 100ms between the evaluate and the response sending the shutdown is fast enough so that it doesn't happen.

The same happens or can happen I think, if you have requests in the rate-limiting queue.