### PR TITLE
Moved and added missing canXY() methods from VoiceChannel to ServerVoiceChannel

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannel.java
@@ -1,6 +1,7 @@
 package org.javacord.api.entity.channel;
 
 import org.javacord.api.audio.AudioConnection;
+import org.javacord.api.entity.permission.PermissionType;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.listener.channel.server.voice.ServerVoiceChannelAttachableListenerManager;
 
@@ -90,6 +91,149 @@ public interface ServerVoiceChannel extends RegularServerChannel, VoiceChannel, 
      */
     default boolean isConnected(User user) {
         return isConnected(user.getId());
+    }
+
+    /**
+     * Checks if the given user is a priority speaker in this voice channel.
+     *
+     * @param user The user to check.
+     * @return Whether the given user is a priority speaker or not.
+     */
+    default boolean isPrioritySpeaker(User user) {
+        return hasAnyPermission(user, PermissionType.ADMINISTRATOR, PermissionType.PRIORITY_SPEAKER);
+    }
+
+    /**
+     * Checks if the given user can connect to the voice channel.
+     *
+     * @param user The user to check.
+     * @return Whether the given user can connect or not.
+     */
+    default boolean canConnect(User user) {
+        return hasAnyPermission(user, PermissionType.ADMINISTRATOR, PermissionType.CONNECT);
+    }
+
+    /**
+     * Checks if the user of the connected account can connect to the voice channel.
+     *
+     * @return Whether the user of the connected account can connect or not.
+     */
+    default boolean canYouConnect() {
+        return canConnect(getApi().getYourself());
+    }
+
+    /**
+     * Checks if the given user can mute users in this voice channel.
+     *
+     * @param user The user to check.
+     * @return Whether the given user can mute users or not.
+     */
+    default boolean canMuteUsers(User user) {
+        return hasAnyPermission(user, PermissionType.ADMINISTRATOR, PermissionType.MUTE_MEMBERS);
+    }
+
+    /**
+     * Checks if the user of the connected account can mute users in this voice channel.
+     *
+     * @return Whether the user of the connected account can mute users or not.
+     */
+    default boolean canYouMuteUsers() {
+        return canMuteUsers(getApi().getYourself());
+    }
+
+    /**
+     * Checks if the given user can speak in this voice channel.
+     *
+     * @param user The user to check.
+     * @return Whether the given user can speak or not.
+     */
+    default boolean canSpeak(User user) {
+        return hasAnyPermission(user, PermissionType.ADMINISTRATOR, PermissionType.SPEAK);
+    }
+
+    /**
+     * Checks if the user of the connected account can speak in this voice channel.
+     *
+     * @return Whether the user of the connected account can speak or not.
+     */
+    default boolean canYouSpeak() {
+        return canSpeak(getApi().getYourself());
+    }
+
+    /**
+     * Checks if the given user can use video in this voice channel.
+     *
+     * @param user The user to check.
+     * @return Whether the given user can use video or not.
+     */
+    default boolean canUseVideo(User user) {
+        return hasAnyPermission(user, PermissionType.ADMINISTRATOR, PermissionType.STREAM);
+    }
+
+    /**
+     * Checks if the user of the connected account can use video in this voice channel.
+     *
+     * @return Whether the user of the connected account can use video or not.
+     */
+    default boolean canYouUseVideo() {
+        return canUseVideo(getApi().getYourself());
+    }
+
+    /**
+     * Checks if the given user can move users in this voice channel.
+     *
+     * @param user The user to check.
+     * @return Whether the given user can move users or not.
+     */
+    default boolean canMoveUsers(User user) {
+        return hasAnyPermission(user, PermissionType.ADMINISTRATOR, PermissionType.MOVE_MEMBERS);
+    }
+
+    /**
+     * Checks if the user of the connected account can move users in this voice channel.
+     *
+     * @return Whether the user of the connected account can move users or not.
+     */
+    default boolean canYouMoveUsers() {
+        return canMoveUsers(getApi().getYourself());
+    }
+
+    /**
+     * Checks if the given user can use voice activation in this voice channel.
+     *
+     * @param user The user to check.
+     * @return Whether the given user can use voice activation or not.
+     */
+    default boolean canUseVoiceActivation(User user) {
+        return hasAnyPermission(user, PermissionType.ADMINISTRATOR, PermissionType.USE_VOICE_ACTIVITY);
+    }
+
+    /**
+     * Checks if the user of the connected account can use voice activation in this voice channel.
+     *
+     * @return Whether the user of the connected account can use voice activation or not.
+     */
+    default boolean canYouUseVoiceActivation() {
+        return canUseVoiceActivation(getApi().getYourself());
+    }
+
+    /**
+     * Checks if the given user can deafen users in this voice channel.
+     *
+     * @param user The user to check.
+     * @return Whether the given user can deafen users or not.
+     */
+    default boolean canDeafenUsers(User user) {
+        return hasAnyPermission(user, PermissionType.ADMINISTRATOR, PermissionType.DEAFEN_MEMBERS);
+    }
+
+    /**
+     * Checks if the user of the connected account can deafen users in this voice channel.
+     *
+     * @return Whether the user of the connected account can deafen users or not.
+     */
+    default boolean canYouDeafenUsers() {
+        return canDeafenUsers(getApi().getYourself());
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/VoiceChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/VoiceChannel.java
@@ -19,16 +19,18 @@ public interface VoiceChannel extends Channel, VoiceChannelAttachableListenerMan
      *
      * @param user The user to check.
      * @return Whether the given user can connect or not.
+     * @deprecated Use {@link ServerVoiceChannel#canConnect(User)} instead.
      */
+    @Deprecated
     default boolean canConnect(User user) {
         if (!canSee(user)) {
             return false;
         }
         Optional<ServerVoiceChannel> severVoiceChannel = asServerVoiceChannel();
         return !severVoiceChannel.isPresent()
-               || severVoiceChannel.get().hasAnyPermission(user,
-                                                          PermissionType.ADMINISTRATOR,
-                                                          PermissionType.CONNECT);
+                || severVoiceChannel.get().hasAnyPermission(user,
+                PermissionType.ADMINISTRATOR,
+                PermissionType.CONNECT);
     }
 
     /**
@@ -36,7 +38,9 @@ public interface VoiceChannel extends Channel, VoiceChannelAttachableListenerMan
      * In private channels this always returns {@code true} if the user is part of the chat.
      *
      * @return Whether the user of the connected account can connect or not.
+     * @deprecated Use {@link ServerVoiceChannel#canYouConnect()} instead.
      */
+    @Deprecated
     default boolean canYouConnect() {
         return canConnect(getApi().getYourself());
     }
@@ -47,16 +51,18 @@ public interface VoiceChannel extends Channel, VoiceChannelAttachableListenerMan
      *
      * @param user The user to check.
      * @return Whether the given user can mute other users or not.
+     * @deprecated Use {@link ServerVoiceChannel#canMuteUsers(User)} instead.
      */
+    @Deprecated
     default boolean canMuteUsers(User user) {
         if (!canConnect(user) || getType() == ChannelType.PRIVATE_CHANNEL) {
             return false;
         }
         Optional<ServerVoiceChannel> serverVoiceChannel = asServerVoiceChannel();
         return !serverVoiceChannel.isPresent()
-               || serverVoiceChannel.get().hasAnyPermission(user,
-                                                            PermissionType.ADMINISTRATOR,
-                                                            PermissionType.MUTE_MEMBERS);
+                || serverVoiceChannel.get().hasAnyPermission(user,
+                PermissionType.ADMINISTRATOR,
+                PermissionType.MUTE_MEMBERS);
     }
 
     /**
@@ -64,7 +70,9 @@ public interface VoiceChannel extends Channel, VoiceChannelAttachableListenerMan
      * In private channels this always returns {@code false}.
      *
      * @return Whether the user of the connected account can mute other users or not.
+     * @deprecated Use {@link ServerVoiceChannel#canYouMuteUsers()} instead.
      */
+    @Deprecated
     default boolean canYouMuteUsers() {
         return canMuteUsers(getApi().getYourself());
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
@@ -519,13 +519,15 @@ public interface MessageAuthor extends DiscordEntity, Nameable {
      * Always returns {@code false} if the author is not a user or if the channel is not a voice channel.
      *
      * @return Whether the author can connect to the voice channel or not.
+     * @deprecated Use {@link ServerVoiceChannel#canConnect(User)} instead.
      */
+    @Deprecated
     default boolean canConnectToVoiceChannel() {
         return getMessage()
-                .getChannel()
-                .asVoiceChannel()
-                .flatMap(voiceChannel -> asUser().map(voiceChannel::canConnect))
-                .orElse(false);
+            .getChannel()
+            .asVoiceChannel()
+            .flatMap(voiceChannel -> asUser().map(voiceChannel::canConnect))
+            .orElse(false);
     }
 
     /**
@@ -534,7 +536,9 @@ public interface MessageAuthor extends DiscordEntity, Nameable {
      * Always returns {@code false} if the author is not a user or if the channel is not a voice channel.
      *
      * @return Whether the author can mute other users in the voice channel or not.
+     * @deprecated Use {@link ServerVoiceChannel#canMuteUsers(User)} instead.
      */
+    @Deprecated
     default boolean canMuteUsersInVoiceChannel() {
         return getMessage()
                 .getChannel()


### PR DESCRIPTION
Already existing canXY() methods now check only the required permission.
Removed canConnectToVoiceChannel and canMuteUsersInVoiceChannel from MessageAuthor because there was no use.

Solves #574 