### PR TITLE
Fix can manage role

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2562,7 +2562,7 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
         return target.getServer() == this
                 && (isOwner(user)
                 || (canManageRoles(user)
-                && getHighestRole(user).orElseGet(this::getEveryoneRole).compareTo(target) >= 0));
+                && getHighestRole(user).orElseGet(this::getEveryoneRole).compareTo(target) > 0));
     }
 
     /**


### PR DESCRIPTION
`Server#canManageRole(User, Role)` doesnt work currently if you pass the highest role the user has.