### PR TITLE
Increase load wait time for new servers to become available

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
@@ -529,9 +529,9 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                                 allUsersLoaded = api.getAllServers().stream()
                                         .noneMatch(server -> server.getMemberCount() != server.getMembers().size());
                             }
-                            if (sameUnavailableServerCounter > 20
+                            if (sameUnavailableServerCounter > 1000
                                     && lastGuildMembersChunkReceived + 5000 < System.currentTimeMillis()) {
-                                // It has been more than two seconds since no more servers became available and more
+                                // It has been more than 1 minute since no more servers became available and more
                                 // than five seconds since the last guild member chunk event was received. We
                                 // can assume that this will not change anytime soon, most likely because Discord
                                 // itself has some issues. Let's break the loop!


### PR DESCRIPTION
The previous wait time was too short and caused some servers to be unavailable when the future from the #login() method already finished.

Fixes https://github.com/Javacord/Javacord/issues/398