### PR TITLE
Fix speaking update logic, send false speaking update on ready packet

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/audio/AudioConnectionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/audio/AudioConnectionImpl.java
@@ -210,6 +210,15 @@ public class AudioConnectionImpl implements AudioConnection, InternalAudioConnec
     }
 
     /**
+     * Sets the current speaking mode.
+     *
+     * @param speaking The speaking mode to set
+     */
+    public void setSpeaking(boolean speaking) {
+        websocketAdapter.sendSpeaking(speaking);
+    }
+
+    /**
      * Tries to establish a connection if all required information is available and there's not already a connection.
      *
      * @return Whether it will try to connect or not.

--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/AudioUdpSocket.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/AudioUdpSocket.java
@@ -109,6 +109,7 @@ public class AudioUdpSocket {
             try {
                 long nextFrameTimestamp = System.nanoTime();
                 boolean dontSleep = true;
+                boolean speaking = false;
                 long framesOfSilenceToPlay = 5;
                 while (shouldSend) {
                     // Get the current audio source. If none is available, it will block the thread
@@ -141,10 +142,18 @@ public class AudioUdpSocket {
                     }
 
                     if (frame != null || framesOfSilenceToPlay > 0) {
+                        if (!speaking) {
+                            speaking = true;
+                            connection.setSpeaking(true);
+                        }
                         packet = new AudioPacket(frame, ssrc, sequence, ((int) sequence) * 960);
                         // We can stop sending frames of silence after 5 frames
                         if (frame == null) {
                             framesOfSilenceToPlay--;
+                            if (framesOfSilenceToPlay == 0) {
+                                speaking = false;
+                                connection.setSpeaking(false);
+                            }
                         } else {
                             framesOfSilenceToPlay = 5;
                         }

--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/AudioWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/AudioWebSocketAdapter.java
@@ -118,7 +118,7 @@ public class AudioWebSocketAdapter extends WebSocketAdapter {
                 sendSelectProtocol(websocket);
 
                 // TODO remove
-                sendSpeaking(websocket, true);
+                sendSpeaking(websocket, false);
                 Thread.sleep(1000);
                 break;
             case SESSION_DESCRIPTION:
@@ -332,7 +332,7 @@ public class AudioWebSocketAdapter extends WebSocketAdapter {
     }
 
     /**
-     * Sends the identify packet.
+     * Sends the speaking packet.
      *
      * @param websocket The websocket the packet should be sent to.
      * @param speaking Whether speaking should be displayed or not.
@@ -342,11 +342,20 @@ public class AudioWebSocketAdapter extends WebSocketAdapter {
         speakingPacket
                 .put("op", VoiceGatewayOpcode.SPEAKING.getCode())
                 .putObject("d")
-                .put("speaking", 1)
+                .put("speaking", speaking ? 1 : 0)
                 .put("delay", 0)
                 .put("ssrc", ssrc);
         logger.debug("Sending speaking packet for {} (packet: {})", connection, speakingPacket);
         WebSocketFrame speakingFrame = WebSocketFrame.createTextFrame(speakingPacket.toString());
         websocket.sendFrame(speakingFrame);
+    }
+
+    /**
+     * Sends the speaking packet.
+     *
+     * @param speaking Whether speaking should be displayed or not.
+     */
+    public void sendSpeaking(boolean speaking) {
+        sendSpeaking(websocket.get(), speaking);
     }
 }


### PR DESCRIPTION
This fixes speaking updates always being sent as 1 (speaking), also fixes the speaking indicator being stuck on at connect.
This is a basic fix and I plan to submit another PR implementing speaking flags properly