### PR TITLE
 Add support for resuming the audio websocket

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/VoiceGatewayOpcode.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/VoiceGatewayOpcode.java
@@ -64,6 +64,11 @@ public enum VoiceGatewayOpcode {
     RESUMED(9),
 
     /**
+     * a client connected to the voice channel.
+     */
+    CLIENT_CONNECT(12),
+
+    /**
      * a client has disconnected from the voice channel.
      */
     CLIENT_DISCONNECT(13);


### PR DESCRIPTION
This PR only adds support for resumes. When a full reconnect is required, it will not be able establish a connection and is stuck in an infinite loop of failing reconnect attempts. This will be fixed in an upcoming PR.