### PR TITLE
Support for intents

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -14,6 +14,7 @@ import org.javacord.api.entity.channel.ServerVoiceChannel;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.channel.VoiceChannel;
 import org.javacord.api.entity.emoji.KnownCustomEmoji;
+import org.javacord.api.entity.intent.Intent;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.MessageSet;
 import org.javacord.api.entity.message.UncachedMessageUtil;
@@ -41,6 +42,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -66,6 +68,13 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
      * @return The prefixed, used token.
      */
     String getPrefixedToken();
+
+    /**
+     * Gets the intents used to receive some or all events specified in {@code Intent}.
+     *
+     * @return The intents for the events.
+     */
+    Set<Intent> getIntents();
 
     /**
      * Gets the thread pool which is internally used.

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
@@ -1,5 +1,6 @@
 package org.javacord.api;
 
+import org.javacord.api.entity.intent.Intent;
 import org.javacord.api.event.server.ServerBecomesAvailableEvent;
 import org.javacord.api.internal.DiscordApiBuilderDelegate;
 import org.javacord.api.listener.ChainableGloballyAttachableListenerManager;
@@ -11,11 +12,13 @@ import org.javacord.api.util.ratelimit.Ratelimiter;
 
 import java.net.Proxy;
 import java.net.ProxySelector;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -320,6 +323,72 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
      */
     public boolean isShutdownHookRegistrationEnabled() {
         return delegate.isShutdownHookRegistrationEnabled();
+    }
+
+    /**
+     * Sets intent for the events which should be received.
+     *
+     * @param intents One or more intents from {@link Intent}.
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder setIntents(Intent... intents) {
+        setAllIntentsWhere(intent -> Arrays.asList(intents).contains(intent));
+        return this;
+    }
+
+    /**
+     * Sets all intents.
+     *
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder setAllIntents() {
+        setAllIntentsWhere(intent -> true);
+        return this;
+    }
+
+    /**
+     * Sets all non privileged intents.
+     *
+     * <p>This is the default behavior if no intents are set in the builder.
+     *
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder setAllNonPrivilegedIntents() {
+        setAllIntentsWhere(intent -> !intent.isPrivileged());
+        return this;
+    }
+
+    /**
+     * Sets all intents except the given intents.
+     *
+     * @param intentsToOmit One or more {@code Intent}s which should be omitted.
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder setAllIntentsExcept(Intent... intentsToOmit) {
+        setAllIntentsWhere(intent -> !Arrays.asList(intentsToOmit).contains(intent));
+        return this;
+    }
+
+    /**
+     * Sets all non privileged intents except the given intents.
+     *
+     * @param intentsToOmit One or more {@code Intent}s which should be omitted.
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder setAllNonPrivilegedIntentsExcept(Intent... intentsToOmit) {
+        setAllIntentsWhere(intent -> !intent.isPrivileged() && !Arrays.asList(intentsToOmit).contains(intent));
+        return this;
+    }
+
+    /**
+     * Sets the intents where the given predicate matches.
+     *
+     * @param condition Whether the intent should be added or not.
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder setAllIntentsWhere(Predicate<Intent> condition) {
+        delegate.setAllIntentsWhere(condition);
+        return this;
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/intent/Intent.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/intent/Intent.java
@@ -1,0 +1,214 @@
+package org.javacord.api.entity.intent;
+
+/**
+ * Represents an intent.
+ *
+ * @see <a href="https://discordapp.com/developers/docs/topics/gateway#list-of-intents">Discord docs</a>
+ */
+public enum Intent {
+
+    /**
+     * The following event are received.
+     * <ul>
+     *     <li>GUILD_CREATE</li>
+     *     <li>GUILD_UPDATE</li>
+     *     <li>GUILD_DELETE</li>
+     *     <li>GUILD_ROLE_CREATE</li>
+     *     <li>GUILD_ROLE_UPDATE</li>
+     *     <li>GUILD_ROLE_DELETE</li>
+     *     <li>CHANNEL_CREATE</li>
+     *     <li>CHANNEL_UPDATE</li>
+     *     <li>CHANNEL_DELETE</li>
+     *     <li>CHANNEL_PINS_UPDATE</li>
+     * </ul>
+     */
+    GUILDS(0, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>GUILD_MEMBER_ADD</li>
+     *     <li>GUILD_MEMBER_UPDATE</li>
+     *     <li>GUILD_MEMBER_REMOVE</li>
+     * </ul>
+     *
+     * <p>Note: This is a privileged intent which must be enabled in the bots application page in the Developer portal
+     *
+     * @see <a href="https://discordapp.com/developers/applications">Discord developer portal</a>
+     */
+    GUILD_MEMBERS(1, true),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>GUILD_BAN_ADD</li>
+     *     <li>GUILD_BAN_REMOVE</li>
+     * </ul>
+     */
+    GUILD_BANS(2, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>GUILD_EMOJIS_UPDATE</li>
+     * </ul>
+     */
+    GUILD_EMOJIS(3, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>GUILD_INTEGRATIONS_UPDATE</li>
+     * </ul>
+     */
+    GUILD_INTEGRATIONS(4, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>WEBHOOKS_UPDATE</li>
+     * </ul>
+     */
+    GUILD_WEBHOOKS(5, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>INVITE_CREATE</li>
+     *     <li>INVITE_DELETE</li>
+     * </ul>
+     */
+    GUILD_INVITES(6, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>VOICE_STATE_UPDATE</li>
+     * </ul>
+     */
+    GUILD_VOICE_STATES(7, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>PRESENCE_UPDATE</li>
+     * </ul>
+     *
+     * <p>Note: This is a privileged intent which must be enabled in the bots application page in the Developer portal
+     *
+     * @see <a href="https://discordapp.com/developers/applications">Discord developer portal</a>
+     */
+    GUILD_PRESENCES(8, true),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>MESSAGE_CREATE</li>
+     *     <li>MESSAGE_UPDATE</li>
+     *     <li>MESSAGE_DELETE</li>
+     *     <li>MESSAGE_DELETE_BULK</li>
+     * </ul>
+     */
+    GUILD_MESSAGES(9, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>MESSAGE_REACTION_ADD</li>
+     *     <li>MESSAGE_REACTION_REMOVE</li>
+     *     <li>MESSAGE_REACTION_REMOVE_ALL</li>
+     *     <li>MESSAGE_REACTION_REMOVE_EMOJI</li>
+     * </ul>
+     */
+    GUILD_MESSAGE_REACTIONS(10, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>TYPING_START</li>
+     * </ul>
+     */
+    GUILD_MESSAGE_TYPING(11, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>CHANNEL_CREATE</li>
+     *     <li>MESSAGE_CREATE</li>
+     *     <li>MESSAGE_UPDATE</li>
+     *     <li>MESSAGE_DELETE</li>
+     *     <li>CHANNEL_PINS_UPDATE</li>
+     * </ul>
+     */
+    DIRECT_MESSAGES(12, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>MESSAGE_REACTION_ADD</li>
+     *     <li>MESSAGE_REACTION_REMOVE</li>
+     *     <li>MESSAGE_REACTION_REMOVE_ALL</li>
+     *     <li>MESSAGE_REACTION_REMOVE_EMOJI</li>
+     * </ul>
+     */
+    DIRECT_MESSAGE_REACTIONS(13, false),
+
+    /**
+     * The following events are received.
+     * <ul>
+     *     <li>TYPING_START</li>
+     * </ul>
+     */
+    DIRECT_MESSAGE_TYPING(14, false);
+
+    private final int id;
+
+    private final boolean privileged;
+
+    /**
+     * Class constructor.
+     *
+     * @param id         The id of the intent.
+     * @param privileged Whether the intent is privileged or not.
+     */
+    Intent(int id, boolean privileged) {
+        this.id = id;
+        this.privileged = privileged;
+    }
+
+    /**
+     * Gets the id of the intent.
+     *
+     * @return The id of the intent.
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Check if the intent is privileged.
+     *
+     * <p>Privileged intents are usually related so sensitive data and must manually be enabled
+     * in the <a href="https://discordapp.com/developers/applications">developer portal</a>.
+     *
+     * @return Whether this intent is privileged or not.
+     */
+    public boolean isPrivileged() {
+        return privileged;
+    }
+
+    /**
+     * Gets the bitmask from the given intents.
+     *
+     * @param intents An array of intents.
+     * @return The calculated bitmask.
+     */
+    public static int calculateBitmask(Intent... intents) {
+        int intentCount = 0;
+        for (Intent intentValue : intents) {
+            intentCount += (1 << intentValue.getId());
+        }
+        return intentCount;
+    }
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
@@ -3,6 +3,7 @@ package org.javacord.api.internal;
 import org.javacord.api.AccountType;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.DiscordApiBuilder;
+import org.javacord.api.entity.intent.Intent;
 import org.javacord.api.listener.GloballyAttachableListener;
 import org.javacord.api.util.auth.Authenticator;
 import org.javacord.api.util.ratelimit.Ratelimiter;
@@ -13,6 +14,7 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -109,7 +111,7 @@ public interface DiscordApiBuilderDelegate {
     void setCurrentShard(int currentShard);
 
     /**
-     * Sets the current shard.
+     * Gets the current shard.
      *
      * @return The current shard.
      */
@@ -147,6 +149,13 @@ public interface DiscordApiBuilderDelegate {
      * @see #setShutdownHookRegistrationEnabled(boolean)
      */
     boolean isShutdownHookRegistrationEnabled();
+
+    /**
+     * Sets the intents where the given predicate matches.
+     *
+     * @param condition Whether the intent should be added or not.
+     */
+    void setAllIntentsWhere(Predicate<Intent> condition);
 
     /**
      * Logs the bot in.
@@ -314,5 +323,4 @@ public interface DiscordApiBuilderDelegate {
      */
     <T extends GloballyAttachableListener> void removeListenerFunction(Class<T> listenerClass,
                                                                        Function<DiscordApi, T> listenerFunction);
-    
 }

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -25,6 +25,7 @@ import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.channel.VoiceChannel;
 import org.javacord.api.entity.emoji.CustomEmoji;
 import org.javacord.api.entity.emoji.KnownCustomEmoji;
+import org.javacord.api.entity.intent.Intent;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.MessageSet;
 import org.javacord.api.entity.message.UncachedMessageUtil;
@@ -212,6 +213,11 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     private final int totalShards;
 
     /**
+     * The intents to be set.
+     */
+    private final Set<Intent> intents;
+
+    /**
      * Whether Javacord should wait for all servers to become available on startup or not.
      */
     private final boolean waitForServersOnStartup;
@@ -381,7 +387,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      */
     public DiscordApiImpl(String token, Ratelimiter globalRatelimiter, ProxySelector proxySelector, Proxy proxy,
                           Authenticator proxyAuthenticator, boolean trustAllCertificates) {
-        this(AccountType.BOT, token, 0, 1, true, globalRatelimiter,
+        this(AccountType.BOT, token, 0, 1, null, true, globalRatelimiter,
                 proxySelector, proxy, proxyAuthenticator, trustAllCertificates, null);
     }
 
@@ -392,6 +398,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * @param token                   The token used to connect without any account type specific prefix.
      * @param currentShard            The current shard the bot should connect to.
      * @param totalShards             The total amount of shards.
+     * @param intents                  The intents for the events which should be received.
      * @param waitForServersOnStartup Whether Javacord should wait for all servers
      *                                to become available on startup or not.
      * @param globalRatelimiter       The ratelimiter used for global ratelimits.
@@ -408,6 +415,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             String token,
             int currentShard,
             int totalShards,
+            Set<Intent> intents,
             boolean waitForServersOnStartup,
             Ratelimiter globalRatelimiter,
             ProxySelector proxySelector,
@@ -416,7 +424,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             boolean trustAllCertificates,
             CompletableFuture<DiscordApi> ready
     ) {
-        this(accountType, token, currentShard, totalShards, waitForServersOnStartup, true, globalRatelimiter,
+        this(accountType, token, currentShard, totalShards, intents, waitForServersOnStartup, true, globalRatelimiter,
                 proxySelector, proxy, proxyAuthenticator, trustAllCertificates, ready, null,
                 Collections.emptyMap(), Collections.emptyList());
     }
@@ -428,6 +436,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * @param token                   The token used to connect without any account type specific prefix.
      * @param currentShard            The current shard the bot should connect to.
      * @param totalShards             The total amount of shards.
+     * @param intents                  The intents for the events which should be received.
      * @param waitForServersOnStartup Whether Javacord should wait for all servers
      *                                to become available on startup or not.
      * @param globalRatelimiter       The ratelimiter used for global ratelimits.
@@ -445,6 +454,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             String token,
             int currentShard,
             int totalShards,
+            Set<Intent> intents,
             boolean waitForServersOnStartup,
             Ratelimiter globalRatelimiter,
             ProxySelector proxySelector,
@@ -453,7 +463,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             boolean trustAllCertificates,
             CompletableFuture<DiscordApi> ready,
             Dns dns) {
-        this(accountType, token, currentShard, totalShards, waitForServersOnStartup, true, globalRatelimiter,
+        this(accountType, token, currentShard, totalShards, intents, waitForServersOnStartup, true, globalRatelimiter,
                 proxySelector, proxy, proxyAuthenticator, trustAllCertificates, ready, dns, Collections.emptyMap(),
                 Collections.emptyList());
     }
@@ -464,6 +474,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * @param token                   The token used to connect without any account type specific prefix.
      * @param currentShard            The current shard the bot should connect to.
      * @param totalShards             The total amount of shards.
+     * @param intents                  The intents for the events which should be received.
      * @param waitForServersOnStartup Whether Javacord should wait for all servers
      *                                to become available on startup or not.
      * @param registerShutdownHook    Whether the shutdown hook should be registered or not.
@@ -485,6 +496,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             String token,
             int currentShard,
             int totalShards,
+            Set<Intent> intents,
             boolean waitForServersOnStartup,
             boolean registerShutdownHook,
             Ratelimiter globalRatelimiter,
@@ -508,6 +520,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
         this.proxy = proxy;
         this.proxyAuthenticator = proxyAuthenticator;
         this.trustAllCertificates = trustAllCertificates;
+        this.intents = intents;
         this.reconnectDelayProvider = x ->
                 (int) Math.round(Math.pow(x, 1.5) - (1 / (1 / (0.1 * x) + 1)) * Math.pow(x, 1.5));
 
@@ -1236,6 +1249,11 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     @Override
     public String getPrefixedToken() {
         return accountType.getTokenPrefix() + token;
+    }
+
+    @Override
+    public Set<Intent> getIntents() {
+        return Collections.unmodifiableSet(intents);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
@@ -17,6 +17,7 @@ import org.javacord.api.Javacord;
 import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.activity.Activity;
 import org.javacord.api.entity.channel.ServerVoiceChannel;
+import org.javacord.api.entity.intent.Intent;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.connection.LostConnectionEvent;
@@ -760,6 +761,9 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                 .put("$device", "Javacord")
                 .put("$referrer", "")
                 .put("$referring_domain", "");
+
+        data.put("intents", Intent.calculateBitmask(api.getIntents().toArray(new Intent[0])));
+
         if (api.getTotalShards() > 1) {
             data.putArray("shard").add(api.getCurrentShard()).add(api.getTotalShards());
         }

--- a/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
+++ b/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
@@ -320,7 +320,7 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.setSocks4SystemProperties()
 
         and:
-            def api = new DiscordApiImpl(AccountType.BOT, 'fakeBotToken', 0, 1, false, null, null, null, null, true,
+            def api = new DiscordApiImpl(AccountType.BOT, 'fakeBotToken', 0, 1, null, false, null, null, null, null, true,
                     null, { [InetAddress.getLoopbackAddress()] })
 
         when:


### PR DESCRIPTION
This is a WIP feature because intents are in the current gateway version optional and Javacord can break when not using this correctly.

Things which are affected of not being able to receive events need to be taken care of in order to not break Javacord.

Current known issues with this implementation:
- When not providing the GUILDS and GUILD_PRESENCES intent some events and other GUILD intents do not work anymore. There's also a long startup time

In regard of issue #522 this provides the implementation of intents. 