### PR TITLE
fix for Server#canManageRole

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2265,9 +2265,10 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      * @return Whether the user can manage the role.
      */
     default boolean canManageRole(User user, Role target) {
-        return canManageRoles(user)
-                && getRoles().contains(target)
-                && getHighestRole(user).orElseGet(this::getEveryoneRole).compareTo(target) >= 0;
+        return target.getServer() == this
+                && (isOwner(user)
+                || (canManageRoles(user)
+                && getHighestRole(user).orElseGet(this::getEveryoneRole).compareTo(target) >= 0));
     }
 
     /**


### PR DESCRIPTION
A user can manage every roles role when he is the owner of the corresponding guild.