### PR TITLE
Allow custom gateway identify ratelimiters

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -115,6 +115,17 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
     Optional<Ratelimiter> getGlobalRatelimiter();
 
     /**
+     * Gets the current gateway identify ratelimiter.
+     *
+     * <p>If you did not provide a ratelimiter yourself, this method will return a {@link LocalRatelimiter}
+     * which is set to allow one gateway identify request per 5500ms and is shared with every bot with the same token
+     * in the same Java program.
+     *
+     * @return The current gateway identify ratelimiter.
+     */
+    Ratelimiter getGatewayIdentifyRatelimiter();
+
+    /**
      * Gets the latest gateway latency.
      *
      * <p>To calculate the gateway latency, Javacord measures the time it takes for Discord to answer the gateway

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
@@ -93,6 +93,26 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
     }
 
     /**
+     * Sets a ratelimiter that can be used to control the 5 seconds gateway identify ratelimit.
+     *
+     * <p>By default, Javacord automatically provides a default {@link LocalRatelimiter}
+     * which is set to allow one gateway identify request per 5500ms and is shared with every bot with the same token
+     * in the same Java program.
+     *
+     * <p>**DO NOT** set a custom gateway identify ratelimiter unless you have to synchronize the ratelimit across
+     * multiple Java programs (running on different JVMs, VMs, phyiscal servers etc.) that run Javacord on the same
+     * bot token. The default ratelimiter will handle the ratelimit for you as long as your whole bot runs in the same
+     * Java program.
+     *
+     * @param ratelimiter The ratelimiter used to control the 5 seconds gateway identify ratelimit.
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder setGatewayIdentifyRatelimiter(Ratelimiter ratelimiter) {
+        delegate.setGatewayIdentifyRatelimiter(ratelimiter);
+        return this;
+    }
+
+    /**
      * Sets the proxy selector which should be used to determine the proxies that should be used to connect to the
      * Discord REST API and web socket.
      * If no explicit proxy is configured using {@link #setProxy(Proxy)} and no proxy selector is configured using this

--- a/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
@@ -31,6 +31,13 @@ public interface DiscordApiBuilderDelegate {
     void setGlobalRatelimiter(Ratelimiter ratelimiter);
 
     /**
+     * Sets a ratelimiter that can be used to respect the 5 second gateway identify ratelimit.
+     *
+     * @param ratelimiter The ratelimiter used to respect the 5 second gateway identify ratelimit.
+     */
+    void setGatewayIdentifyRatelimiter(Ratelimiter ratelimiter);
+
+    /**
      * Sets the proxy selector which should be used to determine the proxies that should be used to connect to the
      * Discord REST API and websocket.
      *

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -122,6 +122,14 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     private static final Map<String, Ratelimiter> defaultGlobalRatelimiter = new ConcurrentHashMap<>();
 
     /**
+     * A map with the default gateway identify ratelimiter.
+     *
+     * <p>The key is the bot's token (because ratelimits are per account) and the value is the ratelimiter for this
+     * token.
+     */
+    private static final Map<String, Ratelimiter> defaultGatewayIdentifyRatelimiter = new ConcurrentHashMap<>();
+
+    /**
      * The thread pool which is used internally.
      */
     private final ThreadPoolImpl threadPool = new ThreadPoolImpl();
@@ -246,6 +254,11 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * A ratelimiter that is used for global ratelimits.
      */
     private final Ratelimiter globalRatelimiter;
+
+    /**
+     * A ratelimiter that is used to respect the 5 seconds gateway identify ratelimit.
+     */
+    private final Ratelimiter gatewayIdentifyRatelimiter;
 
     /**
      * The proxy selector which should be used to determine the proxies that should be used to connect to the Discord
@@ -373,41 +386,48 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * Creates a new discord api instance that can be used for auto-ratelimited REST calls,
      * but does not connect to the Discord WebSocket.
      *
-     * @param token                The token used to connect without any account type specific prefix.
-     * @param globalRatelimiter    The ratelimiter used for global ratelimits.
-     * @param proxySelector        The proxy selector which should be used to determine the proxies that should be used
-     *                             to connect to the Discord REST API and websocket.
-     * @param proxy                The proxy which should be used to connect to the Discord REST API and websocket.
-     * @param proxyAuthenticator   The authenticator that should be used to authenticate against proxies that require
-     *                             it.
-     * @param trustAllCertificates Whether to trust all SSL certificates.
+     * @param token                         The token used to connect without any account type specific prefix.
+     * @param globalRatelimiter             The ratelimiter used for global ratelimits.
+     * @param gatewayIdentifyRatelimiter    The ratelimiter used to respect the 5 second gateway identify ratelimit.
+     * @param proxySelector                 The proxy selector which should be used to determine the proxies that
+     *                                      should be used
+     *                                      to connect to the Discord REST API and websocket.
+     * @param proxy                         The proxy which should be used to connect to the Discord REST API and
+     *                                      websocket.
+     * @param proxyAuthenticator            The authenticator that should be used to authenticate against proxies that
+     *                                      require it.
+     * @param trustAllCertificates          Whether to trust all SSL certificates.
      */
-    public DiscordApiImpl(String token, Ratelimiter globalRatelimiter, ProxySelector proxySelector, Proxy proxy,
-                          Authenticator proxyAuthenticator, boolean trustAllCertificates) {
+    public DiscordApiImpl(String token, Ratelimiter globalRatelimiter, Ratelimiter gatewayIdentifyRatelimiter,
+                          ProxySelector proxySelector, Proxy proxy, Authenticator proxyAuthenticator,
+                          boolean trustAllCertificates) {
         this(AccountType.BOT, token, 0, 1, Collections.emptySet(), true, false, globalRatelimiter,
-                proxySelector, proxy, proxyAuthenticator, trustAllCertificates, null);
+                gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator, trustAllCertificates, null);
     }
 
     /**
      * Creates a new discord api instance.
      *
-     * @param accountType             The account type of the instance.
-     * @param token                   The token used to connect without any account type specific prefix.
-     * @param currentShard            The current shard the bot should connect to.
-     * @param totalShards             The total amount of shards.
-     * @param intents                  The intents for the events which should be received.
-     * @param waitForServersOnStartup Whether Javacord should wait for all servers
-     *                                to become available on startup or not.
-     * @param waitForUsersOnStartup   Whether Javacord should wait for all users
-     *                                to become available on startup or not.
-     * @param globalRatelimiter       The ratelimiter used for global ratelimits.
-     * @param proxySelector           The proxy selector which should be used to determine the proxies that should be
-     *                                used to connect to the Discord REST API and websocket.
-     * @param proxy                   The proxy which should be used to connect to the Discord REST API and websocket.
-     * @param proxyAuthenticator      The authenticator that should be used to authenticate against proxies that require
-     *                                it.
-     * @param trustAllCertificates    Whether to trust all SSL certificates.
-     * @param ready                   The future which will be completed when the connection to Discord was successful.
+     * @param accountType                   The account type of the instance.
+     * @param token                         The token used to connect without any account type specific prefix.
+     * @param currentShard                  The current shard the bot should connect to.
+     * @param totalShards                   The total amount of shards.
+     * @param intents                       The intents for the events which should be received.
+     * @param waitForServersOnStartup       Whether Javacord should wait for all servers
+     *                                      to become available on startup or not.
+     * @param waitForUsersOnStartup         Whether Javacord should wait for all users
+     *                                      to become available on startup or not.
+     * @param globalRatelimiter             The ratelimiter used for global ratelimits.
+     * @param gatewayIdentifyRatelimiter    The ratelimiter used to respect the 5 second gateway identify ratelimit.
+     * @param proxySelector                 The proxy selector which should be used to determine the proxies that
+     *                                      should be used to connect to the Discord REST API and websocket.
+     * @param proxy                         The proxy which should be used to connect to the Discord REST API and
+     *                                      websocket.
+     * @param proxyAuthenticator            The authenticator that should be used to authenticate against proxies that
+     *                                      require it.
+     * @param trustAllCertificates           Whether to trust all SSL certificates.
+     * @param ready                         The future which will be completed when the connection to Discord was
+     *                                      successful.
      */
     public DiscordApiImpl(
             AccountType accountType,
@@ -418,6 +438,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             boolean waitForServersOnStartup,
             boolean waitForUsersOnStartup,
             Ratelimiter globalRatelimiter,
+            Ratelimiter gatewayIdentifyRatelimiter,
             ProxySelector proxySelector,
             Proxy proxy,
             Authenticator proxyAuthenticator,
@@ -425,31 +446,35 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             CompletableFuture<DiscordApi> ready
     ) {
         this(accountType, token, currentShard, totalShards, intents, waitForServersOnStartup, waitForUsersOnStartup,
-                true, globalRatelimiter,  proxySelector, proxy, proxyAuthenticator, trustAllCertificates, ready, null,
-                Collections.emptyMap(), Collections.emptyList());
+                true, globalRatelimiter, gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator,
+                trustAllCertificates, ready, null, Collections.emptyMap(), Collections.emptyList());
     }
 
     /**
      * Creates a new discord api instance.
      *
-     * @param accountType             The account type of the instance.
-     * @param token                   The token used to connect without any account type specific prefix.
-     * @param currentShard            The current shard the bot should connect to.
-     * @param totalShards             The total amount of shards.
-     * @param intents                  The intents for the events which should be received.
-     * @param waitForServersOnStartup Whether Javacord should wait for all servers
-     *                                to become available on startup or not.
-     * @param waitForUsersOnStartup   Whether Javacord should wait for all users
-     *                                to become available on startup or not.
-     * @param globalRatelimiter       The ratelimiter used for global ratelimits.
-     * @param proxySelector           The proxy selector which should be used to determine the proxies that should be
-     *                                used to connect to the Discord REST API and websocket.
-     * @param proxy                   The proxy which should be used to connect to the Discord REST API and websocket.
-     * @param proxyAuthenticator      The authenticator that should be used to authenticate against proxies that require
-     *                                it.
-     * @param trustAllCertificates    Whether to trust all SSL certificates.
-     * @param ready                   The future which will be completed when the connection to Discord was successful.
-     * @param dns                     The DNS instance to use in the OkHttp client. This should only be used in testing.
+     * @param accountType                   The account type of the instance.
+     * @param token                         The token used to connect without any account type specific prefix.
+     * @param currentShard                  The current shard the bot should connect to.
+     * @param totalShards                   The total amount of shards.
+     * @param intents                       The intents for the events which should be received.
+     * @param waitForServersOnStartup       Whether Javacord should wait for all servers
+     *                                      to become available on startup or not.
+     * @param waitForUsersOnStartup         Whether Javacord should wait for all users
+     *                                      to become available on startup or not.
+     * @param globalRatelimiter             The ratelimiter used for global ratelimits.
+     * @param gatewayIdentifyRatelimiter    The ratelimiter used to respect the 5 second gateway identify ratelimit.
+     * @param proxySelector                 The proxy selector which should be used to determine the proxies that
+     *                                      should be used to connect to the Discord REST API and websocket.
+     * @param proxy                         The proxy which should be used to connect to the Discord REST API and
+     *                                      websocket.
+     * @param proxyAuthenticator            The authenticator that should be used to authenticate against proxies that
+     *                                      require it.
+     * @param trustAllCertificates           Whether to trust all SSL certificates.
+     * @param ready                         The future which will be completed when the connection to Discord was
+     *                                      successful.
+     * @param dns                           The DNS instance to use in the OkHttp client. This should only be used in
+     *                                      testing.
      */
     private DiscordApiImpl(
             AccountType accountType,
@@ -460,6 +485,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             boolean waitForServersOnStartup,
             boolean waitForUsersOnStartup,
             Ratelimiter globalRatelimiter,
+            Ratelimiter gatewayIdentifyRatelimiter,
             ProxySelector proxySelector,
             Proxy proxy,
             Authenticator proxyAuthenticator,
@@ -467,33 +493,37 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             CompletableFuture<DiscordApi> ready,
             Dns dns) {
         this(accountType, token, currentShard, totalShards, intents, waitForServersOnStartup, waitForUsersOnStartup,
-                true, globalRatelimiter, proxySelector, proxy, proxyAuthenticator, trustAllCertificates, ready, dns,
-                Collections.emptyMap(), Collections.emptyList());
+                true, globalRatelimiter, gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator,
+                trustAllCertificates, ready, dns, Collections.emptyMap(), Collections.emptyList());
     }
 
     /**
      * Creates a new discord api instance.
-     * @param accountType             The account type of the instance.
-     * @param token                   The token used to connect without any account type specific prefix.
-     * @param currentShard            The current shard the bot should connect to.
-     * @param totalShards             The total amount of shards.
-     * @param intents                 The intents for the events which should be received.
-     * @param waitForServersOnStartup Whether Javacord should wait for all servers
-     *                                to become available on startup or not.
-     * @param waitForUsersOnStartup   Whether Javacord should wait for all users
-     *                                to become available on startup or not.
-     * @param registerShutdownHook    Whether the shutdown hook should be registered or not.
-     * @param globalRatelimiter       The ratelimiter used for global ratelimits.
-     * @param proxySelector           The proxy selector which should be used to determine the proxies that should be
-     *                                used to connect to the Discord REST API and websocket.
-     * @param proxy                   The proxy which should be used to connect to the Discord REST API and websocket.
-     * @param proxyAuthenticator      The authenticator that should be used to authenticate against proxies that require
-     *                                it.
-     * @param trustAllCertificates    Whether to trust all SSL certificates.
-     * @param ready                   The future which will be completed when the connection to Discord was successful.
-     * @param dns                     The DNS instance to use in the OkHttp client. This should only be used in testing.
-     * @param listenerSourceMap       The functions to create listeners for pre-registration.
-     * @param unspecifiedListeners    The listeners of unspecified types to pre-register.
+     * @param accountType                   The account type of the instance.
+     * @param token                         The token used to connect without any account type specific prefix.
+     * @param currentShard                  The current shard the bot should connect to.
+     * @param totalShards                   The total amount of shards.
+     * @param intents                       The intents for the events which should be received.
+     * @param waitForServersOnStartup       Whether Javacord should wait for all servers
+     *                                      to become available on startup or not.
+     * @param waitForUsersOnStartup         Whether Javacord should wait for all users
+     *                                      to become available on startup or not.
+     * @param registerShutdownHook          Whether the shutdown hook should be registered or not.
+     * @param globalRatelimiter             The ratelimiter used for global ratelimits.
+     * @param gatewayIdentifyRatelimiter    The ratelimiter used to respect the 5 second gateway identify ratelimit.
+     * @param proxySelector                 The proxy selector which should be used to determine the proxies that
+     *                                      should be used to connect to the Discord REST API and websocket.
+     * @param proxy                         The proxy which should be used to connect to the Discord REST API and
+     *                                      websocket.
+     * @param proxyAuthenticator            The authenticator that should be used to authenticate against proxies that
+     *                                      require it.
+     * @param trustAllCertificates           Whether to trust all SSL certificates.
+     * @param ready                         The future which will be completed when the connection to Discord was
+     *                                      successful.
+     * @param dns                           The DNS instance to use in the OkHttp client. This should only be used in
+     *                                      testing.
+     * @param listenerSourceMap             The functions to create listeners for pre-registration.
+     * @param unspecifiedListeners           The listeners of unspecified types to pre-register.
      */
     @SuppressWarnings("unchecked")
     public DiscordApiImpl(
@@ -506,6 +536,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             boolean waitForUsersOnStartup,
             boolean registerShutdownHook,
             Ratelimiter globalRatelimiter,
+            Ratelimiter gatewayIdentifyRatelimiter,
             ProxySelector proxySelector,
             Proxy proxy,
             Authenticator proxyAuthenticator,
@@ -523,6 +554,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
         this.waitForServersOnStartup = waitForServersOnStartup;
         this.waitForUsersOnStartup = waitForUsersOnStartup;
         this.globalRatelimiter = globalRatelimiter;
+        this.gatewayIdentifyRatelimiter = gatewayIdentifyRatelimiter;
         this.proxySelector = proxySelector;
         this.proxy = proxy;
         this.proxyAuthenticator = proxyAuthenticator;
@@ -1321,6 +1353,17 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             return Optional.of(ratelimiter);
         }
         return Optional.of(globalRatelimiter);
+    }
+
+    @Override
+    public Ratelimiter getGatewayIdentifyRatelimiter() {
+        if (gatewayIdentifyRatelimiter == null) {
+            return defaultGatewayIdentifyRatelimiter.computeIfAbsent(
+                    getToken(),
+                    (token) -> new LocalRatelimiter(1, Duration.ofMillis(5500))
+            );
+        }
+        return gatewayIdentifyRatelimiter;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
@@ -31,7 +31,6 @@ import org.javacord.core.event.connection.ReconnectEventImpl;
 import org.javacord.core.event.connection.ResumeEventImpl;
 import org.javacord.core.util.auth.NvWebSocketResponseImpl;
 import org.javacord.core.util.auth.NvWebSocketRouteImpl;
-import org.javacord.core.util.concurrent.ThreadFactory;
 import org.javacord.core.util.handler.ReadyHandler;
 import org.javacord.core.util.handler.ResumedHandler;
 import org.javacord.core.util.handler.channel.ChannelCreateHandler;
@@ -90,13 +89,9 @@ import java.util.Optional;
 import java.util.WeakHashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.PriorityBlockingQueue;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicMarkableReference;
@@ -161,30 +156,6 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
     private BlockingQueue<WebSocketFrameSendingQueueEntry> webSocketFrameSendingQueue = new PriorityBlockingQueue<>();
     private AtomicReference<Thread> webSocketFrameSenderThread = new AtomicReference<>();
     private AtomicInteger webSocketFrameSendingLimit = new AtomicInteger(WEB_SOCKET_FRAME_SENDING_RATELIMIT);
-
-    private static final Map<String, Long> lastIdentificationPerAccount = Collections.synchronizedMap(new HashMap<>());
-    private static final ConcurrentMap<String, Semaphore> connectionDelaySemaphorePerAccount =
-            new ConcurrentHashMap<>();
-
-    static {
-        // This scheduler makes sure that the semaphores get released after a while if it failed in the listener
-        // for whatever reason. It's just a fail-safe.
-        Executors.newSingleThreadScheduledExecutor(
-                new ThreadFactory("Javacord - Connection Delay Semaphores Starvation Protector", true)
-        ).scheduleWithFixedDelay(() -> {
-            try {
-                connectionDelaySemaphorePerAccount.forEach((token, semaphore) -> {
-                    if ((semaphore.availablePermits() == 0)
-                            && (System.currentTimeMillis() - lastIdentificationPerAccount.getOrDefault(token, 0L)
-                            >= 15000)) {
-                        semaphore.release();
-                    }
-                });
-            } catch (Throwable t) {
-                logger.error("Failed to do the backup semaphore releasing!", t);
-            }
-        }, 10, 10, TimeUnit.SECONDS);
-    }
 
     /**
      * Creates a new discord websocket adapter.
@@ -474,7 +445,8 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
             websocket.addHeader("Accept-Encoding", "gzip");
             websocket.addListener(this);
             websocket.addListener(new WebSocketLogger());
-            waitForIdentifyRateLimit();
+
+            api.getGatewayIdentifyRatelimiter().requestQuota();
             websocket.connect();
         } catch (Throwable t) {
             logger.warn("An error occurred while connecting to websocket", t);
@@ -498,24 +470,6 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                             this.connect();
                         }, api.getReconnectDelay(reconnectAttempt.get()), TimeUnit.SECONDS);
             }
-        }
-    }
-
-    /**
-     * Identification is rate limited to once every 5 seconds,
-     * so don't try to more often per account, even in different instances.
-     * This method waits for the identification rate limit to be over, then returns.
-     */
-    private void waitForIdentifyRateLimit() {
-        String token = api.getPrefixedToken();
-        connectionDelaySemaphorePerAccount.computeIfAbsent(token, key -> new Semaphore(1)).acquireUninterruptibly();
-        for (long delay = 5100 - (System.currentTimeMillis() - lastIdentificationPerAccount.getOrDefault(token, 0L));
-                delay > 0;
-                delay = 5100 - (System.currentTimeMillis() - lastIdentificationPerAccount.getOrDefault(token, 0L))) {
-            logger.debug("Delaying connecting by {}ms", delay);
-            try {
-                Thread.sleep(delay);
-            } catch (InterruptedException ignored) { }
         }
     }
 
@@ -666,19 +620,22 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                                WebSocketCloseReason.COMMANDED_RECONNECT.getCloseReason());
                 break;
             case INVALID_SESSION:
-                long fakeLastIdentificationTime = System.currentTimeMillis();
                 if (lastSentFrameWasIdentify.isMarked()) {
                     logger.info("Hit identifying rate limit. Retrying in 5 seconds...");
                 } else {
                     // Invalid session :(
-                    int zeroToFourSeconds = (int) (Math.random() * 4000);
+                    int oneToFiveSeconds = 1000 + (int) (Math.random() * 4000);
                     logger.info("Could not resume session. Reconnecting in {}.{} seconds...",
-                            () -> 1 + zeroToFourSeconds / 1000,
-                            () -> 1 + zeroToFourSeconds / 100 % 10);
-                    fakeLastIdentificationTime -= 4000 - zeroToFourSeconds;
+                            () -> oneToFiveSeconds / 1000,
+                            () -> oneToFiveSeconds / 100 % 10);
+                    try {
+                        Thread.sleep(oneToFiveSeconds);
+                    } catch (InterruptedException e) {
+                        logger.error("Interrupted while delaying reconnect!");
+                        return;
+                    }
                 }
-                lastIdentificationPerAccount.put(api.getPrefixedToken(), fakeLastIdentificationTime);
-                waitForIdentifyRateLimit();
+                api.getGatewayIdentifyRatelimiter().requestQuota();
                 sendIdentify(websocket);
                 break;
             case HELLO:
@@ -694,7 +651,6 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                 if (sessionId == null) {
                     sendIdentify(websocket);
                 } else {
-                    connectionDelaySemaphorePerAccount.get(api.getPrefixedToken()).release();
                     sendResume(websocket);
                 }
                 break;
@@ -780,15 +736,13 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                     }
                 } else {
                     // identify frame is actually sent => set the mark
-                    if (lastSentFrameWasIdentify.compareAndSet(frame, null, false, true)) {
-                        lastIdentificationPerAccount.put(token, System.currentTimeMillis());
-                        connectionDelaySemaphorePerAccount.get(token).release();
-                    }
+                    lastSentFrameWasIdentify.compareAndSet(frame, null, false, true);
                 }
             }
         };
         identifyFrameListeners.add(identifyFrameListener);
         websocket.addListener(identifyFrameListener);
+
         logger.debug("Sending identify packet");
         sendLifecycleFrame(websocket, identifyFrame);
     }

--- a/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
+++ b/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
@@ -22,7 +22,7 @@ import java.util.concurrent.CompletionException
 class DiscordApiImplTest extends Specification {
 
     @Subject
-    def api = new DiscordApiImpl(null, null, null, null, null, false)
+    def api = new DiscordApiImpl(null, null, null, null, null, null, false)
 
     def 'getAllServers returns all servers'() {
         given:
@@ -100,7 +100,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setHttpSystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, false)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, false)
 
         when:
             api.applicationInfo.join()
@@ -117,7 +117,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setHttpSystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -133,7 +133,7 @@ class DiscordApiImplTest extends Specification {
 
     def 'allowing man-in-the-middle attacks logs a warning on api instantiation'() {
         when:
-            new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
+            new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
 
         then:
             def expectedWarning = 'All SSL certificates are trusted when connecting to the Discord API and websocket.' +
@@ -150,7 +150,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setHttpSystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -171,7 +171,7 @@ class DiscordApiImplTest extends Specification {
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             def defaultProxySelector = ProxySelector.default
             ProxySelector.default = MockProxyManager.proxySelector
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -193,7 +193,7 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.mockProxy.when(
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
-            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.httpProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true)
 
         when:
             api.applicationInfo.join()
@@ -209,7 +209,7 @@ class DiscordApiImplTest extends Specification {
 
     def 'configuring proxy and proxySelector throws an IllegalStateException'() {
         when:
-            new DiscordApiImpl('fakeBotToken', null, Stub(ProxySelector), Proxy.NO_PROXY, null, true)
+            new DiscordApiImpl('fakeBotToken', null, null, Stub(ProxySelector), Proxy.NO_PROXY, null, true)
 
         then:
             IllegalStateException ise = thrown()
@@ -221,7 +221,7 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.mockProxy.when(
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
-            def api = new DiscordApiImpl('fakeBotToken', null, MockProxyManager.proxySelector, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.proxySelector, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -253,7 +253,7 @@ class DiscordApiImplTest extends Specification {
             Authenticator.default = Mock(Authenticator) {
                 (1.._) * getPasswordAuthentication() >> new PasswordAuthentication(username, password as char[])
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.httpProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true)
 
         when:
             api.applicationInfo.join()
@@ -288,7 +288,7 @@ class DiscordApiImplTest extends Specification {
             org.javacord.api.util.auth.Authenticator authenticator = Mock {
                 (1.._) * authenticate(_, _, _) >> [(HttpHeaderNames.PROXY_AUTHORIZATION as String): [null, credentials]]
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.httpProxy, authenticator, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, authenticator, true)
 
         when:
             api.applicationInfo.join()
@@ -320,8 +320,8 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.setSocks4SystemProperties()
 
         and:
-            def api = new DiscordApiImpl(AccountType.BOT, 'fakeBotToken', 0, 1, Collections.emptySet(), false, false, null, null, null, null, true,
-                    null, { [InetAddress.getLoopbackAddress()] })
+            def api = new DiscordApiImpl(AccountType.BOT, 'fakeBotToken', 0, 1, Collections.emptySet(), false, false, null, null, null, null,
+                    null, true, null, { [InetAddress.getLoopbackAddress()] })
 
         when:
             api.applicationInfo.join()
@@ -350,7 +350,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setSocks5SystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -378,7 +378,7 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.mockProxy.when(
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
-            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.socksProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.socksProxy, null, true)
 
         and:
             def username = UUID.randomUUID().toString()
@@ -428,7 +428,7 @@ class DiscordApiImplTest extends Specification {
                 void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
                 }
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.httpProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true)
 
         when:
             api.applicationInfo.join()
@@ -466,7 +466,7 @@ class DiscordApiImplTest extends Specification {
                 void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
                 }
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, MockProxyManager.proxySelector, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.proxySelector, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -493,7 +493,7 @@ class DiscordApiImplTest extends Specification {
             System.properties.'https.proxyPort' = '1'
             def defaultProxySelector = ProxySelector.default
             ProxySelector.default = MockProxyManager.proxySelector
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
 
         when:
             api.applicationInfo.join()
@@ -532,7 +532,7 @@ class DiscordApiImplTest extends Specification {
             org.javacord.api.util.auth.Authenticator authenticator = Mock {
                 (1.._) * authenticate(_, _, _) >> [(HttpHeaderNames.PROXY_AUTHORIZATION as String): [null, credentials]]
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.httpProxy, authenticator, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, authenticator, true)
 
         when:
             api.applicationInfo.join()


### PR DESCRIPTION
This PR introduces a new mechanic to control the 5 second gateway identify ratelimit.

Currently, Javacord has a hardcoded mechanic in place that only works within a single JVM.
This is a problem for larger bots that might need to split up their shards into multiple JVMs as they might run into identify ratelimit errors if they don't sync this ratelimit across all shards.

The old mechanic has been replaced by re-using the _Ratelimiter_ interface that is already used for the global 50/1 REST ratelimiter, which can already be replaced with a custom implementation. 

By default, Javacord will use one Ratelimiter per token and JVM (just like it has been done for the 50/1 default global ratelimiter) that allows 1 identify request per 5500ms. Users can supply some sort of network/IPC based implementation to the _DiscordApiBuilder_ to ensure that all shards respect the same ratelimit.

@Bastian: Not sure if this is the way to go. The Discord dev docs are inconsistent about wether you have to delay the IDENTIFY payload or the connection itself (both is mentioned in different locations: https://discord.com/developers/docs/topics/gateway#rate-limiting vs. https://discord.com/developers/docs/topics/gateway#identifying-example-gateway-identify). Not sure if it would be okay to connect to the gateway and then, in the worst case, wait 5 minutes (e.g. Yunite has 60 shards = 5 minutes) until sending the IDENTIFY packet. If that's allowed, the ratelimiter could work more accurately as we could request the quota right before sending the already prepared identify packet. Right now, it's waiting before connecting the websocket, without taking the delay between connecting and identifying into account - that's why I arbitrarily added 500ms just in case.