### PR TITLE
Add member and allow disabling of user cache

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -571,6 +571,13 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
     }
 
     /**
+     * Checks if the user cache is enabled.
+     *
+     * @return Whether or not the user cache is enabled;
+     */
+    boolean isUserCacheEnabled();
+
+    /**
      * Gets a collection with all currently cached users.
      *
      * @return A collection with all currently cached users.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/PrivateChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/PrivateChannel.java
@@ -28,9 +28,7 @@ public interface PrivateChannel extends TextChannel, VoiceChannel, PrivateChanne
 
     @Override
     default Optional<PrivateChannel> getCurrentCachedInstance() {
-        return getApi().getCachedUserById(getRecipient().getId())
-                .flatMap(User::getPrivateChannel)
-                .filter(privateChannel -> privateChannel.getId() == getId());
+        return getApi().getPrivateChannelById(getId());
     }
 
     @Override

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
@@ -7,7 +7,6 @@ import org.javacord.api.entity.permission.PermissionState;
 import org.javacord.api.entity.permission.PermissionType;
 import org.javacord.api.entity.permission.Permissions;
 import org.javacord.api.entity.permission.PermissionsBuilder;
-import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.server.invite.InviteBuilder;
 import org.javacord.api.entity.server.invite.RichInvite;
@@ -124,8 +123,8 @@ public interface ServerChannel extends Channel, Nameable, ServerChannelAttachabl
      *
      * @return The overwritten permissions.
      */
-    default Map<Permissionable, Permissions> getOverwrittenPermissions() {
-        Map<Permissionable, Permissions> result = new HashMap<>();
+    default Map<Long, Permissions> getOverwrittenPermissions() {
+        Map<Long, Permissions> result = new HashMap<>();
         result.putAll(getOverwrittenRolePermissions());
         result.putAll(getOverwrittenUserPermissions());
         return Collections.unmodifiableMap(result);
@@ -136,14 +135,14 @@ public interface ServerChannel extends Channel, Nameable, ServerChannelAttachabl
      *
      * @return The overwritten permissions for users.
      */
-    Map<User, Permissions> getOverwrittenUserPermissions();
+    Map<Long, Permissions> getOverwrittenUserPermissions();
 
     /**
      * Gets the overwritten permissions for roles in this channel.
      *
      * @return The overwritten permissions for roles.
      */
-    Map<Role, Permissions> getOverwrittenRolePermissions();
+    Map<Long, Permissions> getOverwrittenRolePermissions();
 
     /**
      * Gets the effective overwritten permissions of a user.
@@ -168,7 +167,7 @@ public interface ServerChannel extends Channel, Nameable, ServerChannelAttachabl
      * @return The effective permissions of the user in this channel.
      */
     default Permissions getEffectivePermissions(User user) {
-        if (getServer().getOwner() == user) {
+        if (getServer().isOwner(user)) {
             return getServer().getPermissions(user);
         }
         PermissionsBuilder builder = new PermissionsBuilder(getServer().getPermissions(user));

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
  * This class represents a Discord message.
  */
 public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFromCache<Message>,
-                                 MessageAttachableListenerManager {
+        MessageAttachableListenerManager {
 
     Pattern ESCAPED_CHARACTER =
             Pattern.compile("\\\\(?<char>[^a-zA-Z0-9\\p{javaWhitespace}\\xa0\\u2007\\u202E\\u202F])");
@@ -923,7 +923,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to tell us if the deletion was successful.
      */
     default CompletableFuture<Void> removeReactionByEmoji(User user, Emoji emoji) {
-        return Reaction.removeUser(getApi(), getChannel().getId(), getId(), emoji, user);
+        return Reaction.removeUser(getApi(), getChannel().getId(), getId(), emoji, user.getId());
     }
 
     /**
@@ -1376,9 +1376,9 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
         return !channel.isPresent()
                 || channel.get().hasPermission(user, PermissionType.ADMINISTRATOR)
                 || channel.get().hasPermissions(user,
-                    PermissionType.READ_MESSAGES,
-                    PermissionType.READ_MESSAGE_HISTORY,
-                    PermissionType.ADD_REACTIONS);
+                PermissionType.READ_MESSAGES,
+                PermissionType.READ_MESSAGE_HISTORY,
+                PermissionType.ADD_REACTIONS);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
@@ -598,12 +598,7 @@ public interface MessageAuthor extends DiscordEntity, Nameable {
      *
      * @return The author as user.
      */
-    default Optional<User> asUser() {
-        if (isUser()) {
-            return getApi().getCachedUserById(getId());
-        }
-        return Optional.empty();
-    }
+    Optional<User> asUser();
 
     /**
      * Checks if the author is a webhook.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Reaction.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Reaction.java
@@ -55,11 +55,12 @@ public interface Reaction {
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param emoji The emoji of the reaction.
-     * @param user The user to remove.
+     * @param userId The if of the user to remove.
      * @return A future to tell us if the action was successful.
      */
-    static CompletableFuture<Void> removeUser(DiscordApi api, long channelId, long messageId, Emoji emoji, User user) {
-        return api.getUncachedMessageUtil().removeUserReactionByEmoji(channelId, messageId, emoji, user);
+    static CompletableFuture<Void> removeUser(
+            DiscordApi api, long channelId, long messageId, Emoji emoji, long userId) {
+        return api.getUncachedMessageUtil().removeUserReactionByEmoji(channelId, messageId, emoji, userId);
     }
 
     /**
@@ -69,12 +70,12 @@ public interface Reaction {
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param emoji The emoji of the reaction.
-     * @param user The user to remove.
+     * @param userId The if of the user to remove.
      * @return A future to tell us if the action was successful.
      */
     static CompletableFuture<Void> removeUser(DiscordApi api, String channelId, String messageId, Emoji emoji,
-                                              User user) {
-        return api.getUncachedMessageUtil().removeUserReactionByEmoji(channelId, messageId, emoji, user);
+                                              String userId) {
+        return api.getUncachedMessageUtil().removeUserReactionByEmoji(channelId, messageId, emoji, userId);
     }
 
     /**
@@ -84,8 +85,8 @@ public interface Reaction {
      * @return A future to tell us if the action was successful.
      */
     default CompletableFuture<Void> removeUser(User user) {
-        return Reaction.removeUser(
-                getMessage().getApi(), getMessage().getChannel().getId(), getMessage().getId(), getEmoji(), user);
+        return Reaction.removeUser(getMessage().getApi(), getMessage().getChannel().getId(), getMessage().getId(),
+                getEmoji(), user.getId());
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
@@ -361,10 +361,10 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param emoji The emoji of the reaction.
-     * @param user The user to remove.
+     * @param userId The if of the user to remove.
      * @return A future to tell us if the action was successful.
      */
-    CompletableFuture<Void> removeUserReactionByEmoji(long channelId, long messageId, Emoji emoji, User user);
+    CompletableFuture<Void> removeUserReactionByEmoji(long channelId, long messageId, Emoji emoji, long userId);
 
     /**
      * Removes the reaction of the given user.
@@ -372,9 +372,9 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param emoji The emoji of the reaction.
-     * @param user The user to remove.
+     * @param userId The if of the user to remove.
      * @return A future to tell us if the action was successful.
      */
-    CompletableFuture<Void> removeUserReactionByEmoji(String channelId, String messageId, Emoji emoji, User user);
+    CompletableFuture<Void> removeUserReactionByEmoji(String channelId, String messageId, Emoji emoji, String userId);
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
  * This class represents a Discord role, e.g. "moderator".
  */
 public interface Role extends DiscordEntity, Mentionable, Nameable, Permissionable, Comparable<Role>,
-                              UpdatableFromCache<Role>, RoleAttachableListenerManager {
+        UpdatableFromCache<Role>, RoleAttachableListenerManager {
 
     /**
      * Gets the server of the role.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  * This class represents a user.
  */
 public interface User extends DiscordEntity, Messageable, Nameable, Mentionable, Permissionable,
-                              UpdatableFromCache<User>, UserAttachableListenerManager {
+        UpdatableFromCache<User>, UserAttachableListenerManager {
 
     @Override
     default String getMentionTag() {
@@ -98,8 +98,8 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
      */
     default Collection<ServerVoiceChannel> getConnectedVoiceChannels() {
         return Collections.unmodifiableCollection(getApi().getServerVoiceChannels().stream()
-                                                          .filter(this::isConnected)
-                                                          .collect(Collectors.toList()));
+                .filter(this::isConnected)
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -227,9 +227,7 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
      * @param server The server.
      * @return The display name of the user.
      */
-    default String getDisplayName(Server server) {
-        return server.getNickname(this).orElseGet(this::getName);
-    }
+    String getDisplayName(Server server);
 
     /**
      * Gets the discriminated name of the user, e. g. {@code Bastian#8222}.
@@ -302,9 +300,7 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
      * @param server The server to check.
      * @return The nickname of the user.
      */
-    default Optional<String> getNickname(Server server) {
-        return server.getNickname(this);
-    }
+    Optional<String> getNickname(Server server);
 
     /**
      * Moves this user to the given channel.
@@ -322,9 +318,7 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
      * @param server The server to check.
      * @return Whether the user is self-muted in the given server.
      */
-    default boolean isSelfMuted(Server server) {
-        return server.isSelfMuted(getId());
-    }
+    boolean isSelfMuted(Server server);
 
     /**
      * Gets the self-deafened state of the user in the given server.
@@ -332,9 +326,7 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
      * @param server The server to check.
      * @return Whether the user is self-deafened in the given server.
      */
-    default boolean isSelfDeafened(Server server) {
-        return server.isSelfDeafened(getId());
-    }
+    boolean isSelfDeafened(Server server);
 
     /**
      * Mutes this user on the given server.
@@ -446,9 +438,7 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
      * @param server The server to check.
      * @return The timestamp of when the user joined the server.
      */
-    default Optional<Instant> getJoinedAtTimestamp(Server server) {
-        return server.getJoinedAtTimestamp(this);
-    }
+    Optional<Instant> getJoinedAtTimestamp(Server server);
 
     /**
      * Gets a sorted list (by position) with all roles of the user in the given server.
@@ -457,9 +447,7 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
      * @return A sorted list (by position) with all roles of the user in the given server.
      * @see Server#getRoles(User)
      */
-    default List<Role> getRoles(Server server) {
-        return server.getRoles(this);
-    }
+    List<Role> getRoles(Server server);
 
     /**
      * Gets the displayed color of the user based on his roles in the given server.
@@ -468,9 +456,7 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
      * @return The color.
      * @see Server#getRoleColor(User)
      */
-    default Optional<Color> getRoleColor(Server server) {
-        return server.getRoleColor(this);
-    }
+    Optional<Color> getRoleColor(Server server);
 
     /**
      * Gets if this user is the user of the connected account.

--- a/javacord-api/src/main/java/org/javacord/api/event/channel/server/ServerChannelChangeOverwrittenPermissionsEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/channel/server/ServerChannelChangeOverwrittenPermissionsEvent.java
@@ -27,12 +27,37 @@ public interface ServerChannelChangeOverwrittenPermissionsEvent extends ServerCh
     Permissions getOldPermissions();
 
     /**
+     * Gets the if of the affected entity.
+     *
+     * @return The id of the affected entity.
+     */
+    long getEntityId();
+
+    /**
+     * Checks if the affected entity is a user.
+     *
+     * @return Whether or not the affected entity is a user.
+     */
+    default boolean isUserEntity() {
+        return !getRole().isPresent();
+    }
+
+    /**
+     * Checks if the affected entity is a role.
+     *
+     * @return Whether or not the affected entity is a role.
+     */
+    default boolean isRoleEntity() {
+        return getRole().isPresent();
+    }
+
+    /**
      * Gets the entity which permissions were changed.
      * The entity is a user or a role.
      *
      * @return The entity which permissions were changed.
      */
-    DiscordEntity getEntity();
+    Optional<DiscordEntity> getEntity();
 
     /**
      * Gets the user which permissions were changed.

--- a/javacord-api/src/main/java/org/javacord/api/event/message/reaction/SingleReactionEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/message/reaction/SingleReactionEvent.java
@@ -4,7 +4,7 @@ import org.javacord.api.entity.emoji.Emoji;
 import org.javacord.api.entity.message.Reaction;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.message.RequestableMessageEvent;
-import org.javacord.api.event.user.UserEvent;
+import org.javacord.api.event.user.OptionalUserEvent;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * A single reaction event.
  */
-public interface SingleReactionEvent extends ReactionEvent, UserEvent {
+public interface SingleReactionEvent extends ReactionEvent, OptionalUserEvent {
 
     /**
      * Gets the emoji of the event.

--- a/javacord-api/src/main/java/org/javacord/api/event/server/ServerChangeOwnerEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/server/ServerChangeOwnerEvent.java
@@ -2,6 +2,8 @@ package org.javacord.api.event.server;
 
 import org.javacord.api.entity.user.User;
 
+import java.util.Optional;
+
 /**
  * A server change owner event.
  */
@@ -12,13 +14,30 @@ public interface ServerChangeOwnerEvent extends ServerEvent {
      *
      * @return The old owner of the server.
      */
-    User getOldOwner();
+    default Optional<User> getOldOwner() {
+        return getApi().getCachedUserById(getOldOwnerId());
+    }
+
+    /**
+     * Gets the id of the old owner of the server.
+     * 
+     * @return The old owner's id.
+     */
+    long getOldOwnerId();
 
     /**
      * Gets the new owner of the server.
      *
      * @return The new owner of the server.
      */
-    User getNewOwner();
+    default Optional<User> getNewOwner() {
+        return getApi().getCachedUserById(getNewOwnerId());
+    }
 
+    /**
+     * Gets the id of the new owner of the server.
+     *
+     * @return The new owner's id.
+     */
+    long getNewOwnerId();
 }

--- a/javacord-api/src/main/java/org/javacord/api/event/user/OptionalUserEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/user/OptionalUserEvent.java
@@ -1,0 +1,51 @@
+package org.javacord.api.event.user;
+
+import org.javacord.api.entity.user.User;
+import org.javacord.api.event.Event;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An optional user event.
+ */
+public interface OptionalUserEvent extends Event {
+
+    /**
+     * Gets the id of the user involved in the event.
+     *
+     * @return The id of the user involved in the event.
+     */
+    long getUserId();
+
+    /**
+     * Gets the id of the user involved in the event.
+     *
+     * @return The id of the user involved in the event.
+     * @see #getUserId()
+     */
+    default String getUserIdAsString() {
+        return String.valueOf(getUserId());
+    }
+
+    /**
+     * Gets the user of the event.
+     *
+     * @return The user of the event.
+     */
+    default Optional<User> getUser() {
+        return getApi().getCachedUserById(getUserId());
+    }
+
+    /**
+     * Requests a user from Discord with the given id.
+     *
+     * <p>If the user is in the cache, the user is served from the cache.
+     *
+     * @return The user.
+     */
+    default CompletableFuture<User> requestUser() {
+        return getApi().getUserById(getUserId());
+    }
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeActivityEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeActivityEvent.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 /**
  * A user change activity event.
  */
-public interface UserChangeActivityEvent extends UserEvent {
+public interface UserChangeActivityEvent extends OptionalUserEvent {
 
     /**
      * Gets the old activity of the user.

--- a/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeStatusEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeStatusEvent.java
@@ -6,7 +6,7 @@ import org.javacord.api.entity.user.UserStatus;
 /**
  * A user change status event.
  */
-public interface UserChangeStatusEvent extends UserEvent {
+public interface UserChangeStatusEvent extends OptionalUserEvent {
 
     /**
      * Gets the old connection status of the user.

--- a/javacord-api/src/main/java/org/javacord/api/event/user/UserStartTypingEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/user/UserStartTypingEvent.java
@@ -1,9 +1,12 @@
 package org.javacord.api.event.user;
 
+import org.javacord.api.event.channel.TextChannelEvent;
+
 /**
  * A event when a user starts typing.
  * If the user starts typing the "xyz is typing..." message is displayed for 5 seconds.
  * It also stops if the user sent a message.
  */
-public interface UserStartTypingEvent extends TextChannelUserEvent {
+public interface UserStartTypingEvent extends TextChannelEvent, OptionalUserEvent {
+
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/auditlog/AuditLogImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/auditlog/AuditLogImpl.java
@@ -8,6 +8,9 @@ import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.webhook.Webhook;
 import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.entity.webhook.WebhookImpl;
 
 import java.util.ArrayList;
@@ -72,7 +75,7 @@ public class AuditLogImpl implements AuditLog {
             boolean alreadyAdded = involvedUsers.stream()
                     .anyMatch(user -> user.getId() == userJson.get("id").asLong());
             if (!alreadyAdded) {
-                involvedUsers.add(((DiscordApiImpl) api).getOrCreateUser(userJson));
+                involvedUsers.add(new UserImpl((DiscordApiImpl) api, userJson, (MemberImpl) null, (ServerImpl) server));
             }
         }
         for (JsonNode entry : data.get("audit_log_entries")) {

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/GroupChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/GroupChannelImpl.java
@@ -11,6 +11,8 @@ import org.javacord.api.entity.user.User;
 import org.javacord.api.util.cache.MessageCache;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.entity.IconImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.listener.channel.group.InternalGroupChannelAttachableListenerManager;
 import org.javacord.core.util.Cleanupable;
 import org.javacord.core.util.cache.MessageCacheImpl;
@@ -76,7 +78,7 @@ public class GroupChannelImpl implements GroupChannel, Cleanupable, InternalText
         this.api = api;
 
         for (JsonNode recipientJson : data.get("recipients")) {
-            recipients.add(api.getOrCreateUser(recipientJson));
+            recipients.add(new UserImpl(api, recipientJson, (MemberImpl) null, null));
         }
 
         messageCache = new MessageCacheImpl(

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/PrivateChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/PrivateChannelImpl.java
@@ -7,6 +7,7 @@ import org.javacord.api.entity.channel.PrivateChannel;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.util.cache.MessageCache;
 import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.entity.user.MemberImpl;
 import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.listener.channel.user.InternalPrivateChannelAttachableListenerManager;
 import org.javacord.core.util.Cleanupable;
@@ -48,13 +49,12 @@ public class PrivateChannelImpl implements PrivateChannel, Cleanupable, Internal
      */
     public PrivateChannelImpl(DiscordApiImpl api, JsonNode data) {
         this.api = api;
-        this.recipient = (UserImpl) api.getOrCreateUser(data.get("recipients").get(0));
-        this.messageCache = new MessageCacheImpl(
+        recipient = new UserImpl(api, data.get("recipients").get(0), (MemberImpl) null, null);
+        messageCache = new MessageCacheImpl(
                 api, api.getDefaultMessageCacheCapacity(), api.getDefaultMessageCacheStorageTimeInSeconds(),
                 api.isDefaultAutomaticMessageCacheCleanupEnabled());
 
         id = Long.parseLong(data.get("id").asText());
-        recipient.setChannel(this);
 
         api.addChannelToCache(this);
     }

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerChannelImpl.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -206,25 +207,13 @@ public abstract class ServerChannelImpl implements ServerChannel, InternalServer
     }
 
     @Override
-    public Map<User, Permissions> getOverwrittenUserPermissions() {
-        Server server = getServer();
-        return Collections.unmodifiableMap(
-                overwrittenUserPermissions.entrySet().stream()
-                        .collect(Collectors.toMap(
-                                entry -> server.getMemberById(entry.getKey()).orElseThrow(AssertionError::new),
-                                Map.Entry::getValue))
-        );
+    public Map<Long, Permissions> getOverwrittenUserPermissions() {
+        return Collections.unmodifiableMap(new HashMap<>(overwrittenUserPermissions));
     }
 
     @Override
-    public Map<Role, Permissions> getOverwrittenRolePermissions() {
-        Server server = getServer();
-        return Collections.unmodifiableMap(
-                overwrittenRolePermissions.entrySet().stream()
-                        .collect(Collectors.toMap(
-                                entry -> server.getRoleById(entry.getKey()).orElseThrow(AssertionError::new),
-                                Map.Entry::getValue))
-        );
+    public Map<Long, Permissions> getOverwrittenRolePermissions() {
+        return Collections.unmodifiableMap(new HashMap<>(overwrittenRolePermissions));
     }
 
     @Override
@@ -261,7 +250,8 @@ public abstract class ServerChannelImpl implements ServerChannel, InternalServer
             }
         }
         for (PermissionType type : PermissionType.values()) {
-            Permissions permissions = getOverwrittenPermissions(user);
+            Permissions permissions = overwrittenUserPermissions
+                    .getOrDefault(user.getId(), PermissionsImpl.EMPTY_PERMISSIONS);
             if (permissions.getState(type) == PermissionState.DENIED) {
                 builder.setState(type, PermissionState.DENIED);
             }

--- a/javacord-core/src/main/java/org/javacord/core/entity/emoji/KnownCustomEmojiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/emoji/KnownCustomEmojiImpl.java
@@ -6,6 +6,9 @@ import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.listener.server.emoji.InternalKnownCustomEmojiAttachableListenerManager;
 import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
@@ -129,7 +132,8 @@ public class KnownCustomEmojiImpl extends CustomEmojiImpl
                             return Optional.empty();
                         } else {
                             creatorId = userJson.get("id").asLong();
-                            return Optional.of(((DiscordApiImpl) getApi()).getOrCreateUser(userJson));
+                            return Optional.of(new UserImpl(
+                                    (DiscordApiImpl) getApi(), userJson, (MemberImpl) null, (ServerImpl) server));
                         }
                     });
         } else {

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderDelegateImpl.java
@@ -18,6 +18,7 @@ import org.javacord.api.entity.user.User;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.entity.message.embed.EmbedBuilderDelegateImpl;
 import org.javacord.core.entity.message.mention.AllowedMentionsImpl;
+import org.javacord.core.entity.user.Member;
 import org.javacord.core.util.FileContainer;
 import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
@@ -275,6 +276,8 @@ public class MessageBuilderDelegateImpl implements MessageBuilderDelegate {
             return send((TextChannel) messageable);
         } else if (messageable instanceof User) {
             return ((User) messageable).openPrivateChannel().thenCompose(this::send);
+        } else if (messageable instanceof Member) {
+            return send(((Member) messageable).getUser());
         }
         throw new IllegalStateException("Messageable of unknown type");
     }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
@@ -19,6 +19,9 @@ import org.javacord.api.util.DiscordRegexPattern;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 import org.javacord.core.entity.message.embed.EmbedImpl;
+import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.listener.message.InternalMessageAttachableListenerManager;
 import org.javacord.core.util.cache.MessageCacheImpl;
 
@@ -148,7 +151,7 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
         type = MessageType.byType(data.get("type").asInt(), data.has("webhook_id"));
 
         Long webhookId = data.has("webhook_id") ? data.get("webhook_id").asLong() : null;
-        author = new MessageAuthorImpl(this, webhookId, data.get("author"));
+        author = new MessageAuthorImpl(this, webhookId, data);
 
         MessageCacheImpl cache = (MessageCacheImpl) channel.getMessageCache();
         cache.addMessage(this);
@@ -176,7 +179,8 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
 
         if (data.has("mentions")) {
             for (JsonNode mentionJson : data.get("mentions")) {
-                User user = api.getOrCreateUser(mentionJson);
+                User user = new UserImpl(api, mentionJson, (MemberImpl) null,
+                        getServer().map(ServerImpl.class::cast).orElse(null));
                 mentions.add(user);
             }
         }

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/BanImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/BanImpl.java
@@ -5,6 +5,8 @@ import org.javacord.api.entity.server.Ban;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 
 import java.util.Optional;
 
@@ -36,8 +38,8 @@ public class BanImpl implements Ban {
      */
     public BanImpl(Server server, JsonNode data) {
         this.server = server;
-        this.user = ((DiscordApiImpl) server.getApi()).getOrCreateUser(data.get("user"));
-        this.reason = data.has("reason") ? data.get("reason").asText() : null;
+        user = new UserImpl((DiscordApiImpl) server.getApi(), data.get("user"), (MemberImpl) null, (ServerImpl) server);
+        reason = data.has("reason") ? data.get("reason").asText() : null;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -755,7 +755,7 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
         }
 
         synchronized (readyConsumers) {
-            if (!ready && getMembers().size() == getMemberCount()) {
+            if (!ready && getRealMembers().size() == getMemberCount()) {
                 ready = true;
                 readyConsumers.forEach(consumer -> consumer.accept(this));
                 readyConsumers.clear();
@@ -1255,7 +1255,9 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
 
     @Override
     public boolean isMember(User user) {
-        return getMemberById(user.getId()).isPresent();
+        return api.getEntityCache().get().getMemberCache()
+                .getMemberByIdAndServer(id, getId())
+                .isPresent();
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/invite/InviteImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/invite/InviteImpl.java
@@ -13,6 +13,9 @@ import org.javacord.api.entity.server.invite.RichInvite;
 import org.javacord.api.entity.user.User;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.entity.IconImpl;
+import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.util.logging.LoggerUtil;
 import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
@@ -155,8 +158,10 @@ public class InviteImpl implements RichInvite {
                 : null;
 
         // Rich data (may not be present)
+        MemberImpl member = null;
         this.inviter = data.has("inviter")
-                ? ((DiscordApiImpl) api).getOrCreateUser(data.get("inviter"))
+                ? new UserImpl((DiscordApiImpl) api, data.get("inviter"), member,
+                getServer().map(ServerImpl.class::cast).orElse(null))
                 : null;
         this.uses = data.has("uses") ? data.get("uses").asInt() : -1;
         this.maxUses = data.has("max_uses") ? data.get("max_uses").asInt() : -1;

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/Member.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/Member.java
@@ -1,0 +1,98 @@
+package org.javacord.core.entity.user;
+
+import org.javacord.api.entity.DiscordEntity;
+import org.javacord.api.entity.Mentionable;
+import org.javacord.api.entity.Permissionable;
+import org.javacord.api.entity.message.Messageable;
+import org.javacord.api.entity.permission.Role;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.entity.user.User;
+
+import java.awt.Color;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A member of a server.
+ */
+public interface Member extends DiscordEntity, Messageable, Mentionable, Permissionable {
+
+    @Override
+    default String getMentionTag() {
+        return "<@!" + getIdAsString() + ">";
+    }
+
+    /**
+     * Gets the display name of this member.
+     *
+     * @return The display name of this member.
+     */
+    default String getDisplayName() {
+        return getNickname().orElse(getUser().getName());
+    }
+
+    /**
+     * Gets the server, this user is a part of.
+     *
+     * @return The server.
+     */
+    Server getServer();
+
+    /**
+     * Gets the user object linked to this member.
+     *
+     * @return The user.
+     */
+    User getUser();
+
+    /**
+     * Gets the nickname of this member.
+     *
+     * @return The nickname of this member.
+     */
+    Optional<String> getNickname();
+
+    /**
+     * Gets a sorted list (by position) with all roles of this member.
+     *
+     * @return A sorted list (by position) with all roles of this member.
+     */
+    List<Role> getRoles();
+
+    /**
+     * Gets the displayed color of this member based on his roles.
+     *
+     * @return The color.
+     */
+    Optional<Color> getRoleColor();
+
+    /**
+     * Gets the timestamp of when this member joined the server.
+     *
+     * @return The timestamp of when this member joined the server.
+     */
+    Instant getJoinedAtTimestamp();
+
+    /**
+     * Gets the timestamp of when this member started boosting the server.
+     *
+     * @return The timestamp of when this member started boosting joined the server.
+     */
+    Optional<Instant> getServerBoostingSinceTimestamp();
+
+    /**
+     * Gets the self-muted state of this member.
+     *
+     * @return Whether or not this member is self-muted.
+     */
+    boolean isSelfMuted();
+
+    /**
+     * Gets the self-deafened state of this member.
+     *
+     * @return Whether or not this member is self-deafened.
+     */
+    boolean isSelfDeafened();
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/MemberImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/MemberImpl.java
@@ -72,8 +72,16 @@ public final class MemberImpl implements Member {
             serverBoostingSince = null;
         }
 
-        selfDeafened = data.get("deaf").asBoolean();
-        selfMuted = data.get("mute").asBoolean();
+        if (data.hasNonNull("deaf")) {
+            selfDeafened = data.get("deaf").asBoolean();
+        } else {
+            selfDeafened = false;
+        }
+        if (data.hasNonNull("mute")) {
+            selfMuted = data.get("mute").asBoolean();
+        } else {
+            selfMuted = false;
+        }
     }
 
     private MemberImpl(DiscordApiImpl api, ServerImpl server, UserImpl user, String nickname, List<Long> roleIds,
@@ -124,6 +132,15 @@ public final class MemberImpl implements Member {
     }
 
     /**
+     * Gets a list with the member's role ids.
+     *
+     * @return A list with the member's role ids.
+     */
+    public List<Long> getRoleIds() {
+        return roleIds;
+    }
+
+    /**
      * Creates a new member object with the new nickname.
      *
      * @param nickname The new nickname.
@@ -143,6 +160,15 @@ public final class MemberImpl implements Member {
     public MemberImpl setServerBoostingSince(String serverBoostingSince) {
         return new MemberImpl(
                 api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted);
+    }
+
+    /**
+     * Gets the string value of the server boosting since field.
+     *
+     * @return The server boosting since field.
+     */
+    public String getServerBoostingSince() {
+        return serverBoostingSince;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/MemberImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/MemberImpl.java
@@ -1,0 +1,217 @@
+package org.javacord.core.entity.user;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.permission.Role;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.entity.user.User;
+import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.entity.server.ServerImpl;
+
+import java.awt.Color;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Maps a member object.
+ *
+ * @see <a href="https://discord.com/developers/docs/resources/guild#guild-member-object">Discord Docs</a>
+ */
+public final class MemberImpl implements Member {
+
+    private final DiscordApiImpl api;
+    private final ServerImpl server;
+    private final UserImpl user;
+    private final String nickname;
+    private final List<Long> roleIds;
+    private final String joinedAt;
+    private final String serverBoostingSince;
+    private final boolean selfDeafened;
+    private final boolean selfMuted;
+
+    /**
+     * Creates a new immutable member instance.
+     *
+     * @param api The api instance.
+     * @param server The server of the member.
+     * @param data The json data of the member.
+     * @param user A user object in case the json does not contain user data (e.g., for message create events).
+     *             If the json contains a non-null user field, this parameter is ignored.
+     */
+    public MemberImpl(DiscordApiImpl api, ServerImpl server, JsonNode data, UserImpl user) {
+        this.api = api;
+        this.server = server;
+
+        if (data.hasNonNull("user")) {
+            this.user = new UserImpl(api, data.get("user"), this, null);
+        } else {
+            this.user = user;
+        }
+
+        if (data.hasNonNull("nick")) {
+            nickname = data.get("nick").asText();
+        } else {
+            nickname = null;
+        }
+
+        roleIds = new ArrayList<>();
+        for (JsonNode roleIdJson : data.get("roles")) {
+            roleIds.add(roleIdJson.asLong());
+        }
+        roleIds.add(server.getEveryoneRole().getId());
+
+        joinedAt = data.get("joined_at").asText();
+        if (data.hasNonNull("premium_since")) {
+            serverBoostingSince = data.get("premium_since").asText();
+        } else {
+            serverBoostingSince = null;
+        }
+
+        selfDeafened = data.get("deaf").asBoolean();
+        selfMuted = data.get("mute").asBoolean();
+    }
+
+    private MemberImpl(DiscordApiImpl api, ServerImpl server, UserImpl user, String nickname, List<Long> roleIds,
+                       String joinedAt, String serverBoostingSince, boolean selfDeafened, boolean selfMuted) {
+        this.api = api;
+        this.server = server;
+        this.user = user;
+        this.nickname = nickname;
+        this.roleIds = roleIds;
+        this.joinedAt = joinedAt;
+        this.serverBoostingSince = serverBoostingSince;
+        this.selfDeafened = selfDeafened;
+        this.selfMuted = selfMuted;
+    }
+
+    /**
+     * Creates a new member object with the new user.
+     *
+     * @param user The new user.
+     * @return The new member.
+     */
+    public MemberImpl setUser(UserImpl user) {
+        return new MemberImpl(
+                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted);
+    }
+
+    /**
+     * Creates a new member object with the new partial user data.
+     *
+     * @param partialUserJson The new partial user data.
+     * @return The new member.
+     */
+    public MemberImpl setPartialUser(JsonNode partialUserJson) {
+        return new MemberImpl(api, server, user.replacePartialUserData(partialUserJson), nickname, roleIds, joinedAt,
+                serverBoostingSince, selfDeafened, selfMuted);
+    }
+
+    /**
+     * Creates a new member object with the new role ids.
+     *
+     * @param roleIds The new role ids.
+     * @return The new member.
+     */
+    public MemberImpl setRoleIds(List<Long> roleIds) {
+        roleIds.add(server.getEveryoneRole().getId());
+        return new MemberImpl(
+                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted);
+    }
+
+    /**
+     * Creates a new member object with the new nickname.
+     *
+     * @param nickname The new nickname.
+     * @return The new member.
+     */
+    public MemberImpl setNickname(String nickname) {
+        return new MemberImpl(
+                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted);
+    }
+
+    /**
+     * Creates a new member object with the new nickname.
+     *
+     * @param serverBoostingSince The new timestamp when the user started boosting the server.
+     * @return The new member.
+     */
+    public MemberImpl setServerBoostingSince(String serverBoostingSince) {
+        return new MemberImpl(
+                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted);
+    }
+
+    @Override
+    public DiscordApi getApi() {
+        return api;
+    }
+
+    @Override
+    public long getId() {
+        return user.getId();
+    }
+
+    @Override
+    public Server getServer() {
+        return server;
+    }
+
+    @Override
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public Optional<String> getNickname() {
+        return Optional.ofNullable(nickname);
+    }
+
+    @Override
+    public List<Role> getRoles() {
+        return roleIds.stream()
+                .map(server::getRoleById)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Color> getRoleColor() {
+        return getRoles().stream()
+                .filter(role -> role.getColor().isPresent())
+                .max(Comparator.comparingInt(Role::getRawPosition))
+                .flatMap(Role::getColor);
+    }
+
+    @Override
+    public Instant getJoinedAtTimestamp() {
+        return OffsetDateTime.parse(joinedAt).toInstant();
+    }
+
+    @Override
+    public Optional<Instant> getServerBoostingSinceTimestamp() {
+        return Optional.ofNullable(serverBoostingSince)
+                .map(OffsetDateTime::parse)
+                .map(OffsetDateTime::toInstant);
+    }
+
+    @Override
+    public boolean isSelfMuted() {
+        return selfMuted;
+    }
+
+    @Override
+    public boolean isSelfDeafened() {
+        return selfDeafened;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Member (id: %s, display name: %s)", getIdAsString(), getDisplayName());
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserPresence.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserPresence.java
@@ -1,0 +1,99 @@
+package org.javacord.core.entity.user;
+
+import io.vavr.collection.Map;
+import org.javacord.api.entity.DiscordClient;
+import org.javacord.api.entity.activity.Activity;
+import org.javacord.api.entity.user.UserStatus;
+
+/**
+ * Internal class for easy caching of user presences.
+ */
+public class UserPresence {
+
+    private final long userId;
+    private final Activity activity;
+    private final UserStatus status;
+    private final Map<DiscordClient, UserStatus> clientStatus;
+
+    /**
+     * Creates a new user presence instance.
+     * 
+     * @param userId The id of the user.
+     * @param activity The activity.
+     * @param status The status.
+     * @param clientStatus The client status.
+     */
+    public UserPresence(
+            long userId, Activity activity, UserStatus status, Map<DiscordClient, UserStatus> clientStatus) {
+        this.userId = userId;
+        this.activity = activity;
+        this.status = status;
+        this.clientStatus = clientStatus;
+    }
+
+    /**
+     * Gets the id of the user that this presence "belongs" to.
+     * 
+     * @return The id of the user.
+     */
+    public long getUserId() {
+        return userId;
+    }
+
+    /**
+     * Sets the activity.
+     * 
+     * @param activity The activity to set.
+     * @return The new user presence with the updated activity.
+     */
+    public UserPresence setActivity(Activity activity) {
+        return new UserPresence(userId, activity, status, clientStatus);
+    }
+
+    /**
+     * Gets the presence's activity.
+     * 
+     * @return The presence's activity.
+     */
+    public Activity getActivity() {
+        return activity;
+    }
+
+    /**
+     * Sets the status.
+     *
+     * @param status The status to set.
+     * @return The new user presence with the updated status.
+     */
+    public UserPresence setStatus(UserStatus status) {
+        return new UserPresence(userId, activity, status, clientStatus);
+    }
+
+    /**
+     * Gets the presence's status.
+     *
+     * @return The presence's status.
+     */
+    public UserStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * Sets the client status.
+     *
+     * @param clientStatus The client status to set.
+     * @return The new user presence with the updated client status.
+     */
+    public UserPresence setClientStatus(Map<DiscordClient, UserStatus> clientStatus) {
+        return new UserPresence(userId, activity, status, clientStatus);
+    }
+
+    /**
+     * Gets the presence's client status.
+     *
+     * @return The presence's client status.
+     */
+    public Map<DiscordClient, UserStatus> getClientStatus() {
+        return clientStatus;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/webhook/WebhookImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/webhook/WebhookImpl.java
@@ -12,6 +12,8 @@ import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.webhook.Webhook;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.entity.IconImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.listener.webhook.InternalWebhookAttachableListenerManager;
 import org.javacord.core.util.logging.LoggerUtil;
 import org.javacord.core.util.rest.RestEndpoint;
@@ -56,7 +58,8 @@ public class WebhookImpl implements Webhook, InternalWebhookAttachableListenerMa
         this.id = Long.parseLong(data.get("id").asText());
         this.serverId = data.has("guild_id") ? Long.parseLong(data.get("guild_id").asText()) : null;
         this.channelId = Long.parseLong(data.get("channel_id").asText());
-        this.user = data.has("user") ? this.api.getOrCreateUser(data.get("user")) : null;
+        this.user = data.has("user")
+                ? new UserImpl((DiscordApiImpl) api, data.get("user"), (MemberImpl) null, null) : null;
         this.name = data.has("name") && !data.get("name").isNull() ? data.get("name").asText() : null;
         this.avatarId = data.has("avatar") && !data.get("avatar").isNull() ? data.get("avatar").asText() : null;
         this.token = data.has("token") ? data.get("token").asText() : null;

--- a/javacord-core/src/main/java/org/javacord/core/event/channel/server/ServerChannelChangeOverwrittenPermissionsEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/channel/server/ServerChannelChangeOverwrittenPermissionsEventImpl.java
@@ -26,6 +26,11 @@ public class ServerChannelChangeOverwrittenPermissionsEventImpl extends ServerCh
     private final Permissions oldPermissions;
 
     /**
+     * The id of the entity.
+     */
+    private final long entityId;
+
+    /**
      * The entity which permissions got changed.
      */
     private final DiscordEntity entity;
@@ -36,13 +41,16 @@ public class ServerChannelChangeOverwrittenPermissionsEventImpl extends ServerCh
      * @param channel The channel of the event.
      * @param newPermissions The new overwritten permissions.
      * @param oldPermissions The old overwritten permissions.
+     * @param entityId The id of the entity.
      * @param entity The entity which permissions got changed.
      */
     public ServerChannelChangeOverwrittenPermissionsEventImpl(
-            ServerChannel channel, Permissions newPermissions, Permissions oldPermissions, DiscordEntity entity) {
+            ServerChannel channel, Permissions newPermissions, Permissions oldPermissions, long entityId,
+            DiscordEntity entity) {
         super(channel);
         this.newPermissions = newPermissions;
         this.oldPermissions = oldPermissions;
+        this.entityId = entityId;
         this.entity = entity;
     }
 
@@ -57,8 +65,13 @@ public class ServerChannelChangeOverwrittenPermissionsEventImpl extends ServerCh
     }
 
     @Override
-    public DiscordEntity getEntity() {
-        return entity;
+    public long getEntityId() {
+        return entityId;
+    }
+
+    @Override
+    public Optional<DiscordEntity> getEntity() {
+        return Optional.ofNullable(entity);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/event/message/MessageEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/message/MessageEventImpl.java
@@ -125,7 +125,7 @@ public abstract class MessageEventImpl extends EventImpl implements MessageEvent
 
     @Override
     public CompletableFuture<Void> removeReactionByEmojiFromMessage(User user, Emoji emoji) {
-        return Reaction.removeUser(getApi(), getChannel().getId(), getMessageId(), emoji, user);
+        return Reaction.removeUser(getApi(), getChannel().getId(), getMessageId(), emoji, user.getId());
     }
 
     @Override
@@ -139,7 +139,7 @@ public abstract class MessageEventImpl extends EventImpl implements MessageEvent
                 .thenCompose(users -> CompletableFuture.allOf(
                         users.stream()
                                 .map(user -> Reaction.removeUser(getApi(), getChannel().getId(),
-                                        getMessageId(), emoji, user))
+                                        getMessageId(), emoji, user.getId()))
                                 .toArray(CompletableFuture[]::new)));
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/event/message/reaction/ReactionAddEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/message/reaction/ReactionAddEventImpl.java
@@ -4,8 +4,8 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.emoji.Emoji;
 import org.javacord.api.entity.message.Reaction;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.event.message.reaction.ReactionAddEvent;
+import org.javacord.core.entity.user.Member;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -21,15 +21,17 @@ public class ReactionAddEventImpl extends SingleReactionEventImpl implements Rea
      * @param messageId The id of the message.
      * @param channel The text channel in which the message was sent.
      * @param emoji The emoji.
-     * @param user The user who added the reaction.
+     * @param userId The if of the user who added the reaction.
+     * @param member The member if it happened in a server.
      */
-    public ReactionAddEventImpl(DiscordApi api, long messageId, TextChannel channel, Emoji emoji, User user) {
-        super(api, messageId, channel, emoji, user);
+    public ReactionAddEventImpl(
+            DiscordApi api, long messageId, TextChannel channel, Emoji emoji, long userId, Member member) {
+        super(api, messageId, channel, emoji, userId);
     }
 
     @Override
     public CompletableFuture<Void> removeReaction() {
-        return Reaction.removeUser(getApi(), getChannel().getId(), getMessageId(), getEmoji(), getUser());
+        return Reaction.removeUser(getApi(), getChannel().getId(), getMessageId(), getEmoji(), getUserId());
     }
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/message/reaction/ReactionRemoveEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/message/reaction/ReactionRemoveEventImpl.java
@@ -3,7 +3,6 @@ package org.javacord.core.event.message.reaction;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.emoji.Emoji;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.event.message.reaction.ReactionRemoveEvent;
 
 /**
@@ -18,10 +17,10 @@ public class ReactionRemoveEventImpl extends SingleReactionEventImpl implements 
      * @param messageId The id of the message.
      * @param channel The text channel in which the message was sent.
      * @param emoji The emoji.
-     * @param user The user whose reaction got removed.
+     * @param userId The if of the user whose reaction got removed.
      */
-    public ReactionRemoveEventImpl(DiscordApi api, long messageId, TextChannel channel, Emoji emoji, User user) {
-        super(api, messageId, channel, emoji, user);
+    public ReactionRemoveEventImpl(DiscordApi api, long messageId, TextChannel channel, Emoji emoji, long userId) {
+        super(api, messageId, channel, emoji, userId);
     }
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/message/reaction/SingleReactionEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/message/reaction/SingleReactionEventImpl.java
@@ -25,7 +25,7 @@ public abstract class SingleReactionEventImpl extends RequestableMessageEventImp
     /**
      * The user of the event.
      */
-    private final User user;
+    private final long userId;
 
     /**
      * Creates a new single reaction event.
@@ -34,12 +34,12 @@ public abstract class SingleReactionEventImpl extends RequestableMessageEventImp
      * @param messageId The id of the message.
      * @param channel The text channel in which the message was sent.
      * @param emoji The emoji.
-     * @param user The "owner" of the reaction.
+     * @param userId The id of the "owner" of the reaction.
      */
-    public SingleReactionEventImpl(DiscordApi api, long messageId, TextChannel channel, Emoji emoji, User user) {
+    public SingleReactionEventImpl(DiscordApi api, long messageId, TextChannel channel, Emoji emoji, long userId) {
         super(api, messageId, channel);
         this.emoji = emoji;
-        this.user = user;
+        this.userId = userId;
     }
 
     @Override
@@ -48,8 +48,8 @@ public abstract class SingleReactionEventImpl extends RequestableMessageEventImp
     }
 
     @Override
-    public User getUser() {
-        return user;
+    public long getUserId() {
+        return userId;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/event/server/ServerChangeOwnerEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/server/ServerChangeOwnerEventImpl.java
@@ -1,7 +1,6 @@
 package org.javacord.core.event.server;
 
 import org.javacord.api.entity.server.Server;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.event.server.ServerChangeOwnerEvent;
 
 /**
@@ -12,35 +11,33 @@ public class ServerChangeOwnerEventImpl extends ServerEventImpl implements Serve
     /**
      * The id of the new owner of the server.
      */
-    private final Long newOwnerId;
+    private final long newOwnerId;
 
     /**
-     * The old owner of the server.
+     * The id of the old owner of the server.
      */
-    private final User oldOwner;
+    private final long oldOwnerId;
 
     /**
      * Creates a new server change owner event.
      *
      * @param server The server of the event.
      * @param newOwnerId The id of the new owner of the server.
-     * @param oldOwner The old owner of the server.
+     * @param oldOwnerId The id of the old owner of the server.
      */
-    public ServerChangeOwnerEventImpl(Server server, Long newOwnerId, User oldOwner) {
+    public ServerChangeOwnerEventImpl(Server server, long newOwnerId, long oldOwnerId) {
         super(server);
         this.newOwnerId = newOwnerId;
-        this.oldOwner = oldOwner;
+        this.oldOwnerId = oldOwnerId;
     }
 
     @Override
-    public User getOldOwner() {
-        return oldOwner;
+    public long getOldOwnerId() {
+        return oldOwnerId;
     }
 
     @Override
-    public User getNewOwner() {
-        // server related events should only get dispatched after all members are cached
-        return getApi().getCachedUserById(newOwnerId).orElseThrow(AssertionError::new);
+    public long getNewOwnerId() {
+        return newOwnerId;
     }
-
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/server/member/ServerMemberBanEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/server/member/ServerMemberBanEventImpl.java
@@ -4,6 +4,7 @@ import org.javacord.api.entity.server.Ban;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.server.member.ServerMemberBanEvent;
+import org.javacord.core.event.server.ServerEventImpl;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -11,7 +12,9 @@ import java.util.concurrent.CompletableFuture;
 /**
  * The implementation of {@link ServerMemberBanEvent}.
  */
-public class ServerMemberBanEventImpl extends ServerMemberEventImpl implements ServerMemberBanEvent {
+public class ServerMemberBanEventImpl extends ServerEventImpl implements ServerMemberBanEvent {
+
+    private final User user;
 
     /**
      * Creates a new server member ban event.
@@ -20,7 +23,8 @@ public class ServerMemberBanEventImpl extends ServerMemberEventImpl implements S
      * @param user The user of the event.
      */
     public ServerMemberBanEventImpl(Server server, User user) {
-        super(server, user);
+        super(server);
+        this.user = user;
     }
 
     @Override
@@ -29,5 +33,10 @@ public class ServerMemberBanEventImpl extends ServerMemberEventImpl implements S
                 .thenApply(bans -> bans.stream()
                         .filter(ban -> ban.getUser().equals(getUser()))
                         .findAny());
+    }
+
+    @Override
+    public User getUser() {
+        return user;
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/server/role/UserRoleAddEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/server/role/UserRoleAddEventImpl.java
@@ -1,8 +1,8 @@
 package org.javacord.core.event.server.role;
 
 import org.javacord.api.entity.permission.Role;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.event.server.role.UserRoleAddEvent;
+import org.javacord.core.entity.user.Member;
 
 /**
  * The implementation of {@link UserRoleAddEvent}.
@@ -13,10 +13,10 @@ public class UserRoleAddEventImpl extends UserRoleEventImpl implements UserRoleA
      * Creates a new user role add event.
      *
      * @param role The role of the event.
-     * @param user The user of the event.
+     * @param member The member of the event.
      */
-    public UserRoleAddEventImpl(Role role, User user) {
-        super(role, user);
+    public UserRoleAddEventImpl(Role role, Member member) {
+        super(role, member);
     }
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/server/role/UserRoleEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/server/role/UserRoleEventImpl.java
@@ -3,30 +3,28 @@ package org.javacord.core.event.server.role;
 import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.server.role.UserRoleEvent;
+import org.javacord.core.entity.user.Member;
 
 /**
  * The implementation of {@link UserRoleEvent}.
  */
 public abstract class UserRoleEventImpl extends RoleEventImpl implements UserRoleEvent {
 
-    /**
-     * The user of the event.
-     */
-    private final User user;
+    private final Member member;
 
     /**
-     * Creates a new user role event.
+     * Creates a new member role event.
      *
      * @param role The role of the event.
-     * @param user The user of the event.
+     * @param member The member of the event.
      */
-    public UserRoleEventImpl(Role role, User user) {
+    public UserRoleEventImpl(Role role, Member member) {
         super(role);
-        this.user = user;
+        this.member = member;
     }
 
     @Override
     public User getUser() {
-        return user;
+        return member.getUser();
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/server/role/UserRoleRemoveEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/server/role/UserRoleRemoveEventImpl.java
@@ -1,8 +1,8 @@
 package org.javacord.core.event.server.role;
 
 import org.javacord.api.entity.permission.Role;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.event.server.role.UserRoleRemoveEvent;
+import org.javacord.core.entity.user.Member;
 
 /**
  * The implementation of {@link UserRoleRemoveEvent}.
@@ -10,13 +10,13 @@ import org.javacord.api.event.server.role.UserRoleRemoveEvent;
 public class UserRoleRemoveEventImpl extends UserRoleEventImpl implements UserRoleRemoveEvent {
 
     /**
-     * Creates a new user role remove event.
+     * Creates a new member role remove event.
      *
      * @param role The role of the event.
-     * @param user The user of the event.
+     * @param member The member of the event.
      */
-    public UserRoleRemoveEventImpl(Role role, User user) {
-        super(role, user);
+    public UserRoleRemoveEventImpl(Role role, Member member) {
+        super(role, member);
     }
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/user/ChannelUserEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/ChannelUserEventImpl.java
@@ -3,24 +3,23 @@ package org.javacord.core.event.user;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.user.TextChannelUserEvent;
+import org.javacord.core.entity.user.Member;
 
 /**
  * The implementation of {@link TextChannelUserEvent}.
  */
 public abstract class ChannelUserEventImpl extends UserEventImpl implements TextChannelUserEvent {
 
-    /**
-     * The text channel of the event.
-     */
     private final TextChannel channel;
 
     /**
      * Creates a new text channel user event.
      *
      * @param user The user of the event.
+     * @param member The member of the event.
      * @param channel The text channel of the event.
      */
-    public ChannelUserEventImpl(User user, TextChannel channel) {
+    public ChannelUserEventImpl(User user, Member member, TextChannel channel) {
         super(user);
         this.channel = channel;
     }
@@ -29,5 +28,4 @@ public abstract class ChannelUserEventImpl extends UserEventImpl implements Text
     public TextChannel getChannel() {
         return channel;
     }
-
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/user/OptionalUserEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/OptionalUserEventImpl.java
@@ -1,0 +1,32 @@
+package org.javacord.core.event.user;
+
+import org.javacord.api.DiscordApi;
+import org.javacord.api.event.user.OptionalUserEvent;
+import org.javacord.core.event.EventImpl;
+
+/**
+ * The implementation of {@link OptionalUserEvent}.
+ */
+public abstract class OptionalUserEventImpl extends EventImpl implements OptionalUserEvent {
+
+    /**
+     * The id of the user of the event.
+     */
+    private final long userId;
+
+    /**
+     * Creates a new optional user event.
+     *
+     * @param api The discord api instance.
+     * @param userId The id of the user of the event.
+     */
+    public OptionalUserEventImpl(DiscordApi api, long userId) {
+        super(api);
+        this.userId = userId;
+    }
+
+    @Override
+    public long getUserId() {
+        return userId;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/event/user/ServerUserEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/ServerUserEventImpl.java
@@ -6,8 +6,6 @@ import org.javacord.api.event.user.TextChannelUserEvent;
 import org.javacord.api.event.user.UserEvent;
 import org.javacord.core.event.server.ServerEventImpl;
 
-import java.util.function.Supplier;
-
 /**
  * The implementation of {@link TextChannelUserEvent}.
  */
@@ -16,7 +14,7 @@ public abstract class ServerUserEventImpl extends ServerEventImpl implements Use
     /**
      * The supplier for the user of the event.
      */
-    private final Supplier<User> userSupplier;
+    private final User user;
 
     /**
      * Creates a new server user event.
@@ -26,24 +24,12 @@ public abstract class ServerUserEventImpl extends ServerEventImpl implements Use
      */
     public ServerUserEventImpl(User user, Server server) {
         super(server);
-        this.userSupplier = () -> user;
-    }
-
-    /**
-     * Creates a new server user event.
-     *
-     * @param userId The id of the user of the event.
-     * @param server The server of the event.
-     */
-    public ServerUserEventImpl(long userId, Server server) {
-        super(server);
-        // server related events should only get dispatched after all members are cached
-        this.userSupplier = () -> getApi().getCachedUserById(userId).orElseThrow(AssertionError::new);
+        this.user = user;
     }
 
     @Override
     public User getUser() {
-        return userSupplier.get();
+        return user;
     }
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeActivityEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeActivityEventImpl.java
@@ -1,7 +1,7 @@
 package org.javacord.core.event.user;
 
+import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.activity.Activity;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.event.user.UserChangeActivityEvent;
 
 import java.util.Optional;
@@ -9,7 +9,7 @@ import java.util.Optional;
 /**
  * The implementation of {@link UserChangeActivityEvent}.
  */
-public class UserChangeActivityEventImpl extends UserEventImpl implements UserChangeActivityEvent {
+public class UserChangeActivityEventImpl extends OptionalUserEventImpl implements UserChangeActivityEvent {
 
     /**
      * The new activity of the user.
@@ -24,12 +24,13 @@ public class UserChangeActivityEventImpl extends UserEventImpl implements UserCh
     /**
      * Creates a new user change activity event.
      *
-     * @param user The user of the event.
+     * @param api The discord api instance.
+     * @param userId The id of the user of the event.
      * @param newActivity The new activity of the user.
      * @param oldActivity The old activity of the user.
      */
-    public UserChangeActivityEventImpl(User user, Activity newActivity, Activity oldActivity) {
-        super(user);
+    public UserChangeActivityEventImpl(DiscordApi api, long userId, Activity newActivity, Activity oldActivity) {
+        super(api, userId);
         this.newActivity = newActivity;
         this.oldActivity = oldActivity;
     }

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeDeafenedEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeDeafenedEventImpl.java
@@ -1,45 +1,36 @@
 package org.javacord.core.event.user;
 
-import org.javacord.api.entity.server.Server;
 import org.javacord.api.event.user.UserChangeDeafenedEvent;
+import org.javacord.core.entity.user.Member;
 
 /**
  * The implementation of {@link UserChangeDeafenedEvent}.
  */
 public class UserChangeDeafenedEventImpl extends ServerUserEventImpl implements UserChangeDeafenedEvent {
 
-    /**
-     * The new deafened state of the user.
-     */
-    private final boolean newDeafened;
-
-    /**
-     * The old deafened state of the user.
-     */
-    private final boolean oldDeafened;
+    private final Member newMember;
+    private final Member oldMember;
 
     /**
      * Creates a new user change deafened event.
      *
-     * @param userId The id of the user of the event.
-     * @param server The server in which the deafened state of the user was changed.
-     * @param newDeafened The new deafened state of the user.
-     * @param oldDeafened The old deafened state of the user.
+     * @param newMember The new member.
+     * @param oldMember The old member.
      */
-    public UserChangeDeafenedEventImpl(long userId, Server server, boolean newDeafened, boolean oldDeafened) {
-        super(userId, server);
-        this.newDeafened = newDeafened;
-        this.oldDeafened = oldDeafened;
+    public UserChangeDeafenedEventImpl(Member newMember, Member oldMember) {
+        super(newMember.getUser(), newMember.getServer());
+        this.newMember = newMember;
+        this.oldMember = oldMember;
     }
 
     @Override
     public boolean isNewDeafened() {
-        return newDeafened;
+        // TODO This is wrong.
+        return newMember.isSelfDeafened();
     }
 
     @Override
     public boolean isOldDeafened() {
-        return oldDeafened;
+        return oldMember.isSelfDeafened();
     }
-
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeMutedEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeMutedEventImpl.java
@@ -1,45 +1,35 @@
 package org.javacord.core.event.user;
 
-import org.javacord.api.entity.server.Server;
 import org.javacord.api.event.user.UserChangeMutedEvent;
+import org.javacord.core.entity.user.Member;
 
 /**
  * The implementation of {@link UserChangeMutedEvent}.
  */
 public class UserChangeMutedEventImpl extends ServerUserEventImpl implements UserChangeMutedEvent {
 
-    /**
-     * The new muted state of the user.
-     */
-    private final boolean newMuted;
-
-    /**
-     * The old muted state of the user.
-     */
-    private final boolean oldMuted;
+    private final Member newMember;
+    private final Member oldMember;
 
     /**
      * Creates a new user change muted event.
      *
-     * @param userId The id of the user of the event.
-     * @param server The server in which the muted state of the user was changed.
-     * @param newMuted The new muted state of the user.
-     * @param oldMuted The old muted state of the user.
+     * @param newMember The new member.
+     * @param oldMember The old member.
      */
-    public UserChangeMutedEventImpl(long userId, Server server, boolean newMuted, boolean oldMuted) {
-        super(userId, server);
-        this.newMuted = newMuted;
-        this.oldMuted = oldMuted;
+    public UserChangeMutedEventImpl(Member newMember, Member oldMember) {
+        super(newMember.getUser(), newMember.getServer());
+        this.newMember = newMember;
+        this.oldMember = oldMember;
     }
 
     @Override
     public boolean isNewMuted() {
-        return newMuted;
+        return newMember.getServer().isSelfMuted(newMember.getUser());
     }
 
     @Override
     public boolean isOldMuted() {
-        return oldMuted;
+        return !isNewMuted();
     }
-
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeNicknameEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeNicknameEventImpl.java
@@ -1,8 +1,7 @@
 package org.javacord.core.event.user;
 
-import org.javacord.api.entity.server.Server;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.event.user.UserChangeNicknameEvent;
+import org.javacord.core.entity.user.Member;
 
 import java.util.Optional;
 
@@ -11,38 +10,28 @@ import java.util.Optional;
  */
 public class UserChangeNicknameEventImpl extends ServerUserEventImpl implements UserChangeNicknameEvent {
 
-    /**
-     * The new nickname of the user.
-     */
-    private final String newNickname;
-
-    /**
-     * The old nickname of the user.
-     */
-    private final String oldNickname;
+    private final Member newMember;
+    private final Member oldMember;
 
     /**
      * Creates a new user change nickname event.
      *
-     * @param user The user of the event.
-     * @param server The server in which the user changed its nickname.
-     * @param newNickname The new nickname of the user.
-     * @param oldNickname The old nickname of the user.
+     * @param newMember The new member.
+     * @param oldMember The old member.
      */
-    public UserChangeNicknameEventImpl(User user, Server server, String newNickname, String oldNickname) {
-        super(user, server);
-        this.newNickname = newNickname;
-        this.oldNickname = oldNickname;
+    public UserChangeNicknameEventImpl(Member newMember, Member oldMember) {
+        super(newMember.getUser(), newMember.getServer());
+        this.newMember = newMember;
+        this.oldMember = oldMember;
     }
 
     @Override
     public Optional<String> getNewNickname() {
-        return Optional.ofNullable(newNickname);
+        return newMember.getNickname();
     }
 
     @Override
     public Optional<String> getOldNickname() {
-        return Optional.ofNullable(oldNickname);
+        return oldMember.getNickname();
     }
-
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeSelfDeafenedEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeSelfDeafenedEventImpl.java
@@ -1,46 +1,35 @@
 package org.javacord.core.event.user;
 
-import org.javacord.api.entity.server.Server;
 import org.javacord.api.event.user.UserChangeSelfDeafenedEvent;
+import org.javacord.core.entity.user.Member;
 
 /**
  * The implementation of {@link UserChangeSelfDeafenedEvent}.
  */
 public class UserChangeSelfDeafenedEventImpl extends ServerUserEventImpl implements UserChangeSelfDeafenedEvent {
 
-    /**
-     * The new self-deafened state of the user.
-     */
-    private final boolean newSelfDeafened;
+    private final Member newMember;
+    private final Member oldMember;
 
     /**
-     * The old self-deafened state of the user.
-     */
-    private final boolean oldSelfDeafened;
-
-    /**
-     * Creates a new user change self-deafened event.
+     * Creates a new user change self deafened event.
      *
-     * @param userId The id of the user of the event.
-     * @param server The server in which the self-deafened state of the user was changed.
-     * @param newSelfDeafened The new self-deafened state of the user.
-     * @param oldSelfDeafened The old self-deafened state of the user.
+     * @param newMember The new member.
+     * @param oldMember The old member.
      */
-    public UserChangeSelfDeafenedEventImpl(
-            long userId, Server server, boolean newSelfDeafened, boolean oldSelfDeafened) {
-        super(userId, server);
-        this.newSelfDeafened = newSelfDeafened;
-        this.oldSelfDeafened = oldSelfDeafened;
+    public UserChangeSelfDeafenedEventImpl(Member newMember, Member oldMember) {
+        super(newMember.getUser(), newMember.getServer());
+        this.newMember = newMember;
+        this.oldMember = oldMember;
     }
 
     @Override
     public boolean isNewSelfDeafened() {
-        return newSelfDeafened;
+        return newMember.isSelfDeafened();
     }
 
     @Override
     public boolean isOldSelfDeafened() {
-        return oldSelfDeafened;
+        return oldMember.isSelfDeafened();
     }
-
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeSelfMutedEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeSelfMutedEventImpl.java
@@ -1,45 +1,35 @@
 package org.javacord.core.event.user;
 
-import org.javacord.api.entity.server.Server;
 import org.javacord.api.event.user.UserChangeSelfMutedEvent;
+import org.javacord.core.entity.user.Member;
 
 /**
  * The implementation of {@link UserChangeSelfMutedEvent}.
  */
 public class UserChangeSelfMutedEventImpl extends ServerUserEventImpl implements UserChangeSelfMutedEvent {
 
-    /**
-     * The new self-muted state of the user.
-     */
-    private final boolean newSelfMuted;
+    private final Member newMember;
+    private final Member oldMember;
 
     /**
-     * The old self-muted state of the user.
-     */
-    private final boolean oldSelfMuted;
-
-    /**
-     * Creates a new user change self-muted event.
+     * Creates a new user change self muted event.
      *
-     * @param userId The id of the user of the event.
-     * @param server The server in which the self-muted state of the user was changed.
-     * @param newSelfMuted The new self-muted state of the user.
-     * @param oldSelfMuted The old self-muted state of the user.
+     * @param newMember The new member.
+     * @param oldMember The old member.
      */
-    public UserChangeSelfMutedEventImpl(long userId, Server server, boolean newSelfMuted, boolean oldSelfMuted) {
-        super(userId, server);
-        this.newSelfMuted = newSelfMuted;
-        this.oldSelfMuted = oldSelfMuted;
+    public UserChangeSelfMutedEventImpl(Member newMember, Member oldMember) {
+        super(newMember.getUser(), newMember.getServer());
+        this.newMember = newMember;
+        this.oldMember = oldMember;
     }
 
     @Override
     public boolean isNewSelfMuted() {
-        return newSelfMuted;
+        return newMember.isSelfMuted();
     }
 
     @Override
     public boolean isOldSelfMuted() {
-        return oldSelfMuted;
+        return oldMember.isSelfMuted();
     }
-
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeStatusEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeStatusEventImpl.java
@@ -1,16 +1,15 @@
 package org.javacord.core.event.user;
 
+import io.vavr.collection.Map;
+import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.DiscordClient;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.user.UserStatus;
 import org.javacord.api.event.user.UserChangeStatusEvent;
-
-import java.util.Map;
 
 /**
  * The implementation of {@link UserChangeStatusEvent}.
  */
-public class UserChangeStatusEventImpl extends UserEventImpl implements UserChangeStatusEvent {
+public class UserChangeStatusEventImpl extends OptionalUserEventImpl implements UserChangeStatusEvent {
 
     /**
      * The new status of the user.
@@ -35,16 +34,17 @@ public class UserChangeStatusEventImpl extends UserEventImpl implements UserChan
     /**
      * Creates a new user change status event.
      *
-     * @param user The user of the event.
+     * @param api A discord api instance.
+     * @param userId The id of the user of the event.
      * @param newStatus The new status of the user.
      * @param oldStatus The old status of the user.
      * @param newClientStatus The new client specific status of the user.
      * @param oldClientStatus The old client specific status of the user.
      */
-    public UserChangeStatusEventImpl(User user, UserStatus newStatus, UserStatus oldStatus,
+    public UserChangeStatusEventImpl(DiscordApi api, long userId, UserStatus newStatus, UserStatus oldStatus,
                                      Map<DiscordClient, UserStatus> newClientStatus,
                                      Map<DiscordClient, UserStatus> oldClientStatus) {
-        super(user);
+        super(api, userId);
         this.newStatus = newStatus;
         this.oldStatus = oldStatus;
         this.newClientStatus = newClientStatus;
@@ -63,12 +63,12 @@ public class UserChangeStatusEventImpl extends UserEventImpl implements UserChan
 
     @Override
     public UserStatus getOldStatusOnClient(DiscordClient client) {
-        return oldClientStatus.getOrDefault(client, UserStatus.OFFLINE);
+        return oldClientStatus.getOrElse(client, UserStatus.OFFLINE);
     }
 
     @Override
     public UserStatus getNewStatusOnClient(DiscordClient client) {
-        return newClientStatus.getOrDefault(client, UserStatus.OFFLINE);
+        return newClientStatus.getOrElse(client, UserStatus.OFFLINE);
     }
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserStartTypingEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserStartTypingEventImpl.java
@@ -3,20 +3,46 @@ package org.javacord.core.event.user;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.user.UserStartTypingEvent;
+import org.javacord.core.entity.user.Member;
+import org.javacord.core.event.EventImpl;
+
+import java.util.Optional;
 
 /**
  * The implementation of {@link UserStartTypingEvent}.
  */
-public class UserStartTypingEventImpl extends ChannelUserEventImpl implements UserStartTypingEvent {
+public class UserStartTypingEventImpl extends EventImpl implements UserStartTypingEvent {
+
+    private final TextChannel channel;
+    private final long userId;
+    private final Member member;
 
     /**
      * Creates a new user start typing event.
      *
-     * @param user The user of the event.
      * @param channel The text channel of the event.
+     * @param userId The id of the user of the event.
+     * @param member The member of the event.
      */
-    public UserStartTypingEventImpl(User user, TextChannel channel) {
-        super(user, channel);
+    public UserStartTypingEventImpl(TextChannel channel, long userId, Member member) {
+        super(channel.getApi());
+        this.channel = channel;
+        this.userId = userId;
+        this.member = member;
     }
 
+    @Override
+    public TextChannel getChannel() {
+        return channel;
+    }
+
+    @Override
+    public long getUserId() {
+        return userId;
+    }
+
+    @Override
+    public Optional<User> getUser() {
+        return Optional.ofNullable(member).map(Member::getUser);
+    }
 }

--- a/javacord-core/src/main/java/org/javacord/core/util/cache/JavacordEntityCache.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/cache/JavacordEntityCache.java
@@ -7,10 +7,13 @@ import java.util.function.UnaryOperator;
  */
 public class JavacordEntityCache {
 
-    private static final JavacordEntityCache EMPTY_CACHE = new JavacordEntityCache(ChannelCache.empty());
+    private static final JavacordEntityCache EMPTY_CACHE = new JavacordEntityCache(
+            ChannelCache.empty(), MemberCache.empty(), UserPresenceCache.empty());
 
     private final ChannelCache channelCache;
-
+    private final MemberCache memberCache;
+    private final UserPresenceCache userPresenceCache;
+    
     /**
      * Gets an empty Javacord cache.
      *
@@ -20,8 +23,11 @@ public class JavacordEntityCache {
         return EMPTY_CACHE;
     }
 
-    private JavacordEntityCache(ChannelCache channelCache) {
+    private JavacordEntityCache(
+            ChannelCache channelCache, MemberCache memberCache, UserPresenceCache userPresenceCache) {
         this.channelCache = channelCache;
+        this.memberCache = memberCache;
+        this.userPresenceCache = userPresenceCache;
     }
 
     /**
@@ -40,7 +46,7 @@ public class JavacordEntityCache {
      * @return The new Javacord entity cache.
      */
     public JavacordEntityCache updateChannelCache(UnaryOperator<ChannelCache> mapper) {
-        return new JavacordEntityCache(mapper.apply(channelCache));
+        return setChannelCache(mapper.apply(channelCache));
     }
 
     /**
@@ -50,6 +56,64 @@ public class JavacordEntityCache {
      * @return The new Javacord entity cache.
      */
     public JavacordEntityCache setChannelCache(ChannelCache channelCache) {
-        return new JavacordEntityCache(channelCache);
+        return new JavacordEntityCache(channelCache, memberCache, userPresenceCache);
+    }
+
+    /**
+     * Gets the member cache.
+     *
+     * @return The member cache.
+     */
+    public MemberCache getMemberCache() {
+        return memberCache;
+    }
+
+    /**
+     * Updates the member cache.
+     *
+     * @param mapper A function that takes the old member cache and returns the new one.
+     * @return The new Javacord entity cache.
+     */
+    public JavacordEntityCache updateMemberCache(UnaryOperator<MemberCache> mapper) {
+        return setMemberCache(mapper.apply(memberCache));
+    }
+
+    /**
+     * Sets the member cache.
+     *
+     * @param memberCache The member cache to set.
+     * @return The new Javacord entity cache.
+     */
+    public JavacordEntityCache setMemberCache(MemberCache memberCache) {
+        return new JavacordEntityCache(channelCache, memberCache, userPresenceCache);
+    }
+
+    /**
+     * Gets the user presence cache.
+     *
+     * @return The user presence cache.
+     */
+    public UserPresenceCache getUserPresenceCache() {
+        return userPresenceCache;
+    }
+
+    /**
+     * Updates the user presence cache.
+     *
+     * @param mapper A function that takes the old user presence cache and returns the new one.
+     * @return The new Javacord entity cache.
+     */
+    public JavacordEntityCache updateUserPresenceCache(UnaryOperator<UserPresenceCache> mapper) {
+        return setUserPresenceCache(mapper.apply(userPresenceCache));
+    }
+
+    /**
+     * Sets the user presence cache.
+     *
+     * @param userPresenceCache The user presence cache to set.
+     * @return The new Javacord entity cache.
+     */
+    public JavacordEntityCache setUserPresenceCache(UserPresenceCache userPresenceCache) {
+        return new JavacordEntityCache(channelCache, memberCache, userPresenceCache);
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/util/cache/MemberCache.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/cache/MemberCache.java
@@ -1,0 +1,131 @@
+package org.javacord.core.util.cache;
+
+import io.vavr.Tuple;
+import org.javacord.core.entity.user.Member;
+import org.javacord.core.util.ImmutableToJavaMapper;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * An immutable cache for all member entities.
+ */
+public class MemberCache {
+
+    private static final String ID_INDEX_NAME = "id";
+    private static final String SERVER_ID_INDEX_NAME = "server-id";
+    private static final String ID_AND_SERVER_ID_INDEX_NAME = "server-id | type";
+
+    private static final MemberCache EMPTY_CACHE = new MemberCache(
+            Cache.<Member>empty()
+                    .addIndex(ID_INDEX_NAME, Member::getId)
+                    .addIndex(SERVER_ID_INDEX_NAME, member -> member.getServer().getId())
+                    .addIndex(ID_AND_SERVER_ID_INDEX_NAME,
+                            member -> Tuple.of(member.getId(), member.getServer().getId())),
+            UserCache.empty()
+    );
+
+    private final Cache<Member> cache;
+    private final UserCache userCache;
+
+    private MemberCache(Cache<Member> cache, UserCache userCache) {
+        this.cache = cache;
+        this.userCache = userCache;
+    }
+
+    /**
+     * Gets an empty channel cache.
+     *
+     * @return An empty channel cache.
+     */
+    public static MemberCache empty() {
+        return EMPTY_CACHE;
+    }
+
+    /**
+     * Adds a member to the cache.
+     *
+     * <p>Automatically updates the underlying user cache, too.
+     *
+     * @param member The member to add.
+     * @return The new member cache.
+     */
+    public MemberCache addMember(Member member) {
+        return new MemberCache(
+                cache.addElement(member),
+                userCache.getUserById(member.getId())
+                        .map(userCache::removeUser)
+                        .orElse(userCache)
+                        .addUser(member.getUser())
+        );
+    }
+
+    /**
+     * Removes a member from the cache.
+     *
+     * <p>Automatically updates the underlying user cache, too.
+     *
+     * @param member The member to remove.
+     * @return The new member cache.
+     */
+    public MemberCache removeMember(Member member) {
+        if (member == null) {
+            return this;
+        }
+        return new MemberCache(
+                cache.removeElement(member),
+                userCache.getUserById(member.getId())
+                        .map(userCache::removeUser)
+                        .orElse(userCache)
+        );
+    }
+
+    /**
+     * Gets the underlying user cache.
+     *
+     * @return The underlying user cache.
+     */
+    public UserCache getUserCache() {
+        return userCache;
+    }
+
+    /**
+     * Gets a set with all channels in the cache.
+     *
+     * @return A set with all channels.
+     */
+    public Set<Member> getMembers() {
+        return ImmutableToJavaMapper.mapToJava(cache.getAll());
+    }
+
+    /**
+     * Get a set with all members with the given id.
+     *
+     * @param id The id of the member.
+     * @return A set with all member with the given id.
+     */
+    public Set<Member> getMembersById(long id) {
+        return ImmutableToJavaMapper.mapToJava(cache.findByIndex(ID_INDEX_NAME, id));
+    }
+
+    /**
+     * Get a set with all members in the server with the given id.
+     *
+     * @param serverId The server id.
+     * @return A set with all member of the server with the given id.
+     */
+    public Set<Member> getMembersByServer(long serverId) {
+        return ImmutableToJavaMapper.mapToJava(cache.findByIndex(SERVER_ID_INDEX_NAME, serverId));
+    }
+
+    /**
+     * Gets the member with the given id in the server with the given id.
+     *
+     * @param id The id of the member.
+     * @param serverId The server id.
+     * @return The member.
+     */
+    public Optional<Member> getMemberByIdAndServer(long id, long serverId) {
+        return cache.findAnyByIndex(ID_AND_SERVER_ID_INDEX_NAME, Tuple.of(id, serverId));
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/cache/UserCache.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/cache/UserCache.java
@@ -1,0 +1,74 @@
+package org.javacord.core.util.cache;
+
+import org.javacord.api.entity.user.User;
+import org.javacord.core.util.ImmutableToJavaMapper;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * An immutable cache for all user entities.
+ */
+public class UserCache {
+
+    private static final String ID_INDEX_NAME = "id";
+
+    private static final UserCache EMPTY_CACHE = new UserCache(Cache.<User>empty()
+            .addIndex(ID_INDEX_NAME, User::getId)
+    );
+
+    private final Cache<User> cache;
+
+    private UserCache(Cache<User> cache) {
+        this.cache = cache;
+    }
+
+    /**
+     * Gets an empty channel cache.
+     *
+     * @return An empty channel cache.
+     */
+    public static UserCache empty() {
+        return EMPTY_CACHE;
+    }
+
+    /**
+     * Adds a user to the cache.
+     *
+     * @param user The user to add.
+     * @return The new user cache.
+     */
+    public UserCache addUser(User user) {
+        return new UserCache(cache.addElement(user));
+    }
+
+    /**
+     * Removes a user from the cache.
+     *
+     * @param user The user to remove.
+     * @return The new user cache.
+     */
+    public UserCache removeUser(User user) {
+        return new UserCache(cache.removeElement(user));
+    }
+
+    /**
+     * Gets a set with all channels in the cache.
+     *
+     * @return A set with all channels.
+     */
+    public Set<User> getUsers() {
+        return ImmutableToJavaMapper.mapToJava(cache.getAll());
+    }
+
+    /**
+     * Get the user with the given id.
+     *
+     * @param id The id of the user.
+     * @return The user with the given id.
+     */
+    public Optional<User> getUserById(long id) {
+        return cache.findAnyByIndex(ID_INDEX_NAME, id);
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/cache/UserPresenceCache.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/cache/UserPresenceCache.java
@@ -1,0 +1,66 @@
+package org.javacord.core.util.cache;
+
+import org.javacord.core.entity.user.UserPresence;
+
+import java.util.Optional;
+
+/**
+ * An immutable cache for all user presences.
+ */
+public class UserPresenceCache {
+
+    private static final String USER_ID_INDEX_NAME = "user-id";
+
+    private static final UserPresenceCache EMPTY_CACHE = new UserPresenceCache(Cache.<UserPresence>empty()
+            .addIndex(USER_ID_INDEX_NAME, UserPresence::getUserId)
+    );
+
+    private final Cache<UserPresence> cache;
+
+    private UserPresenceCache(Cache<UserPresence> cache) {
+        this.cache = cache;
+    }
+
+    /**
+     * Gets an empty user presence cache.
+     *
+     * @return An empty user presence cache.
+     */
+    public static UserPresenceCache empty() {
+        return EMPTY_CACHE;
+    }
+
+    /**
+     * Adds a user presence to the cache.
+     *
+     * @param presence The user presence to add.
+     * @return The new user presence cache.
+     */
+    public UserPresenceCache addUserPresence(UserPresence presence) {
+        return new UserPresenceCache(cache.addElement(presence));
+    }
+
+    /**
+     * Removes a user presence from the cache.
+     *
+     * @param presence The user presence to remove.
+     * @return The new user presence cache.
+     */
+    public UserPresenceCache removeUserPresence(UserPresence presence) {
+        if (presence == null) {
+            return this;
+        }
+        return new UserPresenceCache(cache.removeElement(presence));
+    }
+
+    /**
+     * Get the presence for the user with the given id.
+     *
+     * @param userId The id of the user.
+     * @return The presence for the user with the given id.
+     */
+    public Optional<UserPresence> getPresenceByUserId(long userId) {
+        return cache.findAnyByIndex(USER_ID_INDEX_NAME, userId);
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
@@ -641,7 +641,7 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                             }
                             allServersLoaded = api.getUnavailableServers().isEmpty();
                             if (allServersLoaded) {
-                                allUsersLoaded = api.getAllServers().stream()
+                                allUsersLoaded = !api.hasUserCacheEnabled() || api.getAllServers().stream()
                                         .noneMatch(server -> server.getMemberCount() != server.getMembers().size());
                             }
                             if (sameUnavailableServerCounter > 1000

--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
@@ -2,7 +2,6 @@ package org.javacord.core.util.gateway;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.neovisionaries.ws.client.ProxySettings;
@@ -104,7 +103,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
 import java.util.zip.DataFormatException;
 
 /**
@@ -225,26 +223,16 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                     }
                     // put the element back to the queue
                     requestGuildMembersQueue.add(nextServerId);
-                    // send requests in up-to 50 guilds batches
-                    AtomicInteger batchCounter = new AtomicInteger();
+                    // send requests
                     requestGuildMembersQueue.stream().distinct()
-                            .collect(Collectors.groupingBy(serverId -> batchCounter.getAndIncrement() / 50))
-                            .values()
-                            .forEach(serverIdBatch -> {
-                                requestGuildMembersQueue.removeAll(serverIdBatch);
+                            .forEach(serverId -> {
+                                requestGuildMembersQueue.remove(serverId);
                                 ObjectNode requestGuildMembersPacket = JsonNodeFactory.instance.objectNode()
                                         .put("op", GatewayOpcode.REQUEST_GUILD_MEMBERS.getCode());
                                 ObjectNode data = requestGuildMembersPacket.putObject("d")
                                         .put("query", "")
                                         .put("limit", 0);
-                                if (serverIdBatch.size() == 1) {
-                                    data.put("guild_id", Long.toUnsignedString(serverIdBatch.get(0)));
-                                } else {
-                                    ArrayNode guildIds = data.putArray("guild_id");
-                                    serverIdBatch.stream()
-                                            .map(Long::toUnsignedString)
-                                            .forEach(guildIds::add);
-                                }
+                                data.put("guild_id", Long.toUnsignedString(serverId));
                                 logger.debug("Sending request guild members packet {}",
                                              requestGuildMembersPacket);
                                 sendTextFrame(requestGuildMembersPacket.toString());

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/ReadyHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/ReadyHandler.java
@@ -7,6 +7,8 @@ import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.core.entity.channel.GroupChannelImpl;
 import org.javacord.core.entity.channel.PrivateChannelImpl;
 import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.util.gateway.PacketHandler;
 import org.javacord.core.util.logging.LoggerUtil;
 
@@ -60,7 +62,7 @@ public class ReadyHandler extends PacketHandler {
             }
         }
 
-        api.setYourself(api.getOrCreateUser(packet.get("user")));
+        api.setYourself(new UserImpl(api, packet.get("user"), (MemberImpl) null, null));
     }
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelCreateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelCreateHandler.java
@@ -13,7 +13,9 @@ import org.javacord.api.event.channel.group.GroupChannelCreateEvent;
 import org.javacord.api.event.channel.server.ServerChannelCreateEvent;
 import org.javacord.api.event.channel.user.PrivateChannelCreateEvent;
 import org.javacord.core.entity.channel.GroupChannelImpl;
+import org.javacord.core.entity.channel.PrivateChannelImpl;
 import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
 import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.event.channel.group.GroupChannelCreateEventImpl;
 import org.javacord.core.event.channel.server.ServerChannelCreateEventImpl;
@@ -124,9 +126,10 @@ public class ChannelCreateHandler extends PacketHandler {
     private void handlePrivateChannel(JsonNode channel) {
         // A CHANNEL_CREATE packet is sent every time a bot account receives a message, see
         // https://github.com/hammerandchisel/discord-api-docs/issues/184
-        UserImpl recipient = (UserImpl) api.getOrCreateUser(channel.get("recipients").get(0));
+
+        UserImpl recipient = new UserImpl(api, channel.get("recipients").get(0), (MemberImpl) null, null);
         if (!recipient.getPrivateChannel().isPresent()) {
-            PrivateChannel privateChannel = recipient.getOrCreateChannel(channel);
+            PrivateChannel privateChannel = new PrivateChannelImpl(api, channel);
             PrivateChannelCreateEvent event = new PrivateChannelCreateEventImpl(privateChannel);
 
             api.getEventDispatcher().dispatchPrivateChannelCreateEvent(api, recipient, event);

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelDeleteHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelDeleteHandler.java
@@ -7,7 +7,6 @@ import org.javacord.api.entity.channel.Channel;
 import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.api.entity.channel.GroupChannel;
-import org.javacord.api.entity.channel.PrivateChannel;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.ServerTextChannel;
 import org.javacord.api.entity.channel.ServerVoiceChannel;
@@ -15,11 +14,8 @@ import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.channel.VoiceChannel;
 import org.javacord.api.event.channel.group.GroupChannelDeleteEvent;
 import org.javacord.api.event.channel.server.ServerChannelDeleteEvent;
-import org.javacord.api.event.channel.user.PrivateChannelDeleteEvent;
-import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.event.channel.group.GroupChannelDeleteEventImpl;
 import org.javacord.core.event.channel.server.ServerChannelDeleteEventImpl;
-import org.javacord.core.event.channel.user.PrivateChannelDeleteEventImpl;
 import org.javacord.core.util.event.DispatchQueueSelector;
 import org.javacord.core.util.gateway.PacketHandler;
 import org.javacord.core.util.logging.LoggerUtil;
@@ -138,22 +134,23 @@ public class ChannelDeleteHandler extends PacketHandler {
      * @param channel The channel data.
      */
     private void handlePrivateChannel(JsonNode channel) {
-        UserImpl recipient = (UserImpl) api.getOrCreateUser(channel.get("recipients").get(0));
-        recipient.getPrivateChannel().ifPresent(privateChannel -> {
-            PrivateChannelDeleteEvent event = new PrivateChannelDeleteEventImpl(privateChannel);
-
-            api.getEventDispatcher().dispatchPrivateChannelDeleteEvent(api, privateChannel, recipient, event);
-            long channelId = privateChannel.getId();
-            api.removeObjectListeners(PrivateChannel.class, channelId);
-            api.removeObjectListeners(VoiceChannel.class, channelId);
-            api.removeObjectListeners(TextChannel.class, channelId);
-            api.removeObjectListeners(Channel.class, channelId);
-            api.forEachCachedMessageWhere(
-                    msg -> msg.getChannel().getId() == privateChannel.getId(),
-                    msg -> api.removeMessageFromCache(msg.getId())
-            );
-            recipient.setChannel(null);
-        });
+        // TODO Do we even have to handle private channel deletes?
+        // UserImpl recipient = new UserImpl(api, channel.get("recipients").get(0));
+        // recipient.getPrivateChannel().ifPresent(privateChannel -> {
+        //     PrivateChannelDeleteEvent event = new PrivateChannelDeleteEventImpl(privateChannel);
+        //
+        //     api.getEventDispatcher().dispatchPrivateChannelDeleteEvent(api, privateChannel, recipient, event);
+        //     long channelId = privateChannel.getId();
+        //     api.removeObjectListeners(PrivateChannel.class, channelId);
+        //     api.removeObjectListeners(VoiceChannel.class, channelId);
+        //     api.removeObjectListeners(TextChannel.class, channelId);
+        //     api.removeObjectListeners(Channel.class, channelId);
+        //     api.forEachCachedMessageWhere(
+        //             msg -> msg.getChannel().getId() == privateChannel.getId(),
+        //             msg -> api.removeMessageFromCache(msg.getId())
+        //     );
+        //     recipient.setChannel(null);
+        // });
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildBanAddHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildBanAddHandler.java
@@ -5,6 +5,8 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.server.member.ServerMemberBanEvent;
 import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.event.server.member.ServerMemberBanEventImpl;
 import org.javacord.core.util.gateway.PacketHandler;
 
@@ -27,8 +29,8 @@ public class GuildBanAddHandler extends PacketHandler {
         api.getPossiblyUnreadyServerById(packet.get("guild_id").asLong())
                 .map(server -> (ServerImpl) server)
                 .ifPresent(server -> {
-                    User user = api.getOrCreateUser(packet.get("user"));
-                    server.removeMember(user);
+                    User user = new UserImpl(api, packet.get("user"), (MemberImpl) null, server);
+                    server.removeMember(user.getId());
 
                     ServerMemberBanEvent event = new ServerMemberBanEventImpl(server, user);
 

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildBanRemoveHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildBanRemoveHandler.java
@@ -5,6 +5,8 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.server.member.ServerMemberUnbanEvent;
 import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.event.server.member.ServerMemberUnbanEventImpl;
 import org.javacord.core.util.gateway.PacketHandler;
 
@@ -27,7 +29,7 @@ public class GuildBanRemoveHandler extends PacketHandler {
         api.getPossiblyUnreadyServerById(packet.get("guild_id").asLong())
                 .map(server -> (ServerImpl) server)
                 .ifPresent(server -> {
-                    User user = api.getOrCreateUser(packet.get("user"));
+                    User user = new UserImpl(api, packet.get("user"), (MemberImpl) null, server);
 
                     ServerMemberUnbanEvent event = new ServerMemberUnbanEventImpl(server, user);
 

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildMemberAddHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildMemberAddHandler.java
@@ -5,6 +5,8 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.server.member.ServerMemberJoinEvent;
 import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.event.server.member.ServerMemberJoinEventImpl;
 import org.javacord.core.util.gateway.PacketHandler;
 
@@ -27,9 +29,9 @@ public class GuildMemberAddHandler extends PacketHandler {
         api.getPossiblyUnreadyServerById(packet.get("guild_id").asLong())
                 .map(server -> (ServerImpl) server)
                 .ifPresent(server -> {
-                    server.addMember(packet);
+                    MemberImpl member = server.addMember(packet);
                     server.incrementMemberCount();
-                    User user = api.getOrCreateUser(packet.get("user"));
+                    User user = new UserImpl(api, packet.get("user"), member, server);
 
                     ServerMemberJoinEvent event = new ServerMemberJoinEventImpl(server, user);
 

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildMemberRemoveHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildMemberRemoveHandler.java
@@ -5,6 +5,8 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.server.member.ServerMemberLeaveEvent;
 import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.event.server.member.ServerMemberLeaveEventImpl;
 import org.javacord.core.util.gateway.PacketHandler;
 
@@ -27,8 +29,8 @@ public class GuildMemberRemoveHandler extends PacketHandler {
         api.getPossiblyUnreadyServerById(packet.get("guild_id").asLong())
                 .map(server -> (ServerImpl) server)
                 .ifPresent(server -> {
-                    User user = api.getOrCreateUser(packet.get("user"));
-                    server.removeMember(user);
+                    User user = new UserImpl(api, packet.get("user"), (MemberImpl) null, server);
+                    server.removeMember(user.getId());
                     server.decrementMemberCount();
 
                     ServerMemberLeaveEvent event = new ServerMemberLeaveEventImpl(server, user);

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildUpdateHandler.java
@@ -13,7 +13,6 @@ import org.javacord.api.entity.server.ExplicitContentFilterLevel;
 import org.javacord.api.entity.server.MultiFactorAuthenticationLevel;
 import org.javacord.api.entity.server.ServerFeature;
 import org.javacord.api.entity.server.VerificationLevel;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.event.server.ServerChangeAfkChannelEvent;
 import org.javacord.api.event.server.ServerChangeAfkTimeoutEvent;
 import org.javacord.api.event.server.ServerChangeBoostCountEvent;
@@ -159,10 +158,10 @@ public class GuildUpdateHandler extends PacketHandler {
             }
 
             long newOwnerId = packet.get("owner_id").asLong();
-            User oldOwner = server.getOwner();
-            if (!api.getCachedUserById(newOwnerId).map(oldOwner::equals).orElse(false)) {
+            long oldOwnerId = server.getOwnerId();
+            if (newOwnerId != oldOwnerId) {
                 server.setOwnerId(newOwnerId);
-                ServerChangeOwnerEvent event = new ServerChangeOwnerEventImpl(server, newOwnerId, oldOwner);
+                ServerChangeOwnerEvent event = new ServerChangeOwnerEventImpl(server, newOwnerId, oldOwnerId);
 
                 api.getEventDispatcher().dispatchServerChangeOwnerEvent(server, server, event);
             }

--- a/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
+++ b/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
@@ -320,7 +320,7 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.setSocks4SystemProperties()
 
         and:
-            def api = new DiscordApiImpl(AccountType.BOT, 'fakeBotToken', 0, 1, null, false, null, null, null, null, true,
+            def api = new DiscordApiImpl(AccountType.BOT, 'fakeBotToken', 0, 1, Collections.emptySet(), false, null, null, null, null, true,
                     null, { [InetAddress.getLoopbackAddress()] })
 
         when:


### PR DESCRIPTION
This PR adds support for disabling the user cache and adds a member entity.
Because we have a very strict deadline (October 7), the goal is just to get it working as quickly as possible to give users enough time to update.

What's noteworthy about this PR:
- The Member and User objects are now immutable (this is not 100% true -> They keep a reference to the DiscordApi (and server) instance which is not immutable and also use it for some methods, e.g. `User#getStatus()`. This will be fixed in the next minor release).
- The separation of Member and User is not 100% finished. E.g. there are still plenty of methods that should be moved to the Member object (e.g. `User#mute(Server)` should be `Member#mute()` instead)

This PR is nothing I am proud of. The goal should be to find and fix any bugs that this change introduces. It does not have to be fancy, but it should work and be easy to migrate.

For the next release, I plan to completely rework all entities to be immutable and also adjust the events accordingly.