### PR TITLE
Implement priority speaker

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/audio/AudioConnection.java
+++ b/javacord-api/src/main/java/org/javacord/api/audio/AudioConnection.java
@@ -4,6 +4,7 @@ import org.javacord.api.entity.channel.ServerVoiceChannel;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.listener.audio.AudioConnectionAttachableListenerManager;
 
+import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -136,6 +137,27 @@ public interface AudioConnection extends AudioConnectionAttachableListenerManage
      * @param deafened Whether or not to self-deafen this connection.
      */
     void setSelfDeafened(boolean deafened);
+
+    /**
+     * Gets the priority speaker status of this connection.
+     *
+     * @return Whether or not the connection is priority speaking.
+     */
+    boolean isPrioritySpeaking();
+
+    /**
+     * Sets the priority speaker status of this connection.
+     *
+     * @param prioritySpeaking Whether or not to become a priority speaker.
+     */
+    void setPrioritySpeaking(boolean prioritySpeaking);
+
+    /**
+     * Gets the speaking flags of this connection.
+     *
+     * @return The current speaking flags of this connection.
+     */
+    EnumSet<SpeakingFlag> getSpeakingFlags();
 
     /**
      * Gets the server of the audio connection.

--- a/javacord-api/src/main/java/org/javacord/api/audio/SpeakingFlag.java
+++ b/javacord-api/src/main/java/org/javacord/api/audio/SpeakingFlag.java
@@ -1,0 +1,39 @@
+package org.javacord.api.audio;
+
+public enum SpeakingFlag {
+
+    /**
+     * The speaking flag. This flag indicates whether a client is or is not sending audio.
+     */
+    SPEAKING(1),
+
+    /**
+     * The soundshare flag. This flag is used for sending audio while sharing screens. Not useful to bot accounts.
+     */
+    SOUNDSHARE(2),
+
+    /**
+     * The priority speaker flag. This flag is used for sending audio as a priority speaker (Louder than other clients).
+     */
+    PRIORITY_SPEAKER(4);
+
+    private int flag;
+
+    /**
+     * Creates a new SpeakingFlag.
+     *
+     * @param flag The integer value of the flag.
+     */
+    SpeakingFlag(int flag) {
+        this.flag = flag;
+    }
+
+    /**
+     * Gets the integer value of the flag.
+     *
+     * @return The integer value of the flag.
+     */
+    public int asInt() {
+        return flag;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/AudioUdpSocket.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/AudioUdpSocket.java
@@ -142,7 +142,7 @@ public class AudioUdpSocket {
                     }
 
                     if (frame != null || framesOfSilenceToPlay > 0) {
-                        if (!speaking) {
+                        if (!speaking && frame != null) {
                             speaking = true;
                             connection.setSpeaking(true);
                         }


### PR DESCRIPTION
This PR implements priority speaker for audio connections and adds some basis for other speaking flags (i.e. soundshare which is not currently useful to bots)