### PR TITLE
Fix and cleanup of Allowed Mentions

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/mention/AllowedMentionType.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/mention/AllowedMentionType.java
@@ -1,0 +1,9 @@
+package org.javacord.api.entity.message.mention;
+
+public enum AllowedMentionType {
+
+    USERS,
+    ROLES,
+    EVERYONE;
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/mention/AllowedMentions.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/mention/AllowedMentions.java
@@ -1,7 +1,7 @@
 package org.javacord.api.entity.message.mention;
 
+import java.util.EnumSet;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * This interface represents a mention.
@@ -9,24 +9,28 @@ import java.util.Optional;
 public interface AllowedMentions {
 
     /**
-     * Gets the allowed user mentions from the message.
+     * Gets the explicitly allowed user mentions from the message.
+     * This could differ from the actual mentioned roles if {@link AllowedMentionsBuilder#setMentionRoles(boolean)} has
+     * been set to true.
      *
-     * @return The allowed mentions for users of the message.
+     * @return The explicitly allowed mentions for users of the message.
      */
-    Optional<List<Long>> getAllowedRoleMentions();
+    List<Long> getAllowedRoleMentions();
 
     /**
-     * Gets the allowed role mentions from the message.
+     * Gets the explicitly allowed role mentions from the message.
+     * This could differ from the actual mentioned users if {@link AllowedMentionsBuilder#setMentionUsers(boolean)} has
+     * been set to true.
      *
-     * @return The allowed mentions for roles of the message.
+     * @return The explicitly allowed mentions for roles of the message.
      */
-    Optional<List<Long>> getAllowedUserMentions();
+    List<Long> getAllowedUserMentions();
 
     /**
-     * Gets the allowed general mentions from the message.
+     * Gets the explicitly allowed mention types from the message.
      *
-     * @return The general allowed mentions of the message.
+     * @return The allowed mention types of the message.
      */
-    Optional<List<String>> getGeneralMentions();
+    EnumSet<AllowedMentionType> getMentionTypes();
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/mention/AllowedMentionsBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/mention/AllowedMentionsBuilder.java
@@ -27,6 +27,7 @@ public class AllowedMentionsBuilder {
 
     /**
      * Mentions all mentioned roles.
+     * This will override any explicit role mentions added via {@link #addRole(long)} or {@link #addRoles(Collection)}
      *
      * @param value If roles should be mentioned or not.
      * @return The current instance in order to chain call methods.
@@ -38,6 +39,7 @@ public class AllowedMentionsBuilder {
 
     /**
      * Mentions all mentioned users.
+     * This will override any explicit user mentions added via {@link #addUser(long)} or {@link #addUsers(Collection)}
      *
      * @param value If users should be mentioned or not.
      * @return The current instance in order to chain call methods.
@@ -57,7 +59,6 @@ public class AllowedMentionsBuilder {
         delegate.setMentionEveryoneAndHere(value);
         return this;
     }
-
 
     /**
      * Adds a role to the list which will be mentioned.


### PR DESCRIPTION
A fix to prevent a NullPointerException on trying to use an empty allowed mentions and an incorrect sublist range, as well as some tweaks to make things a bit cleaner.

Unsure whether getAllowedRoleMentions/getAllowedUserMentions should return the user provided allowed mentions with a warning in javadoc, or the effective mentions based on whether or not those mention types are allowed (In which case the Optional<List> would probably be better)