### PR TITLE
fix: typo in Documentation

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageBuilder.java
@@ -249,7 +249,7 @@ public class MessageBuilder {
     }
 
     /**
-     * Adds a file to the message.
+     * Adds a file to the message and marks it as a spoiler.
      *
      * @param url The url of the attachment.
      * @return The current instance in order to chain call methods.


### PR DESCRIPTION
It's just a small typo but I thought of fixing it.

[EDIT] : The previous JavaDoc used to show ``Adds a file to the message.`` to the overloaded method ``addFileAsSpoiler(URL url)``.