### PR TITLE
Added method to get reaction tag of custom emoji

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/emoji/CustomEmoji.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/emoji/CustomEmoji.java
@@ -21,9 +21,18 @@ public interface CustomEmoji extends DiscordEntity, Nameable,  Emoji, UpdatableF
      */
     Icon getImage();
 
+    /**
+     * Gets the tag used to add a reaction with the emoji.
+     *
+     * @return The tag used to add a reaction with the emoji.
+     */
+    default String getReactionTag() {
+        return getName() + ":" + getIdAsString();
+    }
+
     @Override
     default String getMentionTag() {
-        return "<" + (isAnimated() ? "a" : "") + ":" + getName() + ":" + getIdAsString() + ">";
+        return "<" + (isAnimated() ? "a" : "") + ":" + getReactionTag() + ">";
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.DiscordEntity;
+import org.javacord.api.entity.emoji.CustomEmoji;
 import org.javacord.api.entity.emoji.Emoji;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.UncachedMessageUtil;
@@ -267,7 +268,7 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
     public CompletableFuture<Void> addReaction(long channelId, long messageId, Emoji emoji) {
         String value = emoji.asUnicodeEmoji().orElseGet(() ->
                 emoji.asCustomEmoji()
-                        .map(e -> e.getName() + ":" + e.getIdAsString())
+                        .map(CustomEmoji::getReactionTag)
                         .orElse("UNKNOWN")
         );
         return new RestRequest<Void>(api, RestMethod.PUT, RestEndpoint.REACTION)
@@ -346,7 +347,7 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
         api.getThreadPool().getExecutorService().submit(() -> {
             try {
                 final String value = emoji.asUnicodeEmoji().orElseGet(() -> emoji.asCustomEmoji()
-                        .map(e -> e.getName() + ":" + e.getIdAsString()).orElse("UNKNOWN"));
+                        .map(CustomEmoji::getReactionTag).orElse("UNKNOWN"));
                 List<User> users = new ArrayList<>();
                 boolean requestMore = true;
                 while (requestMore) {
@@ -390,7 +391,7 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
     @Override
     public CompletableFuture<Void> removeUserReactionByEmoji(long channelId, long messageId, Emoji emoji, User user) {
         String value = emoji.asUnicodeEmoji().orElseGet(() ->
-                emoji.asCustomEmoji().map(e -> e.getName() + ":" + e.getIdAsString()).orElse("UNKNOWN"));
+                emoji.asCustomEmoji().map(CustomEmoji::getReactionTag).orElse("UNKNOWN"));
         return new RestRequest<Void>(api, RestMethod.DELETE, RestEndpoint.REACTION)
                 .setUrlParameters(
                         Long.toUnsignedString(channelId),


### PR DESCRIPTION
This method allows removing some duplicate code and helps users to get the reaction tag of a custom emoji. This is really useful, when trying to add UnicodeEmojis and CustomEmojis in the same line.