### PR TITLE
Fix User#getMutualServers() performance bottleneck

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -483,6 +483,14 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     }
 
     /**
+     * Checks if the given user is a member of this server.
+     *
+     * @param user The user to check.
+     * @return If the user is a member of this server.
+     */
+    boolean isMember(User user);
+
+    /**
      * Gets a sorted list (by position) with all roles of the server.
      *
      * @return A sorted list (by position) with all roles of the server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -136,9 +136,8 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
      * @return All mutual servers with this user.
      */
     default Collection<Server> getMutualServers() {
-        // TODO This is probably not the most efficient way to do it
         return getApi().getServers().stream()
-                .filter(server -> server.getMembers().contains(this))
+                .filter(server -> server.isMember(this))
                 .collect(Collectors.toList());
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -949,6 +949,11 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     }
 
     @Override
+    public boolean isMember(User user) {
+        return members.containsKey(user.getId());
+    }
+
+    @Override
     public List<Role> getRoles() {
         return Collections.unmodifiableList(roles.values().stream()
                 .sorted(Comparator.comparingInt(Role::getPosition))


### PR DESCRIPTION
This PR fixes a performance issue with the `getMutualServers()` method. The method has a huge performance impact, as it is called for every presence update to dispatch to server-attached listeners.

The issue was caused by calling `Server#getMembers()` which creates an immutable copy of the internal collection. This is an absolute overkill if you just want to check if a user is part of the server.