### PR TITLE
Quickfix for new channel types

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ChannelType.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ChannelType.java
@@ -10,6 +10,8 @@ public enum ChannelType {
     SERVER_VOICE_CHANNEL(2),
     GROUP_CHANNEL(3),
     CHANNEL_CATEGORY(4),
+    SERVER_NEWS_CHANNEL(5),
+    SERVER_STORE_CHANNEL(6),
     UNKNOWN(-1);
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/ReadyHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/ReadyHandler.java
@@ -1,7 +1,9 @@
 package org.javacord.core.util.handler;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.core.entity.channel.GroupChannelImpl;
 import org.javacord.core.entity.channel.PrivateChannelImpl;
 import org.javacord.core.entity.server.ServerImpl;
@@ -12,6 +14,8 @@ import org.javacord.core.util.logging.LoggerUtil;
  * This class handles the ready packet.
  */
 public class ReadyHandler extends PacketHandler {
+
+    private static final Logger logger = LoggerUtil.getLogger(ReadyHandler.class);
 
     /**
      * Creates a new instance of this class.
@@ -41,16 +45,15 @@ public class ReadyHandler extends PacketHandler {
         if (packet.has("private_channels")) {
             JsonNode privateChannels = packet.get("private_channels");
             for (JsonNode channelJson : privateChannels) {
-                switch (channelJson.get("type").asInt()) {
-                    case 1:
+                switch (ChannelType.fromId(channelJson.get("type").asInt())) {
+                    case PRIVATE_CHANNEL:
                         new PrivateChannelImpl(api, channelJson);
                         break;
-                    case 3:
+                    case GROUP_CHANNEL:
                         new GroupChannelImpl(api, channelJson);
                         break;
                     default:
-                        LoggerUtil.getLogger(ReadyHandler.class).warn("Unknown channel type. Your Javacord version"
-                                + " may be outdated.");
+                        logger.warn("Unknown or unexpected channel type. Your Javacord version might be out of date!");
 
                 }
 

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelCreateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelCreateHandler.java
@@ -1,8 +1,10 @@
 package org.javacord.core.util.handler.channel;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.ChannelCategory;
+import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.api.entity.channel.GroupChannel;
 import org.javacord.api.entity.channel.PrivateChannel;
 import org.javacord.api.entity.channel.ServerTextChannel;
@@ -25,6 +27,8 @@ import org.javacord.core.util.logging.LoggerUtil;
  */
 public class ChannelCreateHandler extends PacketHandler {
 
+    private static final Logger logger = LoggerUtil.getLogger(ChannelCreateHandler.class);
+
     /**
      * Creates a new instance of this class.
      *
@@ -36,26 +40,35 @@ public class ChannelCreateHandler extends PacketHandler {
 
     @Override
     public void handle(JsonNode packet) {
-        int type = packet.get("type").asInt();
+        ChannelType type = ChannelType.fromId(packet.get("type").asInt());
         switch (type) {
-            case 0:
+            case SERVER_TEXT_CHANNEL:
                 handleServerTextChannel(packet);
                 break;
-            case 1:
+            case PRIVATE_CHANNEL:
                 handlePrivateChannel(packet);
                 break;
-            case 2:
+            case SERVER_VOICE_CHANNEL:
                 handleServerVoiceChannel(packet);
                 break;
-            case 3:
+            case GROUP_CHANNEL:
                 handleGroupChannel(packet);
                 break;
-            case 4:
+            case CHANNEL_CATEGORY:
                 handleChannelCategory(packet);
                 break;
+            case SERVER_NEWS_CHANNEL:
+                logger.debug("Received CHANNEL_CREATE packet for a news channel. In this Javacord version it is "
+                        + "treated as a normal text channel!");
+                handleServerTextChannel(packet);
+                break;
+            case SERVER_STORE_CHANNEL:
+                // TODO Handle store channels
+                logger.debug("Received CHANNEL_CREATE packet for a store channel. These are not supported in this"
+                        + " Javacord version and get ignored!");
+                break;
             default:
-                LoggerUtil.getLogger(ChannelCreateHandler.class).warn("Unexpected packet type. Your Javacord version"
-                        + " might be out of date.");
+                logger.warn("Unknown or unexpected channel type. Your Javacord version might be out of date!");
         }
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelDeleteHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelDeleteHandler.java
@@ -1,9 +1,11 @@
 package org.javacord.core.util.handler.channel;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.Channel;
 import org.javacord.api.entity.channel.ChannelCategory;
+import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.api.entity.channel.GroupChannel;
 import org.javacord.api.entity.channel.PrivateChannel;
 import org.javacord.api.entity.channel.ServerChannel;
@@ -30,6 +32,8 @@ import java.util.Collections;
  */
 public class ChannelDeleteHandler extends PacketHandler {
 
+    private static final Logger logger = LoggerUtil.getLogger(ChannelDeleteHandler.class);
+
     /**
      * Creates a new instance of this class.
      *
@@ -41,26 +45,34 @@ public class ChannelDeleteHandler extends PacketHandler {
 
     @Override
     public void handle(JsonNode packet) {
-        int type = packet.get("type").asInt();
+        ChannelType type = ChannelType.fromId(packet.get("type").asInt());
         switch (type) {
-            case 0:
+            case SERVER_TEXT_CHANNEL:
                 handleServerTextChannel(packet);
                 break;
-            case 1:
+            case PRIVATE_CHANNEL:
                 handlePrivateChannel(packet);
                 break;
-            case 2:
+            case SERVER_VOICE_CHANNEL:
                 handleServerVoiceChannel(packet);
                 break;
-            case 3:
+            case GROUP_CHANNEL:
                 handleGroupChannel(packet);
                 break;
-            case 4:
+            case CHANNEL_CATEGORY:
                 handleCategory(packet);
                 break;
+            case SERVER_NEWS_CHANNEL:
+                // TODO Handle server news channel differently
+                handleServerTextChannel(packet);
+                break;
+            case SERVER_STORE_CHANNEL:
+                // TODO Handle store channels
+                logger.debug("Received CHANNEL_DELETE packet for a store channel. These are not supported in this"
+                        + " Javacord version and get ignored!");
+                break;
             default:
-                LoggerUtil.getLogger(ChannelDeleteHandler.class).warn("Unexpected packet type. Your Javacord version"
-                        + " might be out of date.");
+                logger.warn("Unknown or unexpected channel type. Your Javacord version might be out of date!");
         }
         api.removeChannelFromCache(packet.get("id").asLong());
     }

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelUpdateHandler.java
@@ -1,10 +1,12 @@
 package org.javacord.core.util.handler.channel;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.channel.Categorizable;
 import org.javacord.api.entity.channel.ChannelCategory;
+import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.permission.Permissions;
 import org.javacord.api.entity.permission.Role;
@@ -51,6 +53,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class ChannelUpdateHandler extends PacketHandler {
 
+    private static final Logger logger = LoggerUtil.getLogger(ChannelUpdateHandler.class);
+
     /**
      * Creates a new instance of this class.
      *
@@ -62,29 +66,36 @@ public class ChannelUpdateHandler extends PacketHandler {
 
     @Override
     public void handle(JsonNode packet) {
-        int type = packet.get("type").asInt();
+        ChannelType type = ChannelType.fromId(packet.get("type").asInt());
         switch (type) {
-            case 0:
+            case SERVER_TEXT_CHANNEL:
                 handleServerChannel(packet);
                 handleServerTextChannel(packet);
                 break;
-            case 1:
+            case PRIVATE_CHANNEL:
                 handlePrivateChannel(packet);
                 break;
-            case 2:
+            case SERVER_VOICE_CHANNEL:
                 handleServerChannel(packet);
                 handleServerVoiceChannel(packet);
                 break;
-            case 3:
+            case GROUP_CHANNEL:
                 handleGroupChannel(packet);
                 break;
-            case 4:
+            case CHANNEL_CATEGORY:
                 handleServerChannel(packet);
                 handleChannelCategory(packet);
                 break;
+            case SERVER_NEWS_CHANNEL:
+                handleServerChannel(packet);
+                break;
+            case SERVER_STORE_CHANNEL:
+                // TODO Handle store channels
+                logger.debug("Received CHANNEL_UPDATE packet for a store channel. These are not supported in this"
+                        + " Javacord version and get ignored!");
+                break;
             default:
-                LoggerUtil.getLogger(ChannelUpdateHandler.class).warn("Unexpected packet type. Your Javacord version"
-                        + " might be out of date.");
+                logger.warn("Unknown or unexpected channel type. Your Javacord version might be out of date!");
         }
     }
 


### PR DESCRIPTION
This commit only adds very basic support for the new channel types.
News channels get treated as normal server text channels and store channels get completely ignored.

It also cleans up the switch-statements a little bit by using the enum instead of hard-coding the integer values.

Better support will be added when we get more information from Discord in https://github.com/discordapp/discord-api-docs/issues/881.