### PR TITLE
Bugfix for getMemberByDiscriminatedName()

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -355,7 +355,9 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      */
     default Optional<User> getMemberByDiscriminatedName(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
-        return getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]);
+        return (nameAndDiscriminator.length > 1) 
+            ? getMemberByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]) 
+            : Optional.empty();
     }
 
     /**
@@ -367,7 +369,9 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      */
     default Optional<User> getMemberByDiscriminatedNameIgnoreCase(String discriminatedName) {
         String[] nameAndDiscriminator = discriminatedName.split("#", 2);
-        return getMemberByNameAndDiscriminatorIgnoreCase(nameAndDiscriminator[0], nameAndDiscriminator[1]);
+        return (nameAndDiscriminator.length > 1) 
+            ? getMemberByNameAndDiscriminatorIgnoreCase(nameAndDiscriminator[0], nameAndDiscriminator[1]) 
+            : Optional.empty();
     }
 
     /**


### PR DESCRIPTION
Bugfix for getMemberByDiscriminatedName() and getMemberByDiscriminatedNameIgnoreCase() to prevent IndexOutOfBounds error for strings without a #