### PR TITLE
Fix OOM killer problem on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
 
     working_directory: ~/javacord
 
+    environment:
+      _JAVA_OPTIONS: -Xmx2G
+
     steps:
       - checkout
 


### PR DESCRIPTION
CircleCI uses some method for resource limitation that Java cannot see through,
so the test runner process allocates more memory than allowed and the OOM killer
then kills the test process which makes the builds fail.
With the environment variable _JAVA_OPTIONS, all Java processes can be configured
as this environment variable is checked by the JVM itself.