### PR TITLE
Rework entity cache

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,6 +34,10 @@ project(':javacord-core') {
         // logging
         implementation 'org.apache.logging.log4j:log4j-api:2.11.0'
 
+        // Vavr, mainly for immutable collections
+        // We are using 0.10.1, because of an issue in 0.10.2: https://github.com/vavr-io/vavr/issues/2573
+        implementation "io.vavr:vavr:0.10.1"
+
         // the Javacord API
         api project(path: ':javacord-api')
 

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -34,7 +34,6 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -991,104 +990,56 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
      *
      * @return A collection with all group channels of the bot.
      */
-    default Collection<GroupChannel> getGroupChannels() {
-        // Not very efficient, but it's a client-only feature and normal users can only be in 100 servers anyway
-        return Collections.unmodifiableList(
-                getChannels().stream()
-                        .filter(GroupChannel.class::isInstance)
-                        .map(GroupChannel.class::cast)
-                        .collect(Collectors.toList()));
-    }
+    Collection<GroupChannel> getGroupChannels();
 
     /**
      * Gets a collection with all private channels of the bot.
      *
      * @return A collection with all private channels of the bot.
      */
-    default Collection<PrivateChannel> getPrivateChannels() {
-        // TODO This can be improved
-        return Collections.unmodifiableList(
-                getChannels().stream()
-                        .filter(PrivateChannel.class::isInstance)
-                        .map(PrivateChannel.class::cast)
-                        .collect(Collectors.toList()));
-    }
+    Collection<PrivateChannel> getPrivateChannels();
 
     /**
      * Gets a collection with all server channels of the bot.
      *
      * @return A collection with all server channels of the bot.
      */
-    default Collection<ServerChannel> getServerChannels() {
-        // TODO This can be improved
-        Collection<ServerChannel> channels = new ArrayList<>();
-        getServers().forEach(server -> channels.addAll(server.getChannels()));
-        return Collections.unmodifiableCollection(channels);
-    }
+    Collection<ServerChannel> getServerChannels();
 
     /**
      * Gets a collection with all channel categories of the bot.
      *
      * @return A collection with all channel categories of the bot.
      */
-    default Collection<ChannelCategory> getChannelCategories() {
-        // TODO This can be improved
-        Collection<ChannelCategory> channels = new ArrayList<>();
-        getServers().forEach(server -> channels.addAll(server.getChannelCategories()));
-        return Collections.unmodifiableCollection(channels);
-    }
+    Collection<ChannelCategory> getChannelCategories();
 
     /**
      * Gets a collection with all server text channels of the bot.
      *
      * @return A collection with all server text channels of the bot.
      */
-    default Collection<ServerTextChannel> getServerTextChannels() {
-        // TODO This can be improved
-        Collection<ServerTextChannel> channels = new ArrayList<>();
-        getServers().forEach(server -> channels.addAll(server.getTextChannels()));
-        return Collections.unmodifiableCollection(channels);
-    }
+    Collection<ServerTextChannel> getServerTextChannels();
 
     /**
      * Gets a collection with all server voice channels of the bot.
      *
      * @return A collection with all server voice channels of the bot.
      */
-    default Collection<ServerVoiceChannel> getServerVoiceChannels() {
-        // TODO This can be improved
-        Collection<ServerVoiceChannel> channels = new ArrayList<>();
-        getServers().forEach(server -> channels.addAll(server.getVoiceChannels()));
-        return Collections.unmodifiableCollection(channels);
-    }
+    Collection<ServerVoiceChannel> getServerVoiceChannels();
 
     /**
      * Gets a collection with all text channels of the bot.
      *
      * @return A collection with all text channels of the bot.
      */
-    default Collection<TextChannel> getTextChannels() {
-        // TODO This can be improved
-        return Collections.unmodifiableList(
-                getChannels().stream()
-                        .filter(TextChannel.class::isInstance)
-                        .map(TextChannel.class::cast)
-                        .collect(Collectors.toList()));
-    }
+    Collection<TextChannel> getTextChannels();
 
     /**
      * Gets a collection with all voice channels of the bot.
      *
      * @return A collection with all voice channels of the bot.
      */
-    default Collection<VoiceChannel> getVoiceChannels() {
-        // TODO This can be improved
-        return Collections.unmodifiableList(
-                getChannels().stream()
-                        .filter(VoiceChannel.class::isInstance)
-                        .map(VoiceChannel.class::cast)
-                        .collect(Collectors.toList()));
-    }
+    Collection<VoiceChannel> getVoiceChannels();
 
     /**
      * Gets a channel by its id.

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelImpl.java
@@ -118,7 +118,6 @@ public abstract class ServerChannelImpl implements ServerChannel, InternalServer
         }
 
         api.addChannelToCache(this);
-        server.addChannelToCache(this);
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/util/ImmutableToJavaMapper.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/ImmutableToJavaMapper.java
@@ -1,0 +1,29 @@
+package org.javacord.core.util;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Maps the immutable collections to unmodifiable Java collections.
+ */
+@SuppressWarnings("unchecked")
+public class ImmutableToJavaMapper {
+
+    private ImmutableToJavaMapper() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Maps the given immutable Vavr set to an unmodifiable java set.
+     *
+     * @param set The immutable Vavr set.
+     * @param <J> The type of the unmodifiable java set.
+     *            The caller must make sure that the given Vavr set only contain elements of this type.
+     * @param <V> The type of the immutable Vavr set.
+     * @return The unmodifiable java set.
+     */
+    public static <J extends V, V> Set<J> mapToJava(io.vavr.collection.Set<V> set) {
+        return Collections.unmodifiableSet((Set<J>) set.toJavaSet());
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/cache/Cache.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/cache/Cache.java
@@ -1,0 +1,182 @@
+package org.javacord.core.util.cache;
+
+import io.vavr.collection.HashMap;
+import io.vavr.collection.HashSet;
+import io.vavr.collection.Map;
+import io.vavr.collection.Set;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * An immutable cache, optionally with indexes.
+ *
+ * <p>The cache can store any elements and supports indexes to quickly access a subset of elements by a specific
+ * criteria (the "key") with an effective (assuming an even distribution of hash keys) time-complexity of {@code O(1)}.
+ *
+ * <p>Ideally, the cache is only filled with immutable elements, but it also supports mutable objects.
+ * However, for mutable objects, the {@link #updateIndexesOfElement(Object)} methods should be called every time an
+ * element update changes the key for this element for one of the indexes.
+ *
+ * @param <T> The type of the elements in the cache.
+ */
+public class Cache<T> {
+
+    /**
+     * A set with all elements in the cache.
+     */
+    private final Set<T> elements;
+
+    /**
+     * A map with all indexes.
+     *
+     * <p>The map's key is the index name and the value is the index itself.
+     */
+    private final Map<String, Index<Object, T>> indexes;
+
+    /**
+     * Creates a new cache.
+     *
+     * @param elements The elements in the cache.
+     * @param indexes The indexes.
+     */
+    private Cache(Set<T> elements, Map<String, Index<Object, T>> indexes) {
+        this.elements = elements;
+        this.indexes = indexes;
+    }
+
+    /**
+     * Gets an empty cache with no elements and no indexes.
+     *
+     * @param <T> The type of the elements in the cache.
+     * @return An empty element cache.
+     */
+    public static <T> Cache<T> empty() {
+        return new Cache<>(HashSet.empty(), HashMap.empty());
+    }
+
+    /**
+     * Adds an index to the cache.
+     *
+     * <p>Indexes allow quick access (effectively {@code O(1)} to elements in the cache by the key for the index like
+     * for example the id or sub type.
+     *
+     * <p>Compound indexes can easily be achieved by using a {@link io.vavr.Tuple} or {@link io.vavr.collection.Seq}
+     * with all keys as the return value of the mapping function.
+     *
+     * <p>This method has a time-complexity of {@code O(n)} with {@code n} being the amount of elements in the cache.
+     *
+     * @param indexName The name of the index.
+     * @param mappingFunction A function to map elements to their key.
+     *                        The function is allowed to return {@code null} which means that the element will not be
+     *                        included in the index.
+     * @return The new cache with the added index.
+     * @throws IllegalStateException If the cache already has an index with the given name.
+     */
+    public Cache<T> addIndex(String indexName, Function<T, Object> mappingFunction) {
+        if (indexes.containsKey(indexName)) {
+            throw new IllegalStateException("The cache already has an index with name " + indexName);
+        }
+        Index<Object, T> index = new Index<>(mappingFunction);
+        for (T element : elements) {
+            index = index.addElement(element);
+        }
+        Map<String, Index<Object, T>> newIndexes = indexes.put(indexName, index);
+        return new Cache<>(elements, newIndexes);
+    }
+
+    /**
+     * Adds an element to the cache.
+     *
+     * <p>This method has an effective time complexity of {@code O(1)} regarding the amount of elements already in the
+     * cache and a time complexity of {@code O(n)} regarding the amount of indexes in the cache (assuming the index's
+     * mapping function has an effective complexity of {@code O(1)}).
+     *
+     * @param element The element to add.
+     * @return The new cache after adding the element.
+     */
+    public Cache<T> addElement(T element) {
+        Set<T> newElements = elements.add(element);
+        Map<String, Index<Object, T>> newIndexes = indexes.mapValues(index -> index.addElement(element));
+        return new Cache<>(newElements, newIndexes);
+    }
+
+    /**
+     * Removes an element from the cache.
+     *
+     * <p>This method has an effective time complexity of {@code O(1)} regarding the amount of elements already in the
+     * cache and a time complexity of {@code O(n)} regarding the amount of indexes in the cache.
+     *
+     * @param element The element to remove.
+     * @return The new cache after removing the element.
+     */
+    public Cache<T> removeElement(T element) {
+        Set<T> newElements = elements.remove(element);
+        Map<String, Index<Object, T>> newIndexes = indexes.mapValues(index -> index.removeElement(element));
+        return new Cache<>(newElements, newIndexes);
+    }
+
+    /**
+     * Updates the indexes of the cache for the given element.
+     *
+     * <p>The update method should be called every time an element's mutation changes the key of one of the indexes.
+     * Ideally the {@code IndexedCache} is only filled with immutable elements which would make this method obsolete.
+     *
+     * <p>This method has an effective time complexity of {@code O(1)} regarding the amount of elements already in the
+     * cache and a time complexity of {@code O(n)} regarding the amount of indexes in the cache (assuming the index's
+     * mapping function has an effective complexity of {@code O(1)}).
+     *
+     * @param element The element of which the values did change.
+     * @return The new cache after updating the element.
+     */
+    public Cache<T> updateIndexesOfElement(T element) {
+        if (!elements.contains(element)) {
+            return this;
+        }
+        return removeElement(element).addElement(element);
+    }
+
+    /**
+     * Gets a set with all elements in the cache.
+     *
+     * <p>This method has a time complexity of {@code O(1)}.
+     *
+     * @return All elements in the cache.
+     */
+    public Set<T> getAll() {
+        return elements;
+    }
+
+    /**
+     * Gets any element in the cache that has the given key.
+     *
+     * <p>This method has an effective time complexity of {@code O(1)}.
+     *
+     * @param indexName The name of the index.
+     * @param key The key of the element.
+     * @return An element with the given key.
+     * @throws IllegalArgumentException If the cache has no index with the given name.
+     */
+    public Optional<T> findAnyByIndex(String indexName, Object key) {
+        Index<Object, T> index = indexes.get(indexName).getOrElseThrow(
+                () -> new IllegalArgumentException("No index with given name (" + indexName + ") found"));
+        return index.findAny(key);
+    }
+
+    /**
+     * Gets a set with all elements in the cache that have the given key.
+     *
+     * <p>This method has an effective time complexity of {@code O(1)}.
+     *
+     * @param indexName The name of the index.
+     * @param key The key of the elements.
+     * @return A set with all the elements that have the given key.
+     * @throws IllegalArgumentException If the cache has no index with the given name.
+     */
+    public Set<T> findByIndex(String indexName, Object key) {
+        Index<Object, T> index = indexes.get(indexName).getOrElseThrow(
+                () -> new IllegalArgumentException("No index with given name (" + indexName + ") found"));
+        return index.find(key);
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/cache/ChannelCache.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/cache/ChannelCache.java
@@ -1,0 +1,142 @@
+package org.javacord.core.util.cache;
+
+import io.vavr.Tuple;
+import org.javacord.api.entity.channel.Channel;
+import org.javacord.api.entity.channel.ChannelType;
+import org.javacord.api.entity.channel.ServerChannel;
+import org.javacord.api.entity.channel.ServerTextChannel;
+import org.javacord.api.entity.channel.ServerVoiceChannel;
+import org.javacord.api.entity.channel.TextChannel;
+import org.javacord.api.entity.channel.VoiceChannel;
+import org.javacord.api.entity.server.Server;
+import org.javacord.core.util.ImmutableToJavaMapper;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * An immutable cache for all channel entities.
+ */
+public class ChannelCache {
+
+    private static final String ID_INDEX_NAME = "id";
+    private static final String TYPE_INDEX_NAME = "type";
+    private static final String SERVER_ID_INDEX_NAME = "server-id";
+    private static final String SERVER_ID_AND_TYPE_INDEX_NAME = "server-id | type";
+
+    private static final ChannelCache EMPTY_CACHE = new ChannelCache(Cache.<Channel>empty()
+            .addIndex(ID_INDEX_NAME, Channel::getId)
+            .addIndex(TYPE_INDEX_NAME, Channel::getType)
+            .addIndex(SERVER_ID_INDEX_NAME, channel -> channel
+                    .asServerChannel()
+                    .map(ServerChannel::getServer)
+                    .map(Server::getId)
+                    .orElse(null))
+            .addIndex(SERVER_ID_AND_TYPE_INDEX_NAME, channel -> channel
+                    .asServerChannel()
+                    .map(ServerChannel::getServer)
+                    .map(Server::getId)
+                    .map(serverId -> Tuple.of(serverId, channel.getType()))
+                    .orElse(null))
+    );
+
+    private final Cache<Channel> cache;
+
+    private ChannelCache(Cache<Channel> cache) {
+        this.cache = cache;
+    }
+
+    /**
+     * Gets an empty channel cache.
+     *
+     * @return An empty channel cache.
+     */
+    public static ChannelCache empty() {
+        return EMPTY_CACHE;
+    }
+
+    /**
+     * Adds a channel to the cache.
+     *
+     * @param channel The channel to add.
+     * @return The new channel cache.
+     */
+    public ChannelCache addChannel(Channel channel) {
+        return new ChannelCache(cache.addElement(channel));
+    }
+
+    /**
+     * Removes a channel from the cache.
+     *
+     * @param channel The channel to remove.
+     * @return The new channel cache.
+     */
+    public ChannelCache removeChannel(Channel channel) {
+        return new ChannelCache(cache.removeElement(channel));
+    }
+
+    /**
+     * Gets a set with all channels in the cache.
+     *
+     * @return A set with all channels.
+     */
+    public Set<Channel> getChannels() {
+        return ImmutableToJavaMapper.mapToJava(cache.getAll());
+    }
+
+    /**
+     * Gets all channels that have one of the given types.
+     *
+     * @param types The types of the channels to get.
+     * @param <T> A type that at least all channels of the given types share.
+     *            E.g., if the provided {@code types} parameter is {@link ChannelType#SERVER_TEXT_CHANNEL} and
+     *            {@link ChannelType#SERVER_VOICE_CHANNEL}, {@code T} can be {@link ServerChannel} but must not be
+     *            {@link TextChannel}.
+     * @return A set with all channels that are of one of the given types.
+     */
+    public <T extends Channel> Set<T> getChannelsWithTypes(ChannelType... types) {
+        io.vavr.collection.HashSet<Channel> channels = io.vavr.collection.HashSet.empty();
+        for (ChannelType type : types) {
+            channels = channels.addAll(cache.findByIndex(TYPE_INDEX_NAME, type));
+        }
+        return ImmutableToJavaMapper.mapToJava(channels);
+    }
+
+    /**
+     * Gets all channels of the server with the given id.
+     *
+     * @param serverId The id of the server.
+     * @return A set with all channels in the server.
+     */
+    public Set<ServerChannel> getChannelsOfServer(long serverId) {
+        return ImmutableToJavaMapper.mapToJava(cache.findByIndex(SERVER_ID_INDEX_NAME, serverId));
+    }
+
+    /**
+     * Gets all channels with the given type of the server with the given id.
+     *
+     * @param serverId The id of the server.
+     * @param type The type of the channels in the server.
+     * @param <T> A type that at least all channels of the given type share.
+     *            E.g., if the provided {@code type} parameter is {@link ChannelType#SERVER_TEXT_CHANNEL}
+     *            {@code T} can be {@link ServerTextChannel} or {@link ServerChannel} but must not be
+     *            {@link ServerVoiceChannel} or {@link VoiceChannel}.
+     * @return A set with all channels with the given type of the server with the given id.
+     */
+    public <T extends Channel> Set<T> getChannelsOfServerAndType(long serverId, ChannelType type) {
+        return ImmutableToJavaMapper.mapToJava(
+                cache.findByIndex(SERVER_ID_AND_TYPE_INDEX_NAME, Tuple.of(serverId, type)));
+    }
+
+    /**
+     * Gets a channel by its id.
+     *
+     * <p>This method has a time-complexity of {@code O(1)}.
+     *
+     * @param id The id of the channel.
+     * @return The channel with the given id.
+     */
+    public Optional<Channel> getChannelById(long id) {
+        return cache.findAnyByIndex(ID_INDEX_NAME, id);
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/cache/Index.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/cache/Index.java
@@ -1,0 +1,141 @@
+package org.javacord.core.util.cache;
+
+import io.vavr.collection.HashMap;
+import io.vavr.collection.HashSet;
+import io.vavr.collection.Map;
+import io.vavr.collection.Set;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * An immutable index.
+ *
+ * @param <K> The type of the key.
+ * @param <E> The type of the elements.
+ */
+public class Index<K, E> {
+
+    /**
+     * A function that maps an element to its key.
+     */
+    private final Function<E, K> keyMapper;
+
+    /**
+     * A map that contains the elements by their key.
+     */
+    private final Map<K, Set<E>> elementsByKey;
+
+    /**
+     * A map that contains the element as its key and the key of the element when it was added to
+     * this index as its value.
+     *
+     * <p>It allows for a reverse lookup of index keys without having to call the {@code keyMapper}.
+     */
+    private final Map<E, K> keyByElement;
+
+    /**
+     * Creates a new index.
+     *
+     * @param keyMapper A function to map elements to their key.
+     */
+    public Index(Function<E, K> keyMapper) {
+        this(keyMapper, HashMap.empty(), HashMap.empty());
+    }
+
+    /**
+     * Creates a new index.
+     *
+     * @param keyMapper A function to map elements to their key.
+     * @param elementsByKey The elements by their key.
+     * @param keyByElement The key by the element.
+     */
+    private Index(Function<E, K> keyMapper, Map<K, Set<E>> elementsByKey, Map<E, K> keyByElement) {
+        this.keyMapper = keyMapper;
+        this.elementsByKey = elementsByKey;
+        this.keyByElement = keyByElement;
+    }
+
+    /**
+     * Gets the mapping function to map elements to their key.
+     *
+     * <p>Compound indexes can easily be achieved by using a {@link io.vavr.Tuple} or {@link io.vavr.collection.Seq}
+     * with all keys as the return value of the mapping function.
+     *
+     * @return The mapping function.
+     */
+    public Function<E, K> getKeyMapper() {
+        return keyMapper;
+    }
+
+    /**
+     * Adds an element to the index.
+     *
+     * <p>This method has an effective time complexity of {@code O(1)}.
+     *
+     * @param element The element to add.
+     * @return The new index with the added element.
+     */
+    public Index<K, E> addElement(E element) {
+        K key = keyMapper.apply(element);
+        if (key == null) {
+            return this;
+        }
+        Set<E> elements = find(key);
+        if (elements.contains(element)) {
+            return this;
+        }
+        if (keyByElement.containsKey(element)) {
+            throw new IllegalStateException("The given element is already in the index with a different key");
+        }
+        Map<K, Set<E>> newElementsByKey = elementsByKey.put(key, elements.add(element));
+        Map<E, K> newKeyByElement = keyByElement.put(element, key);
+        return new Index<>(keyMapper, newElementsByKey, newKeyByElement);
+    }
+
+    /**
+     * Removes an element from the index.
+     *
+     * <p>This method has an effective time complexity of {@code O(1)}.
+     *
+     * @param element The element to remove.
+     * @return The new index with the element removed.
+     */
+    public Index<K, E> removeElement(E element) {
+        K key = keyByElement.getOrElse(element, null);
+        if (key == null) {
+            return this;
+        }
+        Set<E> elements = find(key);
+        if (!elements.contains(element)) {
+            return this;
+        }
+        Map<K, Set<E>> newElementsByKey = elementsByKey.put(key, elements.remove(element));
+        Map<E, K> newKeyByElement = keyByElement.remove(element);
+        return new Index<>(keyMapper, newElementsByKey, newKeyByElement);
+    }
+
+    /**
+     * Gets a set with all elements with the given key.
+     *
+     * <p>This method has an effective time complexity of {@code O(1)}.
+     *
+     * @param key The key of the elements.
+     * @return The elements with the given key.
+     */
+    public Set<E> find(K key) {
+        return elementsByKey.getOrElse(key, HashSet.empty());
+    }
+
+    /**
+     * Gets any element with the given key.
+     *
+     * <p>This method has an effective time complexity of {@code O(1)}.
+     *
+     * @param key The key of the element.
+     * @return An element with the given key.
+     */
+    public Optional<E> findAny(K key) {
+        return find(key).headOption().toJavaOptional();
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/cache/JavacordEntityCache.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/cache/JavacordEntityCache.java
@@ -1,0 +1,55 @@
+package org.javacord.core.util.cache;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * An immutable cache with all Javacord entites.
+ */
+public class JavacordEntityCache {
+
+    private static final JavacordEntityCache EMPTY_CACHE = new JavacordEntityCache(ChannelCache.empty());
+
+    private final ChannelCache channelCache;
+
+    /**
+     * Gets an empty Javacord cache.
+     *
+     * @return An empty Javacord cache.
+     */
+    public static JavacordEntityCache empty() {
+        return EMPTY_CACHE;
+    }
+
+    private JavacordEntityCache(ChannelCache channelCache) {
+        this.channelCache = channelCache;
+    }
+
+    /**
+     * Gets the channel cache.
+     *
+     * @return The channel cache.
+     */
+    public ChannelCache getChannelCache() {
+        return channelCache;
+    }
+
+    /**
+     * Updates the channel cache.
+     *
+     * @param mapper A function that takes the old channel cache and returns the new one.
+     * @return The new Javacord entity cache.
+     */
+    public JavacordEntityCache updateChannelCache(UnaryOperator<ChannelCache> mapper) {
+        return new JavacordEntityCache(mapper.apply(channelCache));
+    }
+
+    /**
+     * Sets the channel cache.
+     *
+     * @param channelCache The channel cache to set.
+     * @return The new Javacord entity cache.
+     */
+    public JavacordEntityCache setChannelCache(ChannelCache channelCache) {
+        return new JavacordEntityCache(channelCache);
+    }
+}

--- a/javacord-core/src/main/java9/module-info.java
+++ b/javacord-core/src/main/java9/module-info.java
@@ -9,6 +9,7 @@ module org.javacord.core {
     requires transitive com.fasterxml.jackson.databind;
     requires transitive nv.websocket.client;
     requires transitive org.apache.logging.log4j;
+    requires transitive io.vavr;
 
     requires transitive java.desktop;
 


### PR DESCRIPTION
Introduces a new immutable and centralized cache for all Javacord entities (besides messages maybe?).