### PR TITLE
BoostLevel TIER_3 Id Bugfix

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/BoostLevel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/BoostLevel.java
@@ -21,7 +21,7 @@ public enum BoostLevel {
     /**
      * Server Boost level 3.
      */
-    TIER_3(2),
+    TIER_3(3),
 
     /**
      * An unknown boost level, most likely due to new added boost levels.


### PR DESCRIPTION
Tier 3 ID was set to "2" when it should be "3"