### PR TITLE
Remove unnecessary null check

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/webhook/WebhookBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/webhook/WebhookBuilderDelegateImpl.java
@@ -113,9 +113,7 @@ public class WebhookBuilderDelegateImpl implements WebhookBuilderDelegate {
             throw new IllegalStateException("Name is no optional parameter!");
         }
         ObjectNode body = JsonNodeFactory.instance.objectNode();
-        if (name != null) {
-            body.put("name", name);
-        }
+        body.put("name", name);
         if (avatar != null) {
             return avatar.asByteArray(channel.getApi()).thenAccept(bytes -> {
                 String base64Avatar = "data:image/" + avatar.getFileType() + ";base64,"


### PR DESCRIPTION
We already throw an exception if the field is null, so we don't need to check if it's not null.