### PR TITLE
Convenience method for EmbedThumbnail image downloading.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedAuthor.java
@@ -1,9 +1,14 @@
 package org.javacord.api.entity.message.embed;
 
+import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.Nameable;
 
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * This interface represents an embed author.
@@ -30,5 +35,30 @@ public interface EmbedAuthor extends Nameable {
      * @return The proxy url of the author icon.
      */
     Optional<URL> getProxyIconUrl();
+
+    /**
+     * Downloads the author icon as a {@code BufferedImage}.
+     *
+     * @param api The discord api instance used to download the author icon.
+     * @return The thumbnail as a {@code BufferedImage}.
+     */
+    Optional<CompletableFuture<BufferedImage>> downloadIconAsBufferedImage(DiscordApi api);
+
+    /**
+     * Downloads the author icon as a byte array.
+     *
+     * @param api The discord api instance used to download the author icon.
+     * @return The thumbnail as a byte array.
+     */
+    Optional<CompletableFuture<byte[]>> downloadIconAsByteArray(DiscordApi api);
+
+    /**
+     * Downloads the author icon as an input stream.
+     *
+     * @param api The discord api instance used to download the author icon.
+     * @return The thumbnail as a input stream.
+     * @throws IOException If an IO error occurs.
+     */
+    Optional<InputStream> downloadIconAsInputStream(DiscordApi api) throws IOException;
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedImage.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedImage.java
@@ -1,6 +1,12 @@
 package org.javacord.api.entity.message.embed;
 
+import org.javacord.api.DiscordApi;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * This interface represents an embed image.
@@ -34,5 +40,30 @@ public interface EmbedImage {
      * @return The width of the image.
      */
     int getWidth();
+
+    /**
+     * Downloads the image as a {@code BufferedImage}.
+     *
+     * @param api The discord api instance used to download the image.
+     * @return The thumbnail as a {@code BufferedImage}.
+     */
+    CompletableFuture<BufferedImage> downloadAsBufferedImage(DiscordApi api);
+
+    /**
+     * Downloads the image as a byte array.
+     *
+     * @param api The discord api instance used to download the image.
+     * @return The thumbnail as a byte array.
+     */
+    CompletableFuture<byte[]> downloadAsByteArray(DiscordApi api);
+
+    /**
+     * Downloads the image as an input stream.
+     *
+     * @param api The discord api instance used to download the image.
+     * @return The thumbnail as a input stream.
+     * @throws IOException If an IO error occurs.
+     */
+    InputStream downloadAsInputStream(DiscordApi api) throws IOException;
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedThumbnail.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedThumbnail.java
@@ -1,6 +1,12 @@
 package org.javacord.api.entity.message.embed;
 
+import org.javacord.api.DiscordApi;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * This interface represents an embed thumbnail.
@@ -34,5 +40,30 @@ public interface EmbedThumbnail {
      * @return The width of the thumbnail.
      */
     int getWidth();
+
+    /**
+     * Downloads the thumbnail as a {@code BufferedImage}.
+     * 
+     * @param api The discord api instance used to download the thumbnail.
+     * @return The thumbnail as a {@code BufferedImage}.
+     */
+    CompletableFuture<BufferedImage> downloadAsBufferedImage(DiscordApi api);
+
+    /**
+     * Downloads the thumbnail as a byte array.
+     *
+     * @param api The discord api instance used to download the thumbnail.
+     * @return The thumbnail as a byte array.
+     */
+    CompletableFuture<byte[]> downloadAsByteArray(DiscordApi api);
+
+    /**
+     * Downloads the thumbnail as an input stream.
+     *
+     * @param api The discord api instance used to download the thumbnail.
+     * @return The thumbnail as a input stream.
+     * @throws IOException If an IO error occurs.
+     */
+    InputStream downloadAsInputStream(DiscordApi api) throws IOException;
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedAuthorImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedAuthorImpl.java
@@ -2,12 +2,19 @@ package org.javacord.core.entity.message.embed;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.Logger;
+import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.message.embed.EmbedAuthor;
+import org.javacord.core.util.FileContainer;
 import org.javacord.core.util.logging.LoggerUtil;
 
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The implementation of {@link EmbedAuthor}.
@@ -79,6 +86,25 @@ public class EmbedAuthorImpl implements EmbedAuthor {
             logger.warn("Seems like the embed author's proxy icon url is malformed! Please contact the developer!", e);
             return Optional.empty();
         }
+    }
+
+    @Override
+    public Optional<CompletableFuture<BufferedImage>> downloadIconAsBufferedImage(DiscordApi api) {
+        return getIconUrl().map(url -> new FileContainer(url).asBufferedImage(api));
+    }
+
+    @Override
+    public Optional<CompletableFuture<byte[]>> downloadIconAsByteArray(DiscordApi api) {
+        return getIconUrl().map(url -> new FileContainer(url).asByteArray(api));
+    }
+
+    @Override
+    public Optional<InputStream> downloadIconAsInputStream(DiscordApi api) throws IOException {
+        URL iconUrl = getIconUrl().orElse(null);
+        if (iconUrl == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new FileContainer(iconUrl).asInputStream(api));
     }
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedImageImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedImageImpl.java
@@ -2,11 +2,17 @@ package org.javacord.core.entity.message.embed;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.Logger;
+import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.message.embed.EmbedImage;
+import org.javacord.core.util.FileContainer;
 import org.javacord.core.util.logging.LoggerUtil;
 
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The implementation of {@link EmbedImage}.
@@ -69,6 +75,21 @@ public class EmbedImageImpl implements EmbedImage {
     @Override
     public int getWidth() {
         return width;
+    }
+
+    @Override
+    public CompletableFuture<BufferedImage> downloadAsBufferedImage(DiscordApi api) {
+        return new FileContainer(getUrl()).asBufferedImage(api);
+    }
+
+    @Override
+    public CompletableFuture<byte[]> downloadAsByteArray(DiscordApi api) {
+        return new FileContainer(getUrl()).asByteArray(api);
+    }
+
+    @Override
+    public InputStream downloadAsInputStream(DiscordApi api) throws IOException {
+        return new FileContainer(getUrl()).asInputStream(api);
     }
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedThumbnailImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedThumbnailImpl.java
@@ -2,11 +2,17 @@ package org.javacord.core.entity.message.embed;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.Logger;
+import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.message.embed.EmbedThumbnail;
+import org.javacord.core.util.FileContainer;
 import org.javacord.core.util.logging.LoggerUtil;
 
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The implementation of {@link EmbedThumbnail}.
@@ -70,5 +76,19 @@ public class EmbedThumbnailImpl implements EmbedThumbnail {
     public int getWidth() {
         return width;
     }
+    
+    @Override
+    public CompletableFuture<BufferedImage> downloadAsBufferedImage(DiscordApi api) {
+        return new FileContainer(getUrl()).asBufferedImage(api);
+    }
 
+    @Override
+    public CompletableFuture<byte[]> downloadAsByteArray(DiscordApi api) {
+        return new FileContainer(getUrl()).asByteArray(api);
+    }
+
+    @Override
+    public InputStream downloadAsInputStream(DiscordApi api) throws IOException {
+        return new FileContainer(getUrl()).asInputStream(api);
+    }
 }


### PR DESCRIPTION
This pull request is about the convenience method i would like to add to the EmbedThumbnail class.
The method functions similarly to the method MessageAttachment#downloadAsImage().

This does not need any major API or source changes.

Thanks in advance.