### PR TITLE
Bugfix for getMemberByDiscriminatedName()

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -355,7 +355,8 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      */
     default Optional<User> getMemberByDiscriminatedName(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
-        return (nameAndDiscriminator.length < 2) ? Optional.empty() : getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]);
+        return (nameAndDiscriminator.length > 2) ? 
+            getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
     }
 
     /**
@@ -367,7 +368,8 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      */
     default Optional<User> getMemberByDiscriminatedNameIgnoreCase(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
-        return (nameAndDiscriminator.length < 2) ? Optional.empty() : getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]);
+        return (nameAndDiscriminator.length > 2) ? 
+            getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -367,7 +367,7 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      */
     default Optional<User> getMemberByDiscriminatedNameIgnoreCase(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
-        return getMemberByNameAndDiscriminatorIgnoreCase(nameAndDiscriminator[0], nameAndDiscriminator[1]);
+        return (nameAndDiscriminator.length < 2) ? Optional.empty() : getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -355,7 +355,7 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      */
     default Optional<User> getMemberByDiscriminatedName(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
-        return getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]);
+        return (nameAndDiscriminator.length < 2) ? Optional.empty() : getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -355,8 +355,8 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      */
     default Optional<User> getMemberByDiscriminatedName(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
-        return (nameAndDiscriminator.length > 1) ? 
-            getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
+        return (nameAndDiscriminator.length > 1) 
+            ? getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
     }
 
     /**
@@ -368,8 +368,8 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      */
     default Optional<User> getMemberByDiscriminatedNameIgnoreCase(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
-        return (nameAndDiscriminator.length > 1) ? 
-            getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
+        return (nameAndDiscriminator.length > 1) 
+            ? getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -369,7 +369,7 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     default Optional<User> getMemberByDiscriminatedNameIgnoreCase(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
         return (nameAndDiscriminator.length > 1) 
-            ? getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
+            ? getMemberByDiscriminatedNameIgnoreCase(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -355,7 +355,7 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      */
     default Optional<User> getMemberByDiscriminatedName(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
-        return (nameAndDiscriminator.length > 2) ? 
+        return (nameAndDiscriminator.length > 1) ? 
             getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
     }
 
@@ -368,7 +368,7 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      */
     default Optional<User> getMemberByDiscriminatedNameIgnoreCase(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
-        return (nameAndDiscriminator.length > 2) ? 
+        return (nameAndDiscriminator.length > 1) ? 
             getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -356,7 +356,8 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     default Optional<User> getMemberByDiscriminatedName(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
         return (nameAndDiscriminator.length > 1) 
-            ? getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
+            ? getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) 
+            : Optional.empty();
     }
 
     /**
@@ -369,7 +370,8 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     default Optional<User> getMemberByDiscriminatedNameIgnoreCase(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
         return (nameAndDiscriminator.length > 1) 
-            ? getMemberByDiscriminatedNameIgnoreCase(nameAndDiscriminator[0], nameAndDiscriminator[1]) : Optional.empty();
+            ? getMemberByDiscriminatedNameIgnoreCase(nameAndDiscriminator[0], nameAndDiscriminator[1]) 
+            : Optional.empty();
     }
 
     /**


### PR DESCRIPTION
Fixed java.lang.ArrayIndexOutOfBoundsException for getMemberByDiscriminatedName() when there was no # present in the discriminatedName parameter