### PR TITLE
Implement Voice State/Server Update events

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/event/server/VoiceServerUpdateEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/server/VoiceServerUpdateEvent.java
@@ -1,0 +1,19 @@
+package org.javacord.api.event.server;
+
+public interface VoiceServerUpdateEvent extends ServerEvent {
+
+    /**
+     * Gets the voice token provided in this voice server update.
+     *
+     * @return The voice token.
+     */
+    String getToken();
+
+    /**
+     * Gets the endpoint provided in this voice server update.
+     *
+     * @return The endpoint.
+     */
+    String getEndpoint();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/event/server/VoiceStateUpdateEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/server/VoiceStateUpdateEvent.java
@@ -1,0 +1,18 @@
+package org.javacord.api.event.server;
+
+import org.javacord.api.event.channel.server.voice.ServerVoiceChannelEvent;
+
+/**
+ * A voice state update event.
+ * Provided only for the current logged in user.
+ */
+public interface VoiceStateUpdateEvent extends ServerVoiceChannelEvent {
+
+    /**
+     * Gets the session id provided in this event.
+     *
+     * @return The session id.
+     */
+    String getSessionId();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/server/VoiceServerUpdateListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/server/VoiceServerUpdateListener.java
@@ -1,0 +1,21 @@
+package org.javacord.api.listener.server;
+
+import org.javacord.api.event.server.VoiceServerUpdateEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+
+/**
+ * This listener listens to voice server updates.
+ */
+@FunctionalInterface
+public interface VoiceServerUpdateListener extends ServerAttachableListener,
+        GloballyAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called every time a voice server update packet is received.
+     *
+     * @param event the event.
+     */
+    void onVoiceServerUpdate(VoiceServerUpdateEvent event);
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/server/VoiceStateUpdateListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/server/VoiceStateUpdateListener.java
@@ -1,0 +1,22 @@
+package org.javacord.api.listener.server;
+
+import org.javacord.api.event.server.VoiceStateUpdateEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.channel.server.ServerChannelAttachableListener;
+
+/**
+ * This listener listens to voice state updates for the current user.
+ */
+@FunctionalInterface
+public interface VoiceStateUpdateListener extends ServerChannelAttachableListener,
+        GloballyAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called every time a voice state update packet is received for the current user.
+     *
+     * @param event The event.
+     */
+    void onVoiceStateUpdate(VoiceStateUpdateEvent event);
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/event/server/VoiceServerUpdateEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/server/VoiceServerUpdateEventImpl.java
@@ -1,0 +1,33 @@
+package org.javacord.core.event.server;
+
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.event.server.VoiceServerUpdateEvent;
+
+public class VoiceServerUpdateEventImpl extends ServerEventImpl implements VoiceServerUpdateEvent {
+
+    private String token;
+    private String endpoint;
+
+    /**
+     * Constructs a new VoiceStateUpdateEventImpl instance.
+     *
+     * @param server   The server this voice server update is for.
+     * @param token    The token provided in this update.
+     * @param endpoint The endpoint provided in this update.
+     */
+    public VoiceServerUpdateEventImpl(Server server, String token, String endpoint) {
+        super(server);
+        this.token = token;
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public String getToken() {
+        return token;
+    }
+
+    @Override
+    public String getEndpoint() {
+        return endpoint;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/event/server/VoiceStateUpdateEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/server/VoiceStateUpdateEventImpl.java
@@ -1,0 +1,27 @@
+package org.javacord.core.event.server;
+
+import org.javacord.api.entity.channel.ServerVoiceChannel;
+import org.javacord.api.event.server.VoiceStateUpdateEvent;
+import org.javacord.core.event.channel.server.voice.ServerVoiceChannelEventImpl;
+
+public class VoiceStateUpdateEventImpl extends ServerVoiceChannelEventImpl implements VoiceStateUpdateEvent {
+
+    private final String sessionId;
+
+    /**
+     * Constructs a new VoiceStateUpdateEventImpl instance.
+     *
+     * @param channel   The channel this voice server update is for.
+     * @param sessionId The session id for this user.
+     */
+    public VoiceStateUpdateEventImpl(ServerVoiceChannel channel, String sessionId) {
+        super(channel);
+        this.sessionId = sessionId;
+    }
+
+    @Override
+    public String getSessionId() {
+        return sessionId;
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/guild/VoiceServerUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/guild/VoiceServerUpdateHandler.java
@@ -2,7 +2,10 @@ package org.javacord.core.util.handler.guild;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.javacord.api.DiscordApi;
+import org.javacord.api.event.server.VoiceServerUpdateEvent;
 import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.event.server.VoiceServerUpdateEventImpl;
+import org.javacord.core.util.event.DispatchQueueSelector;
 import org.javacord.core.util.gateway.PacketHandler;
 
 /**
@@ -26,13 +29,15 @@ public class VoiceServerUpdateHandler extends PacketHandler {
         long serverId = packet.get("guild_id").asLong();
 
         // We need the session id to connect to an audio websocket
-        api.getServerById(serverId)
-                .map(ServerImpl.class::cast)
-                .flatMap(ServerImpl::getPendingAudioConnection)
-                .ifPresent(connection -> {
-                    connection.setToken(token);
-                    connection.setEndpoint(endpoint);
-                    connection.tryConnect();
-                });
+        api.getServerById(serverId).ifPresent(server -> {
+            ((ServerImpl) server).getPendingAudioConnection()
+                    .ifPresent(connection -> {
+                        connection.setToken(token);
+                        connection.setEndpoint(endpoint);
+                        connection.tryConnect();
+                    });
+            VoiceServerUpdateEvent event = new VoiceServerUpdateEventImpl(server, token, endpoint);
+            api.getEventDispatcher().dispatchVoiceServerUpdateEvent((DispatchQueueSelector) server, server, event);
+        });
     }
 }


### PR DESCRIPTION
This PR adds voice state and server updates as events, which enables support for [Lavalink](https://github.com/Frederikam/Lavalink)
I opted to only dispatch voice state update events for the current user as those are the updates required by lavalink, updates for other users are already covered by other events.