### PR TITLE
Allow event listener registration during api creation

### DIFF
--- a/gradle/listener-manager-generation.gradle
+++ b/gradle/listener-manager-generation.gradle
@@ -13,6 +13,8 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 
 import javax.annotation.Generated
 import javax.naming.ConfigurationException
+import java.util.function.Function
+import java.util.function.Supplier
 import java.util.stream.Collectors
 import java.util.stream.Stream
 
@@ -114,6 +116,8 @@ task generateListenerManagers {
 
         def discordApiName =
                 typeSolver.solveType('org.javacord.api.DiscordApi').qualifiedName
+        def discordApiBuilderName =
+                typeSolver.solveType('org.javacord.api.DiscordApiBuilder').qualifiedName
         def discordApiImplName =
                 typeSolver.solveType('org.javacord.core.DiscordApiImpl').qualifiedName
         def listenerManagerName =
@@ -144,7 +148,24 @@ task generateListenerManagers {
             def corePackageName = attachableInterface.packageName.replaceFirst(/\.api(?=.|$)/, '.core')
             def internalAttachableListenerManagerFile
             def internalAttachableListenerManagerInterface
-            if (!attachableInterface.equals(globallyAttachableListener)) {
+            def chainableGloballyAttachableListenerManagerFile
+            def chainableGloballyAttachableListenerManagerInterface
+            if (attachableInterface.equals(globallyAttachableListener)) {
+                chainableGloballyAttachableListenerManagerFile = new CompilationUnit(attachableInterface.packageName)
+                        .setStorage(file("$apiOutputDirectory/" +
+                        "${attachableInterface.packageName.replace '.', '/'}/" +
+                        'ChainableGloballyAttachableListenerManager.java').toPath())
+                        .addImport(Function)
+                        .addImport(Supplier)
+                        .addImport(discordApiName)
+                        .addImport(discordApiBuilderName)
+                chainableGloballyAttachableListenerManagerInterface = chainableGloballyAttachableListenerManagerFile
+                        .addInterface('ChainableGloballyAttachableListenerManager')
+                        .addSingleMemberAnnotation(Generated, '"listener-manager-generation.gradle"')
+                        .setJavadocComment(
+                        'This class can be used to add and retrieve {@link GloballyAttachableListener}s ' +
+                                'on the {@link DiscordApiBuilder}.')
+            } else {
                 internalAttachableListenerManagerFile =
                         new CompilationUnit(corePackageName)
                                 .setStorage(file("$coreOutputDirectory/" +
@@ -239,6 +260,8 @@ task generateListenerManagers {
             listeners.each {
                 addConcreteListenerMethods typeSolver, attachableInterface, it, objectClassByAttachableListenerManager,
                         attachableListenerManagerFile, attachableListenerManagerInterface,
+                        chainableGloballyAttachableListenerManagerFile,
+                        chainableGloballyAttachableListenerManagerInterface,
                         uncachedMessageAttachableListenerManagerFile, uncachedMessageAttachableListenerManagerInterface,
                         internalUncachedMessageAttachableListenerManagerFile,
                         internalUncachedMessageAttachableListenerManagerInterface,
@@ -246,7 +269,8 @@ task generateListenerManagers {
             }
 
             if (attachableInterface.equals(globallyAttachableListener)) {
-                addGenericGloballyAttachableListenerMethods(attachableListenerManagerInterface)
+                addGenericGloballyAttachableListenerMethods attachableListenerManagerInterface,
+                        chainableGloballyAttachableListenerManagerInterface
             } else {
                 if (uncachedMessageAttachableListenerManagerInterface) {
                     uncachedMessageAttachableListenerManagerFile.addImport objectAttachableListener.qualifiedName
@@ -278,6 +302,7 @@ task generateListenerManagers {
 
             [
                     attachableListenerManagerFile,
+                    chainableGloballyAttachableListenerManagerFile,
                     internalAttachableListenerManagerFile,
                     uncachedMessageAttachableListenerManagerFile,
                     internalUncachedMessageAttachableListenerManagerFile
@@ -321,6 +346,8 @@ configure([javacordApi, javacordCore]) {
 
 def addConcreteListenerMethods(typeSolver, attachableInterface, listener, objectClassByAttachableListenerManager,
                                attachableListenerManagerFile, attachableListenerManagerInterface,
+                               chainableGloballyAttachableListenerManagerFile,
+                               chainableGloballyAttachableListenerManagerInterface,
                                uncachedMessageAttachableListenerManagerFile,
                                uncachedMessageAttachableListenerManagerInterface,
                                internalUncachedMessageAttachableListenerManagerFile,
@@ -331,6 +358,7 @@ def addConcreteListenerMethods(typeSolver, attachableInterface, listener, object
 
     if (listener.packageName != attachableInterface.packageName) {
         attachableListenerManagerFile.addImport listener.qualifiedName
+        chainableGloballyAttachableListenerManagerFile?.addImport listener.qualifiedName
         if (specialMessageAttachable) {
             uncachedMessageAttachableListenerManagerFile.addImport listener.qualifiedName
         }
@@ -377,6 +405,51 @@ def addConcreteListenerMethods(typeSolver, attachableInterface, listener, object
         addListenerMethod
                 .createBody()
                 .addStatement("return addListener(${listener.name}.class, listener);")
+
+        chainableGloballyAttachableListenerManagerInterface
+                .addMethod("add$listener.name", Modifier.DEFAULT)
+                .setJavadocComment("""
+                    Adds a {@code $listener.name} to all created {@code DiscordApi} instances.
+
+                    @param listener The listener to add.
+                    @return The current instance in order to chain call methods.
+                """.stripIndent())
+                .setType("DiscordApiBuilder")
+                .addParameter(listener.name, 'listener')
+                .createBody()
+                .addStatement("return addListener(${listener.name}.class, listener);")
+
+        chainableGloballyAttachableListenerManagerInterface
+                .addMethod("add$listener.name", Modifier.DEFAULT)
+                .setJavadocComment("""
+                    Adds a {@code $listener.name} to all created {@code DiscordApi} instances. The supplier is called
+                    for every created {@code DiscordApi} instance, so either the same or different instances can be
+                    registered. One example would be a method reference to a default constructor like
+                    {@code MyListener::new}.
+
+                    @param listenerSupplier The supplier of listeners to add.
+                    @return The current instance in order to chain call methods.
+                """.stripIndent())
+                .setType("DiscordApiBuilder")
+                .addParameter("Supplier<$listener.name>", 'listenerSupplier')
+                .createBody()
+                .addStatement("return addListener(${listener.name}.class, listenerSupplier);")
+
+        chainableGloballyAttachableListenerManagerInterface
+                .addMethod("add$listener.name", Modifier.DEFAULT)
+                .setJavadocComment("""
+                    Adds a {@code $listener.name} to all created {@code DiscordApi} instances. The function is called
+                    for every created {@code DiscordApi} instance, so either the same or different instances can be
+                    registered. One example would be a method reference to a constructor with a {@code DiscordApi}
+                    parameter like {@code MyListener::new}.
+
+                    @param listenerFunction The function to provide listeners to add.
+                    @return The current instance in order to chain call methods.
+                """.stripIndent())
+                .setType("DiscordApiBuilder")
+                .addParameter("Function<DiscordApi, $listener.name>", 'listenerFunction')
+                .createBody()
+                .addStatement("return addListener(${listener.name}.class, listenerFunction);")
     } else {
         addListenerMethod.removeBody()
     }
@@ -533,7 +606,8 @@ def addMessageSpecificConcreteListenerMethods(
     }
 }
 
-def addGenericGloballyAttachableListenerMethods(attachableListenerManagerInterface) {
+def addGenericGloballyAttachableListenerMethods(
+        attachableListenerManagerInterface, chainableGloballyAttachableListenerManagerInterface) {
     attachableListenerManagerInterface
             .addMethod('addListener')
             .setJavadocComment('''
@@ -568,6 +642,115 @@ def addGenericGloballyAttachableListenerMethods(attachableListenerManagerInterfa
             .addParameter('GloballyAttachableListener', 'listener')
             .removeBody()
 
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('addListener')
+            .setJavadocComment('''
+                Adds a {@code GloballyAttachableListener} to all created {@code DiscordApi} instances.
+                Adding a listener multiple times will only add it once.
+                The order of invocation is according to first addition.
+
+                @param listenerClass The listener class.
+                @param listener The listener to add.
+                @param <T> The type of the listener.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .addTypeParameter('T extends GloballyAttachableListener')
+            .setType('DiscordApiBuilder')
+            .addParameter('Class<T>', 'listenerClass')
+            .addParameter('T', 'listener')
+            .removeBody()
+
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('addListener')
+            .setJavadocComment('''
+                Adds a listener that implements one or more {@code GloballyAttachableListener}s to all created
+                {@code DiscordApi} instances.
+                Adding a listener multiple times will only add it once.
+                The order of invocation is according to first addition.
+
+                @param listener The listener to add.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .setType('DiscordApiBuilder')
+            .addParameter('GloballyAttachableListener', 'listener')
+            .removeBody()
+
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('addListener')
+            .setJavadocComment('''
+                Adds a {@code GloballyAttachableListener} to all created {@code DiscordApi} instances. The supplier is
+                called for every created {@code DiscordApi} instance, so either the same or different instances can be
+                registered. One example would be a method reference to a default constructor like
+                {@code MyListener::new}.
+                Adding a listener multiple times will only add it once.
+                The order of invocation is according to first addition.
+
+                @param listenerClass The listener class.
+                @param listenerSupplier The supplier of listeners to add.
+                @param <T> The type of the listener.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .addTypeParameter('T extends GloballyAttachableListener')
+            .setType('DiscordApiBuilder')
+            .addParameter('Class<T>', 'listenerClass')
+            .addParameter('Supplier<T>', 'listenerSupplier')
+            .removeBody()
+
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('addListener')
+            .setJavadocComment('''
+                Adds a listener that implements one or more {@code GloballyAttachableListener}s to all created
+                {@code DiscordApi} instances. The supplier is called for every created {@code DiscordApi} instance,
+                so either the same or different instances can be registered. One example would be a method reference
+                to a default constructor like {@code MyListener::new}.
+                Adding a listener multiple times will only add it once.
+                The order of invocation is according to first addition.
+
+                @param listenerSupplier The supplier of listeners to add.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .setType('DiscordApiBuilder')
+            .addParameter('Supplier<GloballyAttachableListener>', 'listenerSupplier')
+            .removeBody()
+
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('addListener')
+            .setJavadocComment('''
+                Adds a {@code GloballyAttachableListener} to all created {@code DiscordApi} instances. The function
+                is called for every created {@code DiscordApi} instance, so either the same or different instances
+                can be registered. One example would be a method reference to a constructor with a {@code DiscordApi}
+                parameter like {@code MyListener::new}.
+                Adding a listener multiple times will only add it once.
+                The order of invocation is according to first addition.
+
+                @param listenerClass The listener class.
+                @param listenerFunction The function to provide listeners to add.
+                @param <T> The type of the listener.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .addTypeParameter('T extends GloballyAttachableListener')
+            .setType('DiscordApiBuilder')
+            .addParameter('Class<T>', 'listenerClass')
+            .addParameter('Function<DiscordApi, T>', 'listenerFunction')
+            .removeBody()
+
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('addListener')
+            .setJavadocComment('''
+                Adds a listener that implements one or more {@code GloballyAttachableListener}s to all created
+                {@code DiscordApi} instances. The function is called for every created {@code DiscordApi} instance,
+                so either the same or different instances can be registered. One example would be a method reference
+                to a constructor with a {@code DiscordApi} parameter like {@code MyListener::new}.
+                Adding a listener multiple times will only add it once.
+                The order of invocation is according to first addition.
+
+                @param listenerFunction The function to provide listeners to add.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .setType('DiscordApiBuilder')
+            .addParameter('Function<DiscordApi, GloballyAttachableListener>', 'listenerFunction')
+            .removeBody()
+
     attachableListenerManagerInterface
             .addMethod('removeListener')
             .setJavadocComment('''
@@ -590,6 +773,109 @@ def addGenericGloballyAttachableListenerMethods(attachableListenerManagerInterfa
             .addTypeParameter('T extends GloballyAttachableListener')
             .addParameter('Class<T>', 'listenerClass')
             .addParameter('T', 'listener')
+            .removeBody()
+
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('removeListener')
+            .setJavadocComment('''
+                Removes a listener that implements one or more {@code GloballyAttachableListener}s from the list of
+                listeners to be added to {@code DiscordApi} instances. If the listener was already added to a
+                {@code DiscordApi} instance, it will not get removed by calling this method.
+                This method should normally only be used before calling one of the login methods.
+
+                @param listener The listener to remove.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .setType('DiscordApiBuilder')
+            .addParameter('GloballyAttachableListener', 'listener')
+            .removeBody()
+
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('removeListener')
+            .setJavadocComment('''
+                Removes a {@code GloballyAttachableListener} from the list of listeners to be added to
+                {@code DiscordApi} instances. If the listener was already added to a {@code DiscordApi} instance,
+                it will not get removed by calling this method.
+                This method should normally only be used before calling one of the login methods.
+
+                @param listenerClass The listener class.
+                @param listener The listener to remove.
+                @param <T> The type of the listener.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .addTypeParameter('T extends GloballyAttachableListener')
+            .setType('DiscordApiBuilder')
+            .addParameter('Class<T>', 'listenerClass')
+            .addParameter('T', 'listener')
+            .removeBody()
+
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('removeListenerSupplier')
+            .setJavadocComment('''
+                Removes a supplier of listeners that implements one or more {@code GloballyAttachableListener}s
+                from the list of listeners to be added to {@code DiscordApi} instances. If the listener was already
+                added to a {@code DiscordApi} instance, it will not get removed by calling this method.
+                This method should normally only be used before calling one of the login methods.
+
+                @param listenerSupplier The supplier of listeners to remove.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .setType('DiscordApiBuilder')
+            .addParameter('Supplier<GloballyAttachableListener>', 'listenerSupplier')
+            .removeBody()
+
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('removeListenerSupplier')
+            .setJavadocComment('''
+                Removes a supplier of {@code GloballyAttachableListener}s from the list of listeners to be added to
+                {@code DiscordApi} instances. If the listener was already added to a {@code DiscordApi} instance,
+                it will not get removed by calling this method.
+                This method should normally only be used before calling one of the login methods.
+
+                @param listenerClass The listener class.
+                @param listenerSupplier The supplier of listeners to remove.
+                @param <T> The type of the listener.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .addTypeParameter('T extends GloballyAttachableListener')
+            .setType('DiscordApiBuilder')
+            .addParameter('Class<T>', 'listenerClass')
+            .addParameter('Supplier<T>', 'listenerSupplier')
+            .removeBody()
+
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('removeListenerFunction')
+            .setJavadocComment('''
+                Removes a function that provides listeners that implements one or more
+                {@code GloballyAttachableListener}s from the list of listeners to be added to {@code DiscordApi}
+                instances. If the listener was already added to a {@code DiscordApi} instance, it will not get
+                removed by calling this method.
+                This method should normally only be used before calling one of the login methods.
+
+                @param listenerFunction The function to provide listeners to remove.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .setType('DiscordApiBuilder')
+            .addParameter('Function<DiscordApi, GloballyAttachableListener>', 'listenerFunction')
+            .removeBody()
+
+    chainableGloballyAttachableListenerManagerInterface
+            .addMethod('removeListenerFunction')
+            .setJavadocComment('''
+                Removes a function that provides {@code GloballyAttachableListener}s from the list of listeners to be
+                added to {@code DiscordApi} instances. If the listener was already added to a {@code DiscordApi}
+                instance, it will not get removed by calling this method.
+                This method should normally only be used before calling one of the login methods.
+
+                @param listenerClass The listener class.
+                @param listenerFunction The function to provide listeners to remove.
+                @param <T> The type of the listener.
+                @return The current instance in order to chain call methods.
+            '''.stripIndent())
+            .addTypeParameter('T extends GloballyAttachableListener')
+            .setType('DiscordApiBuilder')
+            .addParameter('Class<T>', 'listenerClass')
+            .addParameter('Function<DiscordApi, T>', 'listenerFunction')
             .removeBody()
 
     attachableListenerManagerInterface

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
@@ -2,6 +2,8 @@ package org.javacord.api;
 
 import org.javacord.api.event.server.ServerBecomesAvailableEvent;
 import org.javacord.api.internal.DiscordApiBuilderDelegate;
+import org.javacord.api.listener.ChainableGloballyAttachableListenerManager;
+import org.javacord.api.listener.GloballyAttachableListener;
 import org.javacord.api.util.auth.Authenticator;
 import org.javacord.api.util.internal.DelegateFactory;
 
@@ -10,13 +12,15 @@ import java.net.ProxySelector;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.function.IntPredicate;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 /**
  * This class is used to login to a Discord account.
  */
-public class DiscordApiBuilder {
+public class DiscordApiBuilder implements ChainableGloballyAttachableListenerManager {
 
     /**
      * The delegate used to create a {@link DiscordApi} instance.
@@ -285,5 +289,81 @@ public class DiscordApiBuilder {
      */
     public CompletableFuture<DiscordApiBuilder> setRecommendedTotalShards() {
         return delegate.setRecommendedTotalShards().thenCompose(nothing -> CompletableFuture.completedFuture(this));
+    }
+
+    @Override
+    public <T extends GloballyAttachableListener> DiscordApiBuilder addListener(Class<T> listenerClass, T listener) {
+        delegate.addListener(listenerClass, listener);
+        return this;
+    }
+
+    @Override
+    public DiscordApiBuilder addListener(GloballyAttachableListener listener) {
+        delegate.addListener(listener);
+        return this;
+    }
+
+    @Override
+    public <T extends GloballyAttachableListener> DiscordApiBuilder addListener(
+                                            Class<T> listenerClass, Supplier<T> listenerSupplier) {
+        delegate.addListener(listenerClass, listenerSupplier);
+        return this;
+    }
+
+    @Override
+    public DiscordApiBuilder addListener(Supplier<GloballyAttachableListener> listenerSupplier) {
+        delegate.addListener(listenerSupplier);
+        return this;
+    }
+
+    @Override
+    public <T extends GloballyAttachableListener> DiscordApiBuilder addListener(
+                                Class<T> listenerClass, Function<DiscordApi, T> listenerFunction) {
+        delegate.addListener(listenerClass, listenerFunction);
+        return this;
+    }
+
+    @Override
+    public DiscordApiBuilder addListener(Function<DiscordApi, GloballyAttachableListener> listenerFunction) {
+        delegate.addListener(listenerFunction);
+        return this;
+    }
+
+    @Override
+    public DiscordApiBuilder removeListener(GloballyAttachableListener listener) {
+        delegate.removeListener(listener);
+        return this;
+    }
+
+    @Override
+    public <T extends GloballyAttachableListener> DiscordApiBuilder removeListener(Class<T> listenerClass, T listener) {
+        delegate.removeListener(listenerClass, listener);
+        return this;
+    }
+
+    @Override
+    public DiscordApiBuilder removeListenerSupplier(Supplier<GloballyAttachableListener> listenerSupplier) {
+        delegate.removeListenerSupplier(listenerSupplier);
+        return this;
+    }
+
+    @Override
+    public <T extends GloballyAttachableListener> DiscordApiBuilder removeListenerSupplier(
+                                                            Class<T> listenerClass, Supplier<T> listenerSupplier) {
+        delegate.removeListenerSupplier(listenerClass, listenerSupplier);
+        return this;
+    }
+
+    @Override
+    public DiscordApiBuilder removeListenerFunction(Function<DiscordApi, GloballyAttachableListener> listenerFunction) {
+        delegate.removeListenerFunction(listenerFunction);
+        return this;
+    }
+
+    @Override
+    public <T extends GloballyAttachableListener> DiscordApiBuilder removeListenerFunction(
+                                                    Class<T> listenerClass, Function<DiscordApi, T> listenerFunction) {
+        delegate.removeListenerFunction(listenerClass, listenerFunction);
+        return this;
     }
 }

--- a/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
@@ -3,6 +3,7 @@ package org.javacord.api.internal;
 import org.javacord.api.AccountType;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.DiscordApiBuilder;
+import org.javacord.api.listener.GloballyAttachableListener;
 import org.javacord.api.util.auth.Authenticator;
 
 import java.net.Proxy;
@@ -10,6 +11,8 @@ import java.net.ProxySelector;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * This class is internally used by the {@link DiscordApiBuilder} to create discord api instances.
@@ -142,4 +145,148 @@ public interface DiscordApiBuilderDelegate {
      */
     CompletableFuture<Void> setRecommendedTotalShards();
 
+
+    /**
+     * Adds a {@code GloballyAttachableListener} to all created {@code DiscordApi} instances.
+     * Adding a listener multiple times will only add it once.
+     * The order of invocation is according to first addition.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to add.
+     * @param <T> The type of the listener.
+     */
+    <T extends GloballyAttachableListener> void addListener(Class<T> listenerClass, T listener);
+
+    /**
+     * Adds a listener that implements one or more {@code GloballyAttachableListener}s to all created
+     * {@code DiscordApi} instances.
+     * Adding a listener multiple times will only add it once.
+     * The order of invocation is according to first addition.
+     *
+     * @param listener The listener to add.
+     */
+    void addListener(GloballyAttachableListener listener);
+
+    /**
+     * Adds a {@code GloballyAttachableListener} to all created {@code DiscordApi} instances. The supplier is
+     * called for every created {@code DiscordApi} instance, so either the same or different instances can be
+     * registered. One example would be a method reference to a default constructor like
+     * {@code MyListener::new}.
+     * Adding a listener multiple times will only add it once.
+     * The order of invocation is according to first addition.
+     *
+     * @param listenerClass The listener class.
+     * @param listenerSupplier The supplier of listeners to add.
+     * @param <T> The type of the listener.
+     */
+    <T extends GloballyAttachableListener> void addListener(Class<T> listenerClass, Supplier<T> listenerSupplier);
+
+    /**
+     * Adds a listener that implements one or more {@code GloballyAttachableListener}s to all created
+     * {@code DiscordApi} instances. The supplier is called for every created {@code DiscordApi} instance,
+     * so either the same or different instances can be registered. One example would be a method reference
+     * to a default constructor like {@code MyListener::new}.
+     * Adding a listener multiple times will only add it once.
+     * The order of invocation is according to first addition.
+     *
+     * @param listenerSupplier The supplier of listeners to add.
+     */
+    void addListener(Supplier<GloballyAttachableListener> listenerSupplier);
+
+    /**
+     * Adds a {@code GloballyAttachableListener} to all created {@code DiscordApi} instances. The function
+     * is called for every created {@code DiscordApi} instance, so either the same or different instances
+     * can be registered. One example would be a method reference to a constructor with a {@code DiscordApi}
+     * parameter like {@code MyListener::new}.
+     * Adding a listener multiple times will only add it once.
+     * The order of invocation is according to first addition.
+     *
+     * @param listenerClass The listener class.
+     * @param listenerFunction The function to provide listeners to add.
+     * @param <T> The type of the listener.
+     */
+    <T extends GloballyAttachableListener> void addListener(Class<T> listenerClass,
+                                                            Function<DiscordApi, T> listenerFunction);
+
+    /**
+     * Adds a listener that implements one or more {@code GloballyAttachableListener}s to all created
+     * {@code DiscordApi} instances. The function is called for every created {@code DiscordApi} instance,
+     * so either the same or different instances can be registered. One example would be a method reference
+     * to a constructor with a {@code DiscordApi} parameter like {@code MyListener::new}.
+     * Adding a listener multiple times will only add it once.
+     * The order of invocation is according to first addition.
+     *
+     * @param listenerFunction The function to provide listeners to add.
+     */
+    void addListener(Function<DiscordApi, GloballyAttachableListener> listenerFunction);
+
+    /**
+     * Removes a listener that implements one or more {@code GloballyAttachableListener}s from the list of
+     * listeners to be added to {@code DiscordApi} instances. If the listener was already added to a
+     * {@code DiscordApi} instance, it will not get removed by calling this method.
+     * This method should normally only be used before calling one of the login methods.
+     *
+     * @param listener The listener to remove.
+     */
+    void removeListener(GloballyAttachableListener listener);
+
+    /**
+     * Removes a {@code GloballyAttachableListener} from the list of listeners to be added to
+     * {@code DiscordApi} instances. If the listener was already added to a {@code DiscordApi} instance,
+     * it will not get removed by calling this method.
+     * This method should normally only be used before calling one of the login methods.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    <T extends GloballyAttachableListener> void removeListener(Class<T> listenerClass, T listener);
+
+    /**
+     * Removes a supplier of listeners that implements one or more {@code GloballyAttachableListener}s
+     * from the list of listeners to be added to {@code DiscordApi} instances. If the listener was already
+     * added to a {@code DiscordApi} instance, it will not get removed by calling this method.
+     * This method should normally only be used before calling one of the login methods.
+     *
+     * @param listenerSupplier The supplier of listeners to remove.
+     */
+    void removeListenerSupplier(Supplier<GloballyAttachableListener> listenerSupplier);
+
+    /**
+     * Removes a supplier of {@code GloballyAttachableListener}s from the list of listeners to be added to
+     * {@code DiscordApi} instances. If the listener was already added to a {@code DiscordApi} instance,
+     * it will not get removed by calling this method.
+     * This method should normally only be used before calling one of the login methods.
+     *
+     * @param listenerClass The listener class.
+     * @param listenerSupplier The supplier of listeners to remove.
+     * @param <T> The type of the listener.
+     */
+    <T extends GloballyAttachableListener> void removeListenerSupplier(Class<T> listenerClass,
+                                                                       Supplier<T> listenerSupplier);
+
+    /**
+     * Removes a function that provides listeners that implements one or more
+     * {@code GloballyAttachableListener}s from the list of listeners to be added to {@code DiscordApi}
+     * instances. If the listener was already added to a {@code DiscordApi} instance, it will not get
+     * removed by calling this method.
+     * This method should normally only be used before calling one of the login methods.
+     *
+     * @param listenerFunction The function to provide listeners to remove.
+     */
+    void removeListenerFunction(Function<DiscordApi, GloballyAttachableListener> listenerFunction);
+
+    /**
+     * Removes a function that provides {@code GloballyAttachableListener}s from the list of listeners to be
+     * added to {@code DiscordApi} instances. If the listener was already added to a {@code DiscordApi}
+     * instance, it will not get removed by calling this method.
+     * This method should normally only be used before calling one of the login methods.
+     *
+     * @param listenerClass The listener class.
+     * @param listenerFunction The function to provide listeners to remove.
+     * @param <T> The type of the listener.
+     */
+    <T extends GloballyAttachableListener> void removeListenerFunction(Class<T> listenerClass,
+                                                                       Function<DiscordApi, T> listenerFunction);
+    
 }

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiBuilderDelegateImpl.java
@@ -5,7 +5,9 @@ import org.apache.logging.log4j.CloseableThreadContext;
 import org.apache.logging.log4j.Logger;
 import org.javacord.api.AccountType;
 import org.javacord.api.DiscordApi;
+import org.javacord.api.DiscordApiBuilder;
 import org.javacord.api.internal.DiscordApiBuilderDelegate;
+import org.javacord.api.listener.GloballyAttachableListener;
 import org.javacord.api.util.auth.Authenticator;
 import org.javacord.core.util.gateway.DiscordWebSocketAdapter;
 import org.javacord.core.util.logging.LoggerUtil;
@@ -21,11 +23,18 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * The implementation of {@link DiscordApiBuilderDelegate}.
@@ -89,8 +98,60 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
      */
     private volatile boolean waitForServersOnStartup = true;
 
+    /**
+     * The globally attachable listeners to register for every created DiscordApi instance.
+     */
+    private final Map<Class<? extends GloballyAttachableListener>,
+            List<GloballyAttachableListener>> listeners
+            = new ConcurrentHashMap<>();
+
+    /**
+     * Suppliers for globally attachable listeners.
+     */
+    private final Map<Class<? extends GloballyAttachableListener>,
+            List<Supplier<? extends GloballyAttachableListener>>> listenerSuppliers
+            = new ConcurrentHashMap<>();
+
+    /**
+     * Functions for globally attachable listeners.
+     */
+    private final Map<Class<? extends GloballyAttachableListener>,
+            List<Function<DiscordApi, ? extends GloballyAttachableListener>>> listenerFunctions
+            = new ConcurrentHashMap<>();
+
+    /**
+     * Globally attachable listeners in need of subtype detection.
+     */
+    private final List<GloballyAttachableListener> unspecifiedListeners
+            = new CopyOnWriteArrayList<>();
+
+    /**
+     * Globally attachable listener suppliers in need of subtype detection.
+     */
+    private final List<Supplier<GloballyAttachableListener>> unspecifiedListenerSuppliers
+            = new CopyOnWriteArrayList<>();
+
+    /**
+     * Globally attachable listeners in need of subtype detection.
+     */
+    private final List<Function<DiscordApi,GloballyAttachableListener>> unspecifiedListenerFunctions
+            = new CopyOnWriteArrayList<>();
+
+    /**
+     * Listener sources for pre-registration, compiled into a single map.
+     */
+    private volatile Map<Class<? extends GloballyAttachableListener>,
+            List<Function<DiscordApi, GloballyAttachableListener>>> preparedListeners;
+
+    /**
+     * Unspecified listener sources for pre-registration, compiled into a single map.
+     */
+    private volatile List<Function<DiscordApi,GloballyAttachableListener>> preparedUnspecifiedListeners;
+
+
     @Override
     public CompletableFuture<DiscordApi> login() {
+        prepareListeners();
         logger.debug("Creating shard {} of {}", currentShard.get() + 1, totalShards.get());
         CompletableFuture<DiscordApi> future = new CompletableFuture<>();
         if (token == null) {
@@ -100,9 +161,44 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
         try (CloseableThreadContext.Instance closeableThreadContextInstance =
                      CloseableThreadContext.put("shard", Integer.toString(currentShard.get()))) {
             new DiscordApiImpl(accountType, token, currentShard.get(), totalShards.get(), waitForServersOnStartup,
-                    proxySelector, proxy, proxyAuthenticator, trustAllCertificates, future);
+                    proxySelector, proxy, proxyAuthenticator, trustAllCertificates, future, null,
+                    preparedListeners, preparedUnspecifiedListeners);
         }
         return future;
+    }
+
+    /**
+     * Compile pre-registered listeners into proper collections for DiscordApi creation.
+     */
+    @SuppressWarnings("unchecked")
+    private void prepareListeners() {
+        if (preparedListeners != null && preparedUnspecifiedListeners != null) {
+            // Already created, skip
+            return;
+        }
+        preparedListeners = new ConcurrentHashMap<>();
+        Stream<Class<? extends GloballyAttachableListener>> eventTypes = Stream.concat(
+                listeners.keySet().stream(),
+                Stream.concat(listenerSuppliers.keySet().stream(),
+                        listenerFunctions.keySet().stream())
+        ).distinct();
+        eventTypes.forEach(type -> {
+            ArrayList<Function<DiscordApi, GloballyAttachableListener>> typeListenerFunctions = new ArrayList<>();
+            listeners.getOrDefault(type, Collections.emptyList()).forEach(
+                    listener -> typeListenerFunctions.add(api -> listener)
+            );
+            listenerSuppliers.getOrDefault(type, Collections.emptyList()).forEach(
+                    supplier -> typeListenerFunctions.add(api -> supplier.get())
+            );
+            listenerFunctions.getOrDefault(type, Collections.emptyList()).forEach(
+                    function -> typeListenerFunctions.add((Function<DiscordApi, GloballyAttachableListener>) function)
+            );
+            preparedListeners.put(type, typeListenerFunctions);
+        });
+        // Unspecified Listeners
+        preparedUnspecifiedListeners = new CopyOnWriteArrayList<>(unspecifiedListenerFunctions);
+        unspecifiedListenerSuppliers.forEach(supplier -> preparedUnspecifiedListeners.add((api) -> supplier.get()));
+        unspecifiedListeners.forEach(listener -> preparedUnspecifiedListeners.add((api) -> listener));
     }
 
     @Override
@@ -259,5 +355,98 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
                     return null;
                 })
                 .whenComplete((nothing, throwable) -> api.disconnect());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends GloballyAttachableListener> void addListener(Class<T> listenerClass, T listener) {
+        this.listeners.computeIfAbsent(listenerClass, clazz -> new CopyOnWriteArrayList<>());
+        List<T> listeners = (List<T>) this.listeners.get(listenerClass);
+        if (!listeners.contains(listener)) {
+            listeners.add(listener);
+        }
+    }
+
+    @Override
+    public void addListener(GloballyAttachableListener listener) {
+        if (!this.unspecifiedListeners.contains(listener)) {
+            this.unspecifiedListeners.add(listener);
+        }
+    }
+
+    @Override
+    public <T extends GloballyAttachableListener> void addListener(
+                                            Class<T> listenerClass, Supplier<T> listenerSupplier) {
+        this.listenerSuppliers.computeIfAbsent(listenerClass, clazz -> new CopyOnWriteArrayList<>());
+        List<Supplier<? extends GloballyAttachableListener>> listeners = this.listenerSuppliers.get(listenerClass);
+        if (!listeners.contains(listenerSupplier)) {
+            listeners.add(listenerSupplier);
+        }
+    }
+
+    @Override
+    public void addListener(Supplier<GloballyAttachableListener> listenerSupplier) {
+        if (!this.unspecifiedListenerSuppliers.contains(listenerSupplier))  {
+            this.unspecifiedListenerSuppliers.add(listenerSupplier);
+        }
+    }
+
+    @Override
+    public <T extends GloballyAttachableListener> void addListener(
+                                                Class<T> listenerClass, Function<DiscordApi, T> listenerFunction) {
+        this.listenerFunctions.computeIfAbsent(listenerClass, clazz -> new CopyOnWriteArrayList<>());
+        List<Function<DiscordApi, ? extends GloballyAttachableListener>> functions =
+                this.listenerFunctions.get(listenerClass);
+        if (!functions.contains(listenerFunction)) {
+            functions.add(listenerFunction);
+        }
+    }
+
+    @Override
+    public void addListener(Function<DiscordApi, GloballyAttachableListener> listenerFunction) {
+        if (!this.unspecifiedListenerFunctions.contains(listenerFunction)) {
+            this.unspecifiedListenerFunctions.add(listenerFunction);
+        }
+    }
+
+    @Override
+    public void removeListener(GloballyAttachableListener listener) {
+        this.unspecifiedListeners.remove(listener);
+    }
+
+    @Override
+    public <T extends GloballyAttachableListener> void removeListener(Class<T> listenerClass, T listener) {
+        this.listeners.computeIfPresent(listenerClass, (clazz, listeners) -> {
+            listeners.remove(listener);
+            return listeners.isEmpty() ? null : listeners;
+        });
+    }
+
+    @Override
+    public void removeListenerSupplier(Supplier<GloballyAttachableListener> listenerSupplier) {
+        this.unspecifiedListenerSuppliers.remove(listenerSupplier);
+    }
+
+    @Override
+    public <T extends GloballyAttachableListener> void removeListenerSupplier(
+                                                Class<T> listenerClass, Supplier<T> listenerSupplier) {
+        this.listenerSuppliers.computeIfPresent(listenerClass, (clazz, suppliers) -> {
+            suppliers.remove(listenerSupplier);
+            return suppliers.isEmpty() ? null : suppliers;
+        });
+    }
+
+    @Override
+    public void removeListenerFunction(Function<DiscordApi, GloballyAttachableListener> listenerFunction) {
+        this.unspecifiedListenerFunctions.remove(listenerFunction);
+    }
+
+    @Override
+    public <T extends GloballyAttachableListener> void removeListenerFunction(
+                                                Class<T> listenerClass, Function<DiscordApi, T> listenerFunction) {
+        this.listenerFunctions.computeIfPresent(listenerClass, (clazz, functions) -> {
+            functions.remove(listenerFunction);
+            return functions.isEmpty() ? null : functions;
+        });
     }
 }


### PR DESCRIPTION
Untested for now. Since the `GloballyAttachableListenerManager` interface is a) autogenerated and b) huge, I've settled for a single method requiring the class also passed.

Implements #353 