### PR TITLE
Fix error due to animated field on emojis being optional now.

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/emoji/CustomEmojiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/emoji/CustomEmojiImpl.java
@@ -53,8 +53,11 @@ public class CustomEmojiImpl implements CustomEmoji {
     public CustomEmojiImpl(DiscordApiImpl api, JsonNode data) {
         this.api = api;
         id = data.get("id").asLong();
-        name = data.get("name").asText();
-        animated = data.get("animated").asBoolean();
+        JsonNode nameNode = data.get("name");
+        name = nameNode == null ? "" : nameNode.asText();
+        // Animated field may be missing, default to false
+        JsonNode animatedNode = data.get("animated");
+        animated = animatedNode != null && animatedNode.asBoolean();
     }
 
     /**


### PR DESCRIPTION
Reported by Discord user Ayu. Also, according to our starchy intelligence operatives, `name` got made nullable as well so for that I chose to default to empty string just to prevent breakages.
If the change can be confirmed we should change the interfaces to make `getName()` return an `Optional<String>` or pick a more meaningful default name if it's just an edge case.

```2019-11-18 18:50:27.699-0600 WARN org.javacord.core.util.gateway.PacketHandler Couldn't handle packet of type MESSAGE_REACTION_ADD. Please contact the developer! (packet: {"user_id":"557379901993385994","message_id":"557750770527633439","emoji":{"name":"NA","id":"634289826941763594"},"channel_id":"556239792061415427","guild_id":"417825368062558219"}) {shard=0}
 java.lang.NullPointerException
    at org.javacord.core.entity.emoji.CustomEmojiImpl.<init>(CustomEmojiImpl.java:57)
    at org.javacord.core.DiscordApiImpl.getKnownCustomEmojiOrCreateCustomEmoji(DiscordApiImpl.java:827)
    at org.javacord.core.util.handler.message.reaction.MessageReactionAddHandler.lambda$handle$1(MessageReactionAddHandler.java:45)
    at java.util.Optional.ifPresent(Optional.java:159)
    at org.javacord.core.util.handler.message.reaction.MessageReactionAddHandler.handle(MessageReactionAddHandler.java:35)
    at org.javacord.core.util.gateway.PacketHandler.lambda$handlePacket$0(PacketHandler.java:51)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```