### PR TITLE
Tweaks to the CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
 
     working_directory: ~/javacord
 
+    environment:
+      GRADLE_OPTS: -Xmx2G
+
     steps:
       - checkout
 
@@ -40,7 +43,7 @@ jobs:
       # download and cache dependencies and Gradle
       - run:
           name: Downloading Dependencies
-          command: ./gradlew --max-workers 2 downloadDependencies
+          command: ./gradlew --max-workers 2 --no-daemon downloadDependencies
 
       - save_cache:
           paths:
@@ -55,7 +58,7 @@ jobs:
       # build everything needed for publication
       - run:
           name: Building Project
-          command: ./gradlew --max-workers 2 --continue clean build
+          command: ./gradlew --max-workers 2 --no-daemon --continue clean build
 
       # cache gradle build caches
       - run:


### PR DESCRIPTION
- Restrict max heap to 2 GiB, as the recognition that should be there since Java 10 fails and so the JVM tries to allocate 17 GiB when only 4 GiB are accessible to the container in total
- Do not use the daemon, each run is done in a fresh docker container, so the daemon makes no sense