### PR TITLE
 Add ratelimiter to allow custom hard-coded global ratelimits

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -27,6 +27,7 @@ import org.javacord.api.entity.user.UserStatus;
 import org.javacord.api.entity.webhook.Webhook;
 import org.javacord.api.listener.GloballyAttachableListenerManager;
 import org.javacord.api.util.concurrent.ThreadPool;
+import org.javacord.api.util.ratelimit.Ratelimiter;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -83,6 +84,13 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
      * @return The type of the current account.
      */
     AccountType getAccountType();
+
+    /**
+     * Gets the current global ratelimiter.
+     *
+     * @return The current global ratelimiter.
+     */
+    Optional<Ratelimiter> getGlobalRatelimiter();
 
     /**
      * Creates an invite link for the this bot.

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
@@ -6,6 +6,8 @@ import org.javacord.api.listener.ChainableGloballyAttachableListenerManager;
 import org.javacord.api.listener.GloballyAttachableListener;
 import org.javacord.api.util.auth.Authenticator;
 import org.javacord.api.util.internal.DelegateFactory;
+import org.javacord.api.util.ratelimit.LocalRatelimiter;
+import org.javacord.api.util.ratelimit.Ratelimiter;
 
 import java.net.Proxy;
 import java.net.ProxySelector;
@@ -69,6 +71,22 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
      */
     public Collection<CompletableFuture<DiscordApi>> loginShards(int... shards) {
         return delegate.loginShards(shards);
+    }
+
+    /**
+     * Sets a ratelimiter that can be used to control global ratelimits.
+     *
+     * <p>By default, no ratelimiter is set, but for large bots or special use-cases, it can be useful to provide
+     * a ratelimiter with a hardcoded ratelimit to prevent hitting the global ratelimit.
+     *
+     * <p>An easy implementation is available with the {@link LocalRatelimiter}.
+     *
+     * @param ratelimiter The ratelimiter used to control global ratelimits.
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder setGlobalRatelimiter(Ratelimiter ratelimiter) {
+        delegate.setGlobalRatelimiter(ratelimiter);
+        return this;
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
@@ -5,6 +5,7 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.DiscordApiBuilder;
 import org.javacord.api.listener.GloballyAttachableListener;
 import org.javacord.api.util.auth.Authenticator;
+import org.javacord.api.util.ratelimit.Ratelimiter;
 
 import java.net.Proxy;
 import java.net.ProxySelector;
@@ -19,6 +20,13 @@ import java.util.function.Supplier;
  * You usually don't want to interact with this object.
  */
 public interface DiscordApiBuilderDelegate {
+
+    /**
+     * Sets a ratelimiter that can be used to control global ratelimits.
+     *
+     * @param ratelimiter The ratelimiter used to control global ratelimits.
+     */
+    void setGlobalRatelimiter(Ratelimiter ratelimiter);
 
     /**
      * Sets the proxy selector which should be used to determine the proxies that should be used to connect to the

--- a/javacord-api/src/main/java/org/javacord/api/util/ratelimit/LocalRatelimiter.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/ratelimit/LocalRatelimiter.java
@@ -1,0 +1,85 @@
+package org.javacord.api.util.ratelimit;
+
+/**
+ * An implementation of {@code Ratelimiter} that allows simple local ratelimits.
+ */
+public class LocalRatelimiter implements Ratelimiter {
+
+    private volatile long nextResetNanos;
+    private volatile int remainingQuota;
+
+    private final int amount;
+    private final int seconds;
+
+    /**
+     * Creates a new local ratelimiter.
+     *
+     * @param amount The amount available per reset interval.
+     * @param seconds The time to wait until the available quota resets.
+     */
+    public LocalRatelimiter(int amount, int seconds) {
+        this.amount = amount;
+        this.seconds = seconds;
+    }
+
+    /**
+     * Gets the amount available per reset interval.
+     *
+     * @return The amount.
+     */
+    public int getAmount() {
+        return amount;
+    }
+
+    /**
+     * Gets the time to wait until the available quota resets in seconds.
+     *
+     * @return The time to wait until the available quota resets.
+     */
+    public int getSeconds() {
+        return seconds;
+    }
+
+    /**
+     * Gets the next time the quota resets.
+     *
+     * <p>Use {@link System#nanoTime()} to calculate the absolute difference.
+     *
+     * @return The next time the quota resets. Can be in the past.
+     */
+    public long getNextResetNanos() {
+        return nextResetNanos;
+    }
+
+    /**
+     * Gets the remaining quota in the current reset interval.
+     *
+     * @return The remaining quota.
+     */
+    public int getRemainingQuota() {
+        return remainingQuota;
+    }
+
+    @Override
+    public synchronized void requestQuota() throws InterruptedException {
+        if (remainingQuota <= 0) {
+            // Wait until a new quota becomes available
+            long sleepTime;
+            while ((sleepTime = calculateSleepTime()) > 0) { // Sleep is unreliable, so we have to loop
+                Thread.sleep(sleepTime);
+            }
+        }
+
+        // Reset the limit when the last reset timestamp is past
+        if (System.nanoTime() > nextResetNanos) {
+            remainingQuota = amount;
+            nextResetNanos = System.nanoTime() + seconds * 1_000_000_000L;
+        }
+
+        remainingQuota--;
+    }
+
+    private long calculateSleepTime() {
+        return (nextResetNanos - System.nanoTime()) / 1_000_000;
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/util/ratelimit/Ratelimiter.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/ratelimit/Ratelimiter.java
@@ -1,0 +1,17 @@
+package org.javacord.api.util.ratelimit;
+
+/**
+ * Can be used to implement ratelimits.
+ */
+public interface Ratelimiter {
+
+    /**
+     * Blocks the requesting thread until a quota becomes available.
+     *
+     * @throws InterruptedException if any thread has interrupted the current thread.
+     *                              The interrupted status of the current thread is cleared when this exception is
+     *                              thrown.
+     */
+    void requestQuota() throws InterruptedException;
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/rest/RestRequest.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/rest/RestRequest.java
@@ -305,6 +305,13 @@ public class RestRequest<T> {
      * @throws Exception If something went wrong while executing the request.
      */
     public RestRequestResult executeBlocking() throws Exception {
+        api.getGlobalRatelimiter().ifPresent(ratelimiter -> {
+            try {
+                ratelimiter.requestQuota();
+            } catch (InterruptedException e) {
+                logger.warn("Encountered unexpected ratelimiter interrupt", e);
+            }
+        });
         Request.Builder requestBuilder = new Request.Builder();
         HttpUrl.Builder httpUrlBuilder = endpoint.getOkHttpUrl(urlParameters).newBuilder();
         queryParameters.forEach(httpUrlBuilder::addQueryParameter);

--- a/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
+++ b/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
@@ -12,11 +12,7 @@ import org.mockserver.configuration.ConfigurationProperties
 import org.mockserver.model.HttpRequest
 import org.mockserver.model.HttpResponse
 import org.mockserver.verify.VerificationTimes
-import spock.lang.IgnoreIf
-import spock.lang.PendingFeature
-import spock.lang.Specification
-import spock.lang.Subject
-import spock.lang.Unroll
+import spock.lang.*
 import spock.util.environment.RestoreSystemProperties
 
 import javax.net.ssl.SSLHandshakeException
@@ -26,7 +22,7 @@ import java.util.concurrent.CompletionException
 class DiscordApiImplTest extends Specification {
 
     @Subject
-    def api = new DiscordApiImpl(null, null, null, null, false)
+    def api = new DiscordApiImpl(null, null, null, null, null, false)
 
     def 'getAllServers returns all servers'() {
         given:
@@ -104,7 +100,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setHttpSystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, false)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, false)
 
         when:
             api.applicationInfo.join()
@@ -121,7 +117,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setHttpSystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -137,7 +133,7 @@ class DiscordApiImplTest extends Specification {
 
     def 'allowing man-in-the-middle attacks logs a warning on api instantiation'() {
         when:
-            new DiscordApiImpl('fakeBotToken', null, null, null, true)
+            new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
 
         then:
             def expectedWarning = 'All SSL certificates are trusted when connecting to the Discord API and websocket.' +
@@ -154,7 +150,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setHttpSystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -175,7 +171,7 @@ class DiscordApiImplTest extends Specification {
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             def defaultProxySelector = ProxySelector.default
             ProxySelector.default = MockProxyManager.proxySelector
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -197,7 +193,7 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.mockProxy.when(
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
-            def api = new DiscordApiImpl('fakeBotToken', null, MockProxyManager.httpProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.httpProxy, null, true)
 
         when:
             api.applicationInfo.join()
@@ -213,7 +209,7 @@ class DiscordApiImplTest extends Specification {
 
     def 'configuring proxy and proxySelector throws an IllegalStateException'() {
         when:
-            new DiscordApiImpl('fakeBotToken', Stub(ProxySelector), Proxy.NO_PROXY, null, true)
+            new DiscordApiImpl('fakeBotToken', null, Stub(ProxySelector), Proxy.NO_PROXY, null, true)
 
         then:
             IllegalStateException ise = thrown()
@@ -225,7 +221,7 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.mockProxy.when(
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
-            def api = new DiscordApiImpl('fakeBotToken', MockProxyManager.proxySelector, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, MockProxyManager.proxySelector, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -257,7 +253,7 @@ class DiscordApiImplTest extends Specification {
             Authenticator.default = Mock(Authenticator) {
                 (1.._) * getPasswordAuthentication() >> new PasswordAuthentication(username, password as char[])
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, MockProxyManager.httpProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.httpProxy, null, true)
 
         when:
             api.applicationInfo.join()
@@ -292,7 +288,7 @@ class DiscordApiImplTest extends Specification {
             org.javacord.api.util.auth.Authenticator authenticator = Mock {
                 (1.._) * authenticate(_, _, _) >> [(HttpHeaderNames.PROXY_AUTHORIZATION as String): [null, credentials]]
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, MockProxyManager.httpProxy, authenticator, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.httpProxy, authenticator, true)
 
         when:
             api.applicationInfo.join()
@@ -324,8 +320,8 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.setSocks4SystemProperties()
 
         and:
-            def api = new DiscordApiImpl(AccountType.BOT, 'fakeBotToken', 0, 1, false, null, null, null, true, null,
-                    { [InetAddress.getLoopbackAddress()] })
+            def api = new DiscordApiImpl(AccountType.BOT, 'fakeBotToken', 0, 1, false, null, null, null, null, true,
+                    null, { [InetAddress.getLoopbackAddress()] })
 
         when:
             api.applicationInfo.join()
@@ -354,7 +350,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setSocks5SystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -382,7 +378,7 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.mockProxy.when(
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
-            def api = new DiscordApiImpl('fakeBotToken', null, MockProxyManager.socksProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.socksProxy, null, true)
 
         and:
             def username = UUID.randomUUID().toString()
@@ -432,7 +428,7 @@ class DiscordApiImplTest extends Specification {
                 void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
                 }
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, MockProxyManager.httpProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.httpProxy, null, true)
 
         when:
             api.applicationInfo.join()
@@ -470,7 +466,7 @@ class DiscordApiImplTest extends Specification {
                 void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
                 }
             }
-            def api = new DiscordApiImpl('fakeBotToken', MockProxyManager.proxySelector, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, MockProxyManager.proxySelector, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -497,7 +493,7 @@ class DiscordApiImplTest extends Specification {
             System.properties.'https.proxyPort' = '1'
             def defaultProxySelector = ProxySelector.default
             ProxySelector.default = MockProxyManager.proxySelector
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -536,7 +532,7 @@ class DiscordApiImplTest extends Specification {
             org.javacord.api.util.auth.Authenticator authenticator = Mock {
                 (1.._) * authenticate(_, _, _) >> [(HttpHeaderNames.PROXY_AUTHORIZATION as String): [null, credentials]]
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, MockProxyManager.httpProxy, authenticator, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.httpProxy, authenticator, true)
 
         when:
             api.applicationInfo.join()


### PR DESCRIPTION
On larger bots, it is possible to hit the global ratelimit of 50/1. Preventing to hit this global ratelimit is not possible with just the ratelimit HTTP-headers that we receive from Discord, but only with hard-coded limits. As the limits could change over-time (and there might even some increased limits for large bots?) it's no option to hard-code them directly into the Javacord code.

This PR allows users to set their own ratelimits in the `DiscordApiBuilder`. A default implementation is available for local ratelimits that allows users to set a hard-coded limit. It is possible to write custom implementations that allow more complex ratelimiters that can for example share their state across multiple machines.

The code can be used like this:
```java
DiscordApi api = new DiscordApiBuilder()
        .setGlobalRatelimiter(new LocalRatelimiter(50, 1)) // 50/1 ratelimit
        .setToken("<token>")
        .login()
        .join();
```