### PR TITLE
Fix custom emoji comparison

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/emoji/Emoji.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/emoji/Emoji.java
@@ -52,7 +52,7 @@ public interface Emoji extends Mentionable, Specializable<Emoji> {
         }
         // Both are custom emojis, so we have to compare the id
         long thisId = asCustomEmoji().map(CustomEmoji::getId).orElseThrow(AssertionError::new);
-        long otherId = asCustomEmoji().map(CustomEmoji::getId).orElseThrow(AssertionError::new);
+        long otherId = otherEmoji.asCustomEmoji().map(CustomEmoji::getId).orElseThrow(AssertionError::new);
         return thisId == otherId;
     }
 

--- a/javacord-core/src/test/groovy/org/javacord/core/entity/emoji/CustomEmojiImplTest.groovy
+++ b/javacord-core/src/test/groovy/org/javacord/core/entity/emoji/CustomEmojiImplTest.groovy
@@ -1,0 +1,15 @@
+package org.javacord.core.entity.emoji
+
+import org.javacord.api.entity.emoji.CustomEmoji
+import spock.lang.Specification
+
+class CustomEmojiImplTest extends Specification {
+    def "equalsEmoji returns false for different custom emojis"() {
+        setup:
+            CustomEmoji one = new CustomEmojiImpl(null, 1, "one", false)
+            CustomEmoji two = new CustomEmojiImpl(null, 2, "two", false)
+
+        expect:
+            !one.equalsEmoji(two)
+    }
+}


### PR DESCRIPTION
Due to this bug, if you for example add two custom reactions to a message you will only find the first one at the Javacord message object, as they are considered equal.