### PR TITLE
Add DiscordApi#getLatestGatewayLatency()

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -95,6 +95,25 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
     Optional<Ratelimiter> getGlobalRatelimiter();
 
     /**
+     * Gets the latest gateway latency.
+     *
+     * <p>To calculate the gateway latency, Javacord measures the time it takes for Discord to answer the gateway
+     * heartbeat packet with a heartbeat ack packet. Please notice, that this values does only get updated on every
+     * heartbeat and not on every method call. To calculate an average, you have to collect the latency over a period of
+     * multiple minutes.
+     *
+     * <p>In very rare cases, the latency will be {@code -1 ns} directly after startup, because the initial heartbeat
+     * was not answered yet. Usually, the heartbeat is answered before the bot finished loading.
+     *
+     * <p><b>Expected latency</b>: Usually, you can expect a latency between {@code 30 ms} and {@code 300 ms} with a
+     * good internet connection. This value may vary, depending on your location, time of day, Discord's status, and the
+     * current workload of your system. A value above {@code 1000 ms} is usually an indicator that something is wrong.
+     *
+     * @return The latest measured gateway latency.
+     */
+    Duration getLatestGatewayLatency();
+
+    /**
      * Measures, how long Javacord will need to perform a single REST call.
      *
      * <p>This method does not measure the "true" latency to Discord's REST endpoints because the request is handled by

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -208,6 +208,11 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     private final boolean waitForServersOnStartup;
 
     /**
+     * The latest gateway latency.
+     */
+    private volatile long latestGatewayLatencyNanos = -1;
+
+    /**
      * A lock that makes sure that there are not more than one ping attempt at the same time.
      * This ensures that the ping does not get affected by other requests that use the same bucket.
      */
@@ -810,6 +815,24 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     }
 
     /**
+     * Gets the latest gateway latency in nano seconds.
+     *
+     * @return The latest gateway latency.
+     */
+    public long getLatestGatewayLatencyNanos() {
+        return latestGatewayLatencyNanos;
+    }
+
+    /**
+     * Sets the latest gateway latency in nano seconds.
+     *
+     * @param latestGatewayLatencyNanos The latest gateway latency.
+     */
+    public void setLatestGatewayLatencyNanos(long latestGatewayLatencyNanos) {
+        this.latestGatewayLatencyNanos = latestGatewayLatencyNanos;
+    }
+
+    /**
      * Sets the user of the connected account.
      *
      * @param yourself The user of the connected account.
@@ -1166,6 +1189,11 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     @Override
     public Optional<Ratelimiter> getGlobalRatelimiter() {
         return Optional.ofNullable(globalRatelimiter);
+    }
+
+    @Override
+    public Duration getLatestGatewayLatency() {
+        return Duration.ofNanos(latestGatewayLatencyNanos);
     }
 
     @Override


### PR DESCRIPTION
Partially fixes https://github.com/Javacord/Javacord/issues/463.
A method to measure the REST latency is added in https://github.com/Javacord/Javacord/pull/569.

#### Why `Duration` and not `Optional<Duration>`?

In nearly every case, the duration will be available when the `DiscordApi` future finishes. It is just more convenient to now have the value wrapped in an `Optional` when it is not necessary in 99.99% of all cases. Returning `-1` should be enough in this very very rare case.
