### PR TITLE
Improve performance of getters for channels

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -13,7 +13,7 @@ import org.javacord.api.Javacord;
 import org.javacord.api.entity.ApplicationInfo;
 import org.javacord.api.entity.activity.Activity;
 import org.javacord.api.entity.activity.ActivityType;
-import org.javacord.api.entity.channel.GroupChannel;
+import org.javacord.api.entity.channel.Channel;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.emoji.CustomEmoji;
 import org.javacord.api.entity.emoji.KnownCustomEmoji;
@@ -250,6 +250,11 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     private final ReferenceQueue<User> usersCleanupQueue = new ReferenceQueue<>();
 
     /**
+     * Allows for a quick lookup for channels by their id.
+     */
+    private final ConcurrentHashMap<Long, Channel> channels = new ConcurrentHashMap<>();
+
+    /**
      * A map which contains all servers that are ready.
      */
     private final ConcurrentHashMap<Long, Server> servers = new ConcurrentHashMap<>();
@@ -258,11 +263,6 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * A map which contains all servers that are not ready.
      */
     private final ConcurrentHashMap<Long, Server> nonReadyServers = new ConcurrentHashMap<>();
-
-    /**
-     * A map which contains all group channels.
-     */
-    private final ConcurrentHashMap<Long, GroupChannel> groupChannels = new ConcurrentHashMap<>();
 
     /**
      * A set with all unavailable servers.
@@ -571,10 +571,11 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
                 .map(Cleanupable.class::cast)
                 .forEach(Cleanupable::cleanup);
         servers.clear();
-        groupChannels.values().stream()
+        channels.values().stream()
+                .filter(Cleanupable.class::isInstance)
                 .map(Cleanupable.class::cast)
                 .forEach(Cleanupable::cleanup);
-        groupChannels.clear();
+        channels.clear();
         unavailableServers.clear();
         customEmojis.clear();
         messages.clear();
@@ -659,25 +660,27 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     }
 
     /**
-     * Adds a group channel to the cache.
+     * Adds a channel to the cache.
      *
      * @param channel The channel to add.
      */
-    public void addGroupChannelToCache(GroupChannel channel) {
-        GroupChannel oldChannel = groupChannels.put(channel.getId(), channel);
-        if ((oldChannel != null) && (oldChannel != channel)) {
+    public void addChannelToCache(Channel channel) {
+        Channel oldChannel = channels.put(channel.getId(), channel);
+        if (oldChannel != channel && oldChannel instanceof Cleanupable) {
             ((Cleanupable) oldChannel).cleanup();
         }
     }
 
     /**
-     * Removes a group channel from the cache.
+     * Removes a channel from the cache.
      *
      * @param channelId The id of the channel to remove.
      */
-    public void removeGroupChannelFromCache(long channelId) {
-        groupChannels.computeIfPresent(channelId, (key, groupChannel) -> {
-            ((Cleanupable) groupChannel).cleanup();
+    public void removeChannelFromCache(long channelId) {
+        channels.computeIfPresent(channelId, (key, channel) -> {
+            if (channel instanceof Cleanupable) {
+                ((Cleanupable) channel).cleanup();
+            }
             return null;
         });
     }
@@ -1353,13 +1356,13 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     }
 
     @Override
-    public Collection<GroupChannel> getGroupChannels() {
-        return Collections.unmodifiableCollection(groupChannels.values());
+    public Collection<Channel> getChannels() {
+        return Collections.unmodifiableCollection(new ArrayList<>(channels.values()));
     }
 
     @Override
-    public Optional<GroupChannel> getGroupChannelById(long id) {
-        return Optional.ofNullable(groupChannels.get(id));
+    public Optional<Channel> getChannelById(long id) {
+        return Optional.ofNullable(channels.get(id));
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/GroupChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/GroupChannelImpl.java
@@ -78,7 +78,7 @@ public class GroupChannelImpl implements GroupChannel, Cleanupable, InternalText
             recipients.add(api.getOrCreateUser(recipientJson));
         }
 
-        this.messageCache = new MessageCacheImpl(
+        messageCache = new MessageCacheImpl(
                 api, api.getDefaultMessageCacheCapacity(), api.getDefaultMessageCacheStorageTimeInSeconds(),
                 api.isDefaultAutomaticMessageCacheCleanupEnabled());
 
@@ -86,7 +86,7 @@ public class GroupChannelImpl implements GroupChannel, Cleanupable, InternalText
         name = data.has("name") && !data.get("name").isNull() ? data.get("name").asText() : null;
         iconId = data.has("icon") && !data.get("icon").isNull() ? data.get("icon").asText() : null;
 
-        api.addGroupChannelToCache(this);
+        api.addChannelToCache(this);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/PrivateChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/PrivateChannelImpl.java
@@ -55,6 +55,8 @@ public class PrivateChannelImpl implements PrivateChannel, Cleanupable, Internal
 
         id = Long.parseLong(data.get("id").asText());
         recipient.setChannel(this);
+
+        api.addChannelToCache(this);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelImpl.java
@@ -109,6 +109,7 @@ public abstract class ServerChannelImpl implements ServerChannel, InternalServer
             }
         }
 
+        api.addChannelToCache(this);
         server.addChannelToCache(this);
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1227,6 +1227,9 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     @Override
     public void cleanup() {
         channels.values().stream()
+                .map(ServerChannel::getId)
+                .forEach(api::removeChannelFromCache);
+        channels.values().stream()
                 .filter(Cleanupable.class::isInstance)
                 .map(Cleanupable.class::cast)
                 .forEach(Cleanupable::cleanup);

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelDeleteHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelDeleteHandler.java
@@ -62,6 +62,7 @@ public class ChannelDeleteHandler extends PacketHandler {
                 LoggerUtil.getLogger(ChannelDeleteHandler.class).warn("Unexpected packet type. Your Javacord version"
                         + " might be out of date.");
         }
+        api.removeChannelFromCache(packet.get("id").asLong());
     }
 
     /**
@@ -159,8 +160,6 @@ public class ChannelDeleteHandler extends PacketHandler {
             api.removeObjectListeners(VoiceChannel.class, channelId);
             api.removeObjectListeners(TextChannel.class, channelId);
             api.removeObjectListeners(Channel.class, channelId);
-
-            api.removeGroupChannelFromCache(channelId);
         });
     }
 


### PR DESCRIPTION
This PR is a cherry-pick of https://github.com/Javacord/Javacord/pull/436, as this PR became a bit of a mess with several other changes, too.

This PR mainly improves the performance of the `getChannelXyzById(...)` methods. As these are used internally by the packet handlers, improving their performance has a huge impact on Javacord#s overall performance.