### PR TITLE
Remove unnecessary shard-id based reconnect waiting time

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -444,7 +444,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
         this.proxyAuthenticator = proxyAuthenticator;
         this.trustAllCertificates = trustAllCertificates;
         this.reconnectDelayProvider = x ->
-                (int) Math.round(Math.pow(x, 1.5) - (1 / (1 / (0.1 * x) + 1)) * Math.pow(x, 1.5)) + (currentShard * 6);
+                (int) Math.round(Math.pow(x, 1.5) - (1 / (1 / (0.1 * x) + 1)) * Math.pow(x, 1.5));
 
         if ((proxySelector != null) && (proxy != null)) {
             throw new IllegalStateException("proxy and proxySelector must not be configured both");


### PR DESCRIPTION
This PR removes the addtional reconnect wait time per shard ( `+ (currentShard * 6)` ) in the default `reconnectDelayProvider` as it is not necessary.

The goal of it was to delay the reconnect of each shard by 6 seconds if all websockets disconnect simultaneously to prevent hitting the identify ratelimit. However, this causes inconvenient delays if only a single shard with a large shard ID disconnects, e.g. shard 10 - then Javacord is currently waiting 60 unnecessary seconds before even attempting to reconnect.

`+ (currentShard * 6)`  can be removed as `DiscordWebSocketAdapter` prevents hitting the identify rate limit using a Semaphore anyways. Relevant code:

DiscordWebSocketAdapter.java L391
```java
            waitForIdentifyRateLimit(); //Javacord ensures to not hit the limit BEFORE (re)connecting
            websocket.connect();
```

The `waitForIdentifyRateLimit()` method prevents that more than one connect attempt per 5100ms can happen on the same token.

DiscordWebSocketAdapter.java L413
```java
    /**
     * Identification is rate limited to once every 5 seconds,
     * so don't try to more often per account, even in different instances.
     * This method waits for the identification rate limit to be over, then returns.
     */
    private void waitForIdentifyRateLimit() {
        String token = api.getPrefixedToken();
        connectionDelaySemaphorePerAccount.computeIfAbsent(token, key -> new Semaphore(1)).acquireUninterruptibly();
        for (long delay = 5100 - (System.currentTimeMillis() - lastIdentificationPerAccount.getOrDefault(token, 0L));
                delay > 0;
                delay = 5100 - (System.currentTimeMillis() - lastIdentificationPerAccount.getOrDefault(token, 0L))) {
            logger.debug("Delaying connecting by {}ms", delay);
            try {
                Thread.sleep(delay);
            } catch (InterruptedException ignored) { }
        }
    }
```

Thus, we can safely remove the additional waiting time included in the default `reconnectDelayProvider`.