### PR TITLE
Catch Throwable instead of Exception when handling packets

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/PacketHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/PacketHandler.java
@@ -49,17 +49,17 @@ public abstract class PacketHandler {
             executorService.submit(() -> {
                 try {
                     handle(packet);
-                } catch (Exception e) {
+                } catch (Throwable t) {
                     logger.warn("Couldn't handle packet of type {}. Please contact the developer! (packet: {})",
-                            getType(), packet, e);
+                            getType(), packet, t);
                 }
             });
         } else {
             try {
                 handle(packet);
-            } catch (Exception e) {
+            } catch (Throwable t) {
                 logger.warn("Couldn't handle packet of type {}. Please contact the developer! (packet: {})",
-                        getType(), packet, e);
+                        getType(), packet, t);
             }
         }
     }


### PR DESCRIPTION
Without this change things like NoSuchMethodError due to incompatible Jackson version
are just swallowed and the bot might just not work properly.
This for example happened when a server text channel inside a category was constructed
from the GUILD_CREATE package and Jackson version where the used method was not yet
available. The bot just didn't work on those servers but worked fine on ones that only
have text channels outside categories or in private messages.