### PR TITLE
Update checkstyle document type definitions

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Javadoc coding conventions.

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE suppressions PUBLIC
         "-//Puppy Crawl//DTD Suppressions 1.2//EN"
-        "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <suppress id="finalizer" files=".*[\\/]DiscordApiImpl.java$" />


### PR DESCRIPTION
Old ones are no longer reachable and may lead to problems.