### PR TITLE
Fix AudioConnection#setSpeaking(boolean) method

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/audio/AudioConnection.java
+++ b/javacord-api/src/main/java/org/javacord/api/audio/AudioConnection.java
@@ -4,8 +4,8 @@ import org.javacord.api.entity.channel.ServerVoiceChannel;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.listener.audio.AudioConnectionAttachableListenerManager;
 
-import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 public interface AudioConnection extends AudioConnectionAttachableListenerManager {
@@ -157,7 +157,7 @@ public interface AudioConnection extends AudioConnectionAttachableListenerManage
      *
      * @return The current speaking flags of this connection.
      */
-    EnumSet<SpeakingFlag> getSpeakingFlags();
+    Set<SpeakingFlag> getSpeakingFlags();
 
     /**
      * Gets the server of the audio connection.

--- a/javacord-core/src/main/java/org/javacord/core/audio/AudioConnectionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/audio/AudioConnectionImpl.java
@@ -12,8 +12,10 @@ import org.javacord.core.listener.audio.InternalAudioConnectionAttachableListene
 import org.javacord.core.util.gateway.AudioWebSocketAdapter;
 import org.javacord.core.util.logging.LoggerUtil;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -222,7 +224,7 @@ public class AudioConnectionImpl implements AudioConnection, InternalAudioConnec
      * @param speaking The speaking mode to set
      */
     public void setSpeaking(boolean speaking) {
-        EnumSet<SpeakingFlag> newSpeakingFlags = getSpeakingFlags();
+        EnumSet<SpeakingFlag> newSpeakingFlags = speakingFlags.clone();
         if (speaking) {
             newSpeakingFlags.add(SpeakingFlag.SPEAKING);
         } else {
@@ -246,7 +248,7 @@ public class AudioConnectionImpl implements AudioConnection, InternalAudioConnec
      * @param prioritySpeaking Whether or not to speak with priority.
      */
     public void setPrioritySpeaking(boolean prioritySpeaking) {
-        EnumSet<SpeakingFlag> newSpeakingFlags = getSpeakingFlags();
+        EnumSet<SpeakingFlag> newSpeakingFlags = speakingFlags.clone();
         if (prioritySpeaking) {
             newSpeakingFlags.add(SpeakingFlag.PRIORITY_SPEAKER);
         } else {
@@ -260,11 +262,11 @@ public class AudioConnectionImpl implements AudioConnection, InternalAudioConnec
      *
      * @return The current set of active speaking flags.
      */
-    public EnumSet<SpeakingFlag> getSpeakingFlags() {
-        return speakingFlags;
+    public Set<SpeakingFlag> getSpeakingFlags() {
+        return Collections.unmodifiableSet(speakingFlags);
     }
 
-    /**
+    /**M
      * Sets the current speaking flags and sends a speaking packet if they have changed.
      *
      * @param speakingFlags The new speaking flags to set.


### PR DESCRIPTION
When calling the `AudioConnectionImpl#setSpeakingFlags(...)` method, the method checks if the flags did change and if yes, it sends an update to the voice websocket.
The `#set[Priority]Speaking(boolean)` method however did modify the speakingFlags enum set directly before calling `#setSpeakingFlags(...)`. Because of this the check always yielded false (no change) and thus it never send something to the voice websocket.

![image](https://user-images.githubusercontent.com/5033001/80869977-be63f080-8ca3-11ea-87fa-f047bf88af3c.png)

![image](https://user-images.githubusercontent.com/5033001/80869967-aee4a780-8ca3-11ea-97b2-64f784f49404.png)

![image](https://user-images.githubusercontent.com/5033001/80869982-c3c13b00-8ca3-11ea-943b-f7aa932d2ab8.png)
