### PR TITLE
Add Europe and India voice region

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/Region.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/Region.java
@@ -8,6 +8,7 @@ public enum Region implements Nameable {
     // "Normal" regions
     AMSTERDAM("amsterdam", "Amsterdam", false),
     BRAZIL("brazil", "Brazil", false),
+    EUROPE("europe", "Europe", false),
     EU_WEST("eu-west", "EU West", false),
     EU_CENTRAL("eu-central", "EU Central", false),
     FRANKFURT("frankfurt", "Frankfurt", false),
@@ -15,6 +16,7 @@ public enum Region implements Nameable {
     JAPAN("japan", "Japan", false),
     LONDON("london", "London", false),
     RUSSIA("russia", "Russia", false),
+    INDIA("india", "India", false),
     SINGAPORE("singapore", "Singapore", false),
     SYDNEY("sydney", "Sydney", false),
     US_EAST("us-east", "US East", false),


### PR DESCRIPTION
Adds the two new voice regions "Europe" and "India".
You can no longer select "EU West" or "EU Central" in the UI, but they still exist (e.g. for older servers).
![image](https://user-images.githubusercontent.com/5033001/69437645-ff92c480-0d43-11ea-9460-58f3ce364122.png)
![image](https://user-images.githubusercontent.com/5033001/69437613-f3a70280-0d43-11ea-9410-9e816f3b5982.png)

Closes #505