### PR TITLE
#getReadableContent() Bugfix

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -652,7 +652,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
             if (userOptional.isPresent()) {
                 User user = userOptional.get();
                 String userName = getServer().map(user::getDisplayName).orElseGet(user::getName);
-                content = userMention.replaceFirst("@" + userName);
+                content = userMention.replaceFirst(Matcher.quoteReplacement("@" + userName));
                 userMention.reset(content);
             }
         }
@@ -664,7 +664,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
                             .getRoleById(roleId)
                             .map(Role::getName))
                     .orElse("deleted-role");
-            content = roleMention.replaceFirst("@" + roleName);
+            content = roleMention.replaceFirst(Matcher.quoteReplacement("@" + roleName));
             roleMention.reset(content);
         }
         Matcher channelMention = DiscordRegexPattern.CHANNEL_MENTION.matcher(content);


### PR DESCRIPTION
Fix for Illegal group reference exception when a username or a role name has a non-regex friendly character (like $'s)