### PR TITLE
Support for mobile indicator

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/DiscordClient.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/DiscordClient.java
@@ -1,0 +1,46 @@
+package org.javacord.api.entity;
+
+/**
+ * Represents the three different Discord clients.
+ */
+public enum DiscordClient {
+
+    /**
+     * The Discord desktop client.
+     *
+     * <p>Does not differentiate between operating systems like Windows or Linux.
+     */
+    DESKTOP("desktop"),
+
+    /**
+     * The Discord mobile client.
+     *
+     * <p>Does not differentiate between the iOS app and the Android app.
+     */
+    MOBILE("mobile"),
+
+    /**
+     * The Discord web client.
+     */
+    WEB("web");
+
+    private final String name;
+
+    /**
+     * Creates a new Discord Client.
+     *
+     * @param name The name for the client, as it appears in the Discord REST-api.
+     */
+    DiscordClient(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the name of client, as it appears in the Discord REST-api.
+     *
+     * @return The name of the client.
+     */
+    public String getName() {
+        return name;
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -2,6 +2,7 @@ package org.javacord.api.entity.user;
 
 import org.javacord.api.AccountType;
 import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.DiscordClient;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.Mentionable;
@@ -20,10 +21,12 @@ import org.javacord.api.listener.user.UserAttachableListenerManager;
 
 import java.awt.Color;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -120,11 +123,77 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
     }
 
     /**
-     * Gets the status of the user.
+     * Gets the connection status of the user as it is displayed in the user list.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
+     *
+     * <p>To see if a non-offline user is connected via a mobile client, a desktop client, a web client or any
+     * combination of the three use the {@link #getStatusOnClient(DiscordClient)}} method.
      *
      * @return The status of the user.
      */
     UserStatus getStatus();
+
+    /**
+     * Gets the status of the user on the given client.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
+     *
+     * @param client The client.
+     * @return The status of the user
+     * @see #getStatus()
+     */
+    UserStatus getStatusOnClient(DiscordClient client);
+
+    /**
+     * Gets the status of the user on the {@link DiscordClient#DESKTOP desktop} client.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
+     *
+     * @return The status of the the user.
+     * @see #getStatusOnClient(DiscordClient)
+     */
+    default UserStatus getDesktopStatus() {
+        return getStatusOnClient(DiscordClient.DESKTOP);
+    }
+
+    /**
+     * Gets the status of the user on the {@link DiscordClient#MOBILE mobile} client.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
+     *
+     * @return The status of the the user.
+     * @see #getStatusOnClient(DiscordClient)
+     */
+    default UserStatus getMobileStatus() {
+        return getStatusOnClient(DiscordClient.MOBILE);
+    }
+
+    /**
+     * Gets the status of the user on the {@link DiscordClient#WEB web} (browser) client.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
+     *
+     * @return The status of the the user.
+     * @see #getStatusOnClient(DiscordClient)
+     */
+    default UserStatus getWebStatus() {
+        return getStatusOnClient(DiscordClient.WEB);
+    }
+
+    /**
+     * Gets all clients of the user that are not {@link UserStatus#OFFLINE offline}.
+     *
+     * @return A set with the clients.
+     * @see #getStatusOnClient(DiscordClient)
+     */
+    default Set<DiscordClient> getCurrentClients() {
+        Set<DiscordClient> connectedClients = Arrays
+                .stream(DiscordClient.values())
+                .filter(client -> getStatusOnClient(client) != UserStatus.OFFLINE)
+                .collect(Collectors.toSet());
+        return Collections.unmodifiableSet(connectedClients);
+    }
 
     /**
      * Gets the avatar of the user.

--- a/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeStatusEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeStatusEvent.java
@@ -1,5 +1,6 @@
 package org.javacord.api.event.user;
 
+import org.javacord.api.entity.DiscordClient;
 import org.javacord.api.entity.user.UserStatus;
 
 /**
@@ -8,17 +9,119 @@ import org.javacord.api.entity.user.UserStatus;
 public interface UserChangeStatusEvent extends UserEvent {
 
     /**
-     * Gets the old status of the user.
+     * Gets the old connection status of the user.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
      *
      * @return The old status of the user.
      */
     UserStatus getOldStatus();
 
     /**
-     * Gets the new status of the user.
+     * Gets the new connection status of the user.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
      *
      * @return The new status of the user.
      */
     UserStatus getNewStatus();
+
+    /**
+     * Gets the old status of the user on the {@link DiscordClient#DESKTOP desktop} client.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
+     *
+     * @return The status of the the user.
+     * @see #getOldStatusOnClient(DiscordClient)
+     */
+    default UserStatus getOldDesktopStatus() {
+        return getOldStatusOnClient(DiscordClient.DESKTOP);
+    }
+
+    /**
+     * Gets the old status of the user on the {@link DiscordClient#MOBILE mobile} client.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
+     *
+     * @return The status of the the user.
+     * @see #getOldStatusOnClient(DiscordClient)
+     */
+    default UserStatus getOldMobileStatus() {
+        return getOldStatusOnClient(DiscordClient.MOBILE);
+    }
+
+    /**
+     * Gets the old status of the user on the {@link DiscordClient#WEB web} (browser) client.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
+     *
+     * @return The status of the the user.
+     * @see #getOldStatusOnClient(DiscordClient)
+     */
+    default UserStatus getOldWebStatus() {
+        return getOldStatusOnClient(DiscordClient.WEB);
+    }
+
+    /**
+     * Gets the new status of the user on the {@link DiscordClient#DESKTOP desktop} client.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
+     *
+     * @return The status of the the user.
+     * @see #getNewStatusOnClient(DiscordClient)
+     */
+    default UserStatus getNewDesktopStatus() {
+        return getNewStatusOnClient(DiscordClient.DESKTOP);
+    }
+
+    /**
+     * Gets the new status of the user on the {@link DiscordClient#MOBILE mobile} client.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
+     *
+     * @return The status of the the user.
+     * @see #getNewStatusOnClient(DiscordClient)
+     */
+    default UserStatus getNewMobileStatus() {
+        return getNewStatusOnClient(DiscordClient.MOBILE);
+    }
+
+    /**
+     * Gets the new status of the user on the {@link DiscordClient#WEB web} (browser) client.
+     *
+     * <p>This will return {@link UserStatus#OFFLINE} for invisible users.
+     *
+     * @return The status of the the user.
+     * @see #getNewStatusOnClient(DiscordClient)
+     */
+    default UserStatus getNewWebStatus() {
+        return getNewStatusOnClient(DiscordClient.WEB);
+    }
+
+    /**
+     * Gets the old status on the given client.
+     *
+     * @param client The client.
+     * @return The old status on the given client.
+     */
+    UserStatus getOldStatusOnClient(DiscordClient client);
+
+    /**
+     * Gets the new status on the given client.
+     *
+     * @param client The client.
+     * @return The new status on the given client.
+     */
+    UserStatus getNewStatusOnClient(DiscordClient client);
+
+    /**
+     * Checks if the status has changed on the given client.
+     *
+     * @param client The client.
+     * @return Wether the status changed on the given client or not.
+     */
+    default boolean hasStatusChangeOnClient(DiscordClient client) {
+        return getOldStatusOnClient(client) != getNewStatusOnClient(client);
+    }
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.apache.logging.log4j.Logger;
 import org.javacord.api.AccountType;
 import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.DiscordClient;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.Region;
@@ -329,6 +330,18 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
                 if (presenceJson.has("status")) {
                     UserStatus status = UserStatus.fromString(presenceJson.get("status").asText());
                     user.setStatus(status);
+                }
+
+                if (presenceJson.has("client_status")) {
+                    JsonNode clientStatus = presenceJson.get("client_status");
+                    for (DiscordClient client : DiscordClient.values()) {
+                        if (clientStatus.hasNonNull(client.getName())) {
+                            user.setClientStatus(
+                                    client, UserStatus.fromString(clientStatus.get(client.getName()).asText()));
+                        } else {
+                            user.setClientStatus(client, UserStatus.OFFLINE);
+                        }
+                    }
                 }
             }
         }

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.DiscordClient;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.activity.Activity;
@@ -22,9 +23,11 @@ import org.javacord.core.util.rest.RestRequest;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The implementation of {@link User}.
@@ -82,6 +85,11 @@ public class UserImpl implements User, Cleanupable, InternalUserAttachableListen
     private volatile UserStatus status = UserStatus.OFFLINE;
 
     /**
+     * The status of the user on a given client.
+     */
+    private final Map<DiscordClient, UserStatus> clientStatus = new ConcurrentHashMap<>();
+
+    /**
      * Creates a new user.
      *
      * @param api The discord api instance.
@@ -131,6 +139,16 @@ public class UserImpl implements User, Cleanupable, InternalUserAttachableListen
      */
     public void setStatus(UserStatus status) {
         this.status = status;
+    }
+
+    /**
+     * Sets the client status of the user.
+     *
+     * @param client The client.
+     * @param status The status to set.
+     */
+    public void setClientStatus(DiscordClient client, UserStatus status) {
+        clientStatus.put(client, status);
     }
 
     /**
@@ -208,6 +226,11 @@ public class UserImpl implements User, Cleanupable, InternalUserAttachableListen
     @Override
     public UserStatus getStatus() {
         return status;
+    }
+
+    @Override
+    public UserStatus getStatusOnClient(DiscordClient client) {
+        return clientStatus.getOrDefault(client, UserStatus.OFFLINE);
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeStatusEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeStatusEventImpl.java
@@ -1,8 +1,11 @@
 package org.javacord.core.event.user;
 
+import org.javacord.api.entity.DiscordClient;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.user.UserStatus;
 import org.javacord.api.event.user.UserChangeStatusEvent;
+
+import java.util.Map;
 
 /**
  * The implementation of {@link UserChangeStatusEvent}.
@@ -20,16 +23,32 @@ public class UserChangeStatusEventImpl extends UserEventImpl implements UserChan
     private final UserStatus oldStatus;
 
     /**
+     * The new client specific status of the user.
+     */
+    private final Map<DiscordClient, UserStatus> newClientStatus;
+
+    /**
+     * The old client specific status of the user.
+     */
+    private final Map<DiscordClient, UserStatus> oldClientStatus;
+
+    /**
      * Creates a new user change status event.
      *
      * @param user The user of the event.
      * @param newStatus The new status of the user.
      * @param oldStatus The old status of the user.
+     * @param newClientStatus The new client specific status of the user.
+     * @param oldClientStatus The old client specific status of the user.
      */
-    public UserChangeStatusEventImpl(User user, UserStatus newStatus, UserStatus oldStatus) {
+    public UserChangeStatusEventImpl(User user, UserStatus newStatus, UserStatus oldStatus,
+                                     Map<DiscordClient, UserStatus> newClientStatus,
+                                     Map<DiscordClient, UserStatus> oldClientStatus) {
         super(user);
         this.newStatus = newStatus;
         this.oldStatus = oldStatus;
+        this.newClientStatus = newClientStatus;
+        this.oldClientStatus = oldClientStatus;
     }
 
     @Override
@@ -40,6 +59,16 @@ public class UserChangeStatusEventImpl extends UserEventImpl implements UserChan
     @Override
     public UserStatus getNewStatus() {
         return newStatus;
+    }
+
+    @Override
+    public UserStatus getOldStatusOnClient(DiscordClient client) {
+        return oldClientStatus.getOrDefault(client, UserStatus.OFFLINE);
+    }
+
+    @Override
+    public UserStatus getNewStatusOnClient(DiscordClient client) {
+        return newClientStatus.getOrDefault(client, UserStatus.OFFLINE);
     }
 
 }


### PR DESCRIPTION
With the last update, a `PRESENCE_UPDATE` packet might include the `client_status` node with up to three of the nodes `web`, `mobile` and `desktop`. They have string values similar to the `status` node, except that `offline` is indicated by them being absent.

These mobile and desktop statuses, if they are both present, seem to always have the same value as discord persists the user status over all platforms. So, if we take that assumption for granted, they could get replaced with methods returning a `boolean`.

Also: Should the connection / disconnection of another device trigger an event even if it doesn't change the global online state of a user? I've gone with "no" so far.