### PR TITLE
Revert the CircleCI tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ jobs:
 
     working_directory: ~/javacord
 
-    environment:
-      GRADLE_OPTS: -Xmx2G
-
     steps:
       - checkout
 
@@ -43,7 +40,7 @@ jobs:
       # download and cache dependencies and Gradle
       - run:
           name: Downloading Dependencies
-          command: ./gradlew --max-workers 2 --no-daemon downloadDependencies
+          command: ./gradlew --max-workers 2 downloadDependencies
 
       - save_cache:
           paths:
@@ -58,7 +55,7 @@ jobs:
       # build everything needed for publication
       - run:
           name: Building Project
-          command: ./gradlew --max-workers 2 --no-daemon --continue clean build
+          command: ./gradlew --max-workers 2 --continue clean build
 
       # cache gradle build caches
       - run:


### PR DESCRIPTION
They are unnecessary and not helping.
Build is still killed by the OOM killer and actually Gradle already sets sensible defaults when --no-daemon is not used.