### PR TITLE
Prevent non-lifecycle frame sends when not fully connected

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/WebSocketFrameSendingQueueEntry.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/WebSocketFrameSendingQueueEntry.java
@@ -90,6 +90,15 @@ public class WebSocketFrameSendingQueueEntry implements Comparable<WebSocketFram
         return priority && lifecycle;
     }
 
+    /**
+     * Gets whether this entry is a lifecyle one.
+     *
+     * @return Whether this entry is a lifecyle one.
+     */
+    public boolean isLifecycle() {
+        return lifecycle;
+    }
+
     @Override
     public int compareTo(WebSocketFrameSendingQueueEntry other) {
         return ENTRY_COMPARATOR.compare(this, other);


### PR DESCRIPTION
Sending frames before receiving a RESUMED (or READY) packet caused the websocket to be closed by Discord with reason 4003 (Not authenticated).
![image](https://user-images.githubusercontent.com/5033001/93670292-b06c0c00-fa9a-11ea-9979-0aee66b7ed9a.png)
