### PR TITLE
Support for Spoilers

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAttachment.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAttachment.java
@@ -85,4 +85,16 @@ public interface MessageAttachment extends DiscordEntity {
      */
     CompletableFuture<BufferedImage> downloadAsImage();
 
+    /**
+     * Checks whether the attachment is marked as a spoiler.
+     *
+     * <p>Discord encodes the information on whether a file is considered a spoiler in the file name. Any file whose
+     * filename starts with {@code SPOILER_} is considered a spoiler.
+     *
+     * @return The spoiler status.
+     */
+    default boolean isSpoiler() {
+        return getFileName().startsWith("SPOILER_");
+    }
+
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageBuilder.java
@@ -37,6 +37,7 @@ public class MessageBuilder {
             builder.setEmbed(message.getEmbeds().get(0).toBuilder());
         }
         for (MessageAttachment attachment : message.getAttachments()) {
+            // Since spoiler status is encoded in the file name, it is copied automatically.
             builder.addAttachment(attachment.getUrl());
         }
         return builder;
@@ -210,6 +211,81 @@ public class MessageBuilder {
     }
 
     /**
+     * Adds a file to the message and marks it as spoiler.
+     *
+     * @param image The image to add as an attachment.
+     * @param fileName The file name of the image.
+     * @return The current instance in order to chain call methods.
+     * @see #addAttachmentAsSpoiler(BufferedImage, String)
+     */
+    public MessageBuilder addFileAsSpoiler(BufferedImage image, String fileName) {
+        delegate.addFile(image, "SPOILER_" + fileName);
+        return this;
+    }
+
+    /**
+     * Adds a file to the message and marks it as spoiler.
+     *
+     * @param file The file to add as an attachment.
+     * @return The current instance in order to chain call methods.
+     * @see #addAttachmentAsSpoiler(File)
+     */
+    public MessageBuilder addFileAsSpoiler(File file) {
+        delegate.addFileAsSpoiler(file);
+        return this;
+    }
+
+    /**
+     * Adds a file to the message and marks it as spoiler.
+     *
+     * @param icon The icon to add as an attachment.
+     * @return The current instance in order to chain call methods.
+     * @see #addAttachmentAsSpoiler(Icon)
+     */
+    public MessageBuilder addFileAsSpoiler(Icon icon) {
+        delegate.addFileAsSpoiler(icon);
+        return this;
+    }
+
+    /**
+     * Adds a file to the message.
+     *
+     * @param url The url of the attachment.
+     * @return The current instance in order to chain call methods.
+     * @see #addAttachment(URL)
+     */
+    public MessageBuilder addFileAsSpoiler(URL url) {
+        delegate.addFileAsSpoiler(url);
+        return this;
+    }
+
+    /**
+     * Adds a file to the message and marks it as spoiler.
+     *
+     * @param bytes The bytes of the file.
+     * @param fileName The name of the file.
+     * @return The current instance in order to chain call methods.
+     * @see #addAttachmentAsSpoiler(byte[], String)
+     */
+    public MessageBuilder addFileAsSpoiler(byte[] bytes, String fileName) {
+        delegate.addFile(bytes, "SPOILER_" + fileName);
+        return this;
+    }
+
+    /**
+     * Adds a file to the message and marks it as spoiler.
+     *
+     * @param stream The stream of the file.
+     * @param fileName The name of the file.
+     * @return The current instance in order to chain call methods.
+     * @see #addAttachment(InputStream, String)
+     */
+    public MessageBuilder addFileAsSpoiler(InputStream stream, String fileName) {
+        delegate.addFile(stream, "SPOILER_" + fileName);
+        return this;
+    }
+
+    /**
      * Adds an attachment to the message.
      *
      * @param image The image to add as an attachment.
@@ -275,6 +351,75 @@ public class MessageBuilder {
      */
     public MessageBuilder addAttachment(InputStream stream, String fileName) {
         delegate.addAttachment(stream, fileName);
+        return this;
+    }
+
+    /**
+     * Adds an attachment to the message and marks it as spoiler.
+     *
+     * @param image The image to add as an attachment.
+     * @param fileName The file name of the image.
+     * @return The current instance in order to chain call methods.
+     */
+    public MessageBuilder addAttachmentAsSpoiler(BufferedImage image, String fileName) {
+        delegate.addAttachment(image, "SPOILER_" + fileName);
+        return this;
+    }
+
+    /**
+     * Adds an attachment to the message and marks it as spoiler.
+     *
+     * @param file The file to add as an attachment.
+     * @return The current instance in order to chain call methods.
+     */
+    public MessageBuilder addAttachmentAsSpoiler(File file) {
+        delegate.addAttachmentAsSpoiler(file);
+        return this;
+    }
+
+    /**
+     * Adds an attachment to the message and marks it as spoiler.
+     *
+     * @param icon The icon to add as an attachment.
+     * @return The current instance in order to chain call methods.
+     */
+    public MessageBuilder addAttachmentAsSpoiler(Icon icon) {
+        delegate.addAttachmentAsSpoiler(icon);
+        return this;
+    }
+
+    /**
+     * Adds an attachment to the message and marks it as spoiler.
+     *
+     * @param url The url of the attachment.
+     * @return The current instance in order to chain call methods.
+     */
+    public MessageBuilder addAttachmentAsSpoiler(URL url) {
+        delegate.addAttachmentAsSpoiler(url);
+        return this;
+    }
+
+    /**
+     * Adds an attachment to the message and marks it as spoiler.
+     *
+     * @param bytes The bytes of the file.
+     * @param fileName The name of the file.
+     * @return The current instance in order to chain call methods.
+     */
+    public MessageBuilder addAttachmentAsSpoiler(byte[] bytes, String fileName) {
+        delegate.addAttachment(bytes, "SPOILER_" + fileName);
+        return this;
+    }
+
+    /**
+     * Adds an attachment to the message and marks it as spoiler.
+     *
+     * @param stream The stream of the file.
+     * @param fileName The name of the file.
+     * @return The current instance in order to chain call methods.
+     */
+    public MessageBuilder addAttachmentAsSpoiler(InputStream stream, String fileName) {
+        delegate.addAttachment(stream, "SPOILER_" + fileName);
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageDecoration.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageDecoration.java
@@ -10,7 +10,8 @@ public enum MessageDecoration {
     STRIKEOUT("~~"),
     CODE_SIMPLE("`"),
     CODE_LONG("```"),
-    UNDERLINE("__");
+    UNDERLINE("__"),
+    SPOILER("||");
 
     /**
      * The prefix of the decoration.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/internal/MessageBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/internal/MessageBuilderDelegate.java
@@ -133,6 +133,24 @@ public interface MessageBuilderDelegate {
     void addFile(InputStream stream, String fileName);
 
     /**
+     * Adds a spoiler attachment to the message.
+     * @param file The file to add as an attachment.
+     */
+    void addFileAsSpoiler(File file);
+
+    /**
+     * Adds a spoiler attachment to the message.
+     * @param icon The icon to add as an attachment.
+     */
+    void addFileAsSpoiler(Icon icon);
+
+    /**
+     * Adds a spoiler attachment to the message.
+     * @param url The url of the attachment.
+     */
+    void addFileAsSpoiler(URL url);
+
+    /**
      * Adds an attachment to the message.
      *
      * @param image The image to add as an attachment.
@@ -178,6 +196,24 @@ public interface MessageBuilderDelegate {
     void addAttachment(InputStream stream, String fileName);
 
     /**
+     * Adds a spoiler attachment to the message.
+     * @param file The file to add as an attachment.
+     */
+    void addAttachmentAsSpoiler(File file);
+
+    /**
+     * Adds a spoiler attachment to the message.
+     * @param icon The icon to add as an attachment.
+     */
+    void addAttachmentAsSpoiler(Icon icon);
+
+    /**
+     * Adds a spoiler attachment to the message.
+     * @param url The url of the attachment.
+     */
+    void addAttachmentAsSpoiler(URL url);
+
+    /**
      * Sets the nonce of the message.
      *
      * @param nonce The nonce to set.
@@ -214,5 +250,4 @@ public interface MessageBuilderDelegate {
      * @return The sent message.
      */
     CompletableFuture<Message> send(Messageable messageable);
-
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderDelegateImpl.java
@@ -150,6 +150,21 @@ public class MessageBuilderDelegateImpl implements MessageBuilderDelegate {
     }
 
     @Override
+    public void addFileAsSpoiler(File file) {
+        addAttachmentAsSpoiler(file);
+    }
+
+    @Override
+    public void addFileAsSpoiler(Icon icon) {
+        addAttachmentAsSpoiler(icon);
+    }
+
+    @Override
+    public void addFileAsSpoiler(URL url) {
+        addAttachmentAsSpoiler(url);
+    }
+
+    @Override
     public void addAttachment(BufferedImage image, String fileName) {
         if (image == null || fileName == null) {
             throw new IllegalArgumentException("image and fileName cannot be null!");
@@ -195,6 +210,30 @@ public class MessageBuilderDelegateImpl implements MessageBuilderDelegate {
             throw new IllegalArgumentException("stream and fileName cannot be null!");
         }
         attachments.add(new FileContainer(stream, fileName));
+    }
+
+    @Override
+    public void addAttachmentAsSpoiler(File file) {
+        if (file == null) {
+            throw new IllegalArgumentException("file cannot be null!");
+        }
+        attachments.add(new FileContainer(file, true));
+    }
+
+    @Override
+    public void addAttachmentAsSpoiler(Icon icon) {
+        if (icon == null) {
+            throw new IllegalArgumentException("icon cannot be null!");
+        }
+        attachments.add(new FileContainer(icon, true));
+    }
+
+    @Override
+    public void addAttachmentAsSpoiler(URL url) {
+        if (url == null) {
+            throw new IllegalArgumentException("url cannot be null!");
+        }
+        attachments.add(new FileContainer(url, true));
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/util/FileContainer.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/FileContainer.java
@@ -88,28 +88,48 @@ public class FileContainer {
      * @param file The file as a file.
      */
     public FileContainer(File file) {
+        this(file, false);
+    }
+
+    /**
+     * Creates a new file container with a file.
+     *
+     * @param file The file as a file.
+     * @param isSpoiler Whether the file is to be marked as spoiler.
+     */
+    public FileContainer(File file, boolean isSpoiler) {
         fileAsBufferedImage = null;
         fileAsFile = file;
         fileAsIcon = null;
         fileAsUrl = null;
         fileAsByteArray = null;
         fileAsInputStream = null;
-        fileTypeOrName = file.getName();
+        fileTypeOrName = (isSpoiler ? "SPOILER_" : "") + file.getName();
     }
 
     /**
      * Creates a new file container with an icon.
      *
-     * @param file The file a an icon.
+     * @param file The file as an icon.
      */
     public FileContainer(Icon file) {
+        this(file, false);
+    }
+
+    /**
+     * Creates a new file container with an icon.
+     *
+     * @param file The file as an icon.
+     * @param isSpoiler Whether the icon is marked as a spoiler.
+     */
+    public FileContainer(Icon file, boolean isSpoiler) {
         fileAsBufferedImage = null;
         fileAsFile = null;
         fileAsIcon = file;
         fileAsUrl = null;
         fileAsByteArray = null;
         fileAsInputStream = null;
-        fileTypeOrName = file.getUrl().getFile();
+        fileTypeOrName = (isSpoiler ? "SPOILER_" : "") + file.getUrl().getFile();
     }
 
     /**
@@ -118,13 +138,23 @@ public class FileContainer {
      * @param file The file as an url.
      */
     public FileContainer(URL file) {
+        this(file, false);
+    }
+
+    /**
+     * Creates a new file container with an url.
+     *
+     * @param file The file as an url.
+     * @param isSpoiler Whether the file is to be marked as spoiler.
+     */
+    public FileContainer(URL file, boolean isSpoiler) {
         fileAsBufferedImage = null;
         fileAsFile = null;
         fileAsIcon = null;
         fileAsUrl = file;
         fileAsByteArray = null;
         fileAsInputStream = null;
-        fileTypeOrName = file.getFile();
+        fileTypeOrName = (isSpoiler ? "SPOILER_" : "") + file.getFile();
     }
 
     /**


### PR DESCRIPTION
As of today's update, both textual and attachment spoilers are live in the discord client.

Since adding a "spoiler: true/false" field to the json would be the sensible thing to do, discord decided to instead prefix file names with `SPOILER_` to indicate a file should be considered a spoiler. However, this saves us waiting for a new documentation since the file name is something we can already control.

This PR implements
 - [x] Checking the spoiler status of a `MessageAttachment`
 - [x] Adding spoiler-marked attachments via the `MessageBuilder`
 - [ ] Sending spoilerific messages and attachments directly from the `Messageable` interface

I'd like some input with regard to method names for `Messageable` since `sendMessageAsSpoiler` would be confusing as to whether the text or the files would be marked as spoilers.