### PR TITLE
Remove AudioSourceFinishedEvent#getNextSource()

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/event/audio/AudioSourceFinishedEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/audio/AudioSourceFinishedEvent.java
@@ -1,23 +1,8 @@
 package org.javacord.api.event.audio;
 
-import org.javacord.api.audio.AudioSource;
-
-import java.util.Optional;
-
 /**
  * An audio source finished event.
  */
 public interface AudioSourceFinishedEvent extends AudioSourceEvent {
-
-    /**
-     * Gets the next source of the audio connection.
-     *
-     * <p>This method is equal to calling {@code getConnection().getCurrentAudioSource()}.
-     *
-     * @return The next source of the audio connection.
-     */
-    default Optional<AudioSource> getNextSource() {
-        return getConnection().getAudioSource();
-    }
 
 }


### PR DESCRIPTION
We no longer have a queue, so this method does not make any sense.