### PR TITLE
Role performance & synchronization enhancements

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
@@ -64,6 +64,14 @@ public interface Role extends DiscordEntity, Mentionable, Nameable, Permissionab
     Collection<User> getUsers();
 
     /**
+     * Checks whether the specified users has this role.
+     *
+     * @param user the user to check
+     * @return true if the user has this role; false otherwise
+     */
+    boolean hasUser(User user);
+
+    /**
      * Gets the permissions of the role.
      *
      * @return The permissions of the role.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -510,7 +510,7 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     default List<Role> getRoles(User user) {
         return Collections.unmodifiableList(
                 getRoles().stream()
-                        .filter(role -> role.getUsers().contains(user))
+                        .filter(role -> role.hasUser(user))
                         .collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
This PRs fixes some bugs I encountered:

- `RoleImpl#getUsers` does now create a defensive copy (before, it only wrapped it into a unmodifiable view)
- Synchronize access to the `users` hashset of `RoleImpl` using a `ReentrantReadWriteLock` as it caused frequent `ConcurrentModificationException`s for me because there was a change to the set while creating a defensive copy

This PR also aims to further improve the internal handling related to `RoleImpl`, so I added a convenience method `RoleImpl#hasUser` (also added to the public interface) that allows to check whether an user has a role without first creating a defensive copy. 

Additionally, I changed `Server#getRoles(User user)` to use that method instead of using `contains()` to increase performance.