### PR TITLE
Fix wrong warning about uncached members

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildMemberUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildMemberUpdateHandler.java
@@ -51,8 +51,7 @@ public class GuildMemberUpdateHandler extends PacketHandler {
                     api.addMemberToCacheOrReplaceExisting(newMember);
 
                     if (oldMember == null) {
-                        // This should not happen
-                        logger.warn("Failed to get old member in GUILD_MEMBER_UPDATE packet");
+                        // Should only happen shortly after startup and is unproblematic
                         return;
                     }
 


### PR DESCRIPTION
It's completely unproblematic, as long as it happened directly after startup.