### PR TITLE
Add Message Reaction Remove Emoji event and switch endpoint

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Reaction.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Reaction.java
@@ -131,11 +131,5 @@ public interface Reaction {
      *
      * @return A future to tell us if the action was successful.
      */
-    default CompletableFuture<Void> remove() {
-        return getUsers()
-                .thenCompose(users -> CompletableFuture.allOf(
-                        users.stream()
-                                .map(this::removeUser)
-                                .toArray(CompletableFuture[]::new)));
-    }
+    CompletableFuture<Void> remove();
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
@@ -300,6 +300,26 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
     CompletableFuture<Void> removeAllReactions(String channelId, String messageId);
 
     /**
+     * Deletes all the reactions for a given emoji on a message.
+     *
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param emoji The emoji to remove.
+     * @return A future to tell us if the deletion was successful.
+     */
+    CompletableFuture<Void> removeAllReactionsForEmoji(long channelId, long messageId, Emoji emoji);
+
+    /**
+     * Deletes all the reactions for a given emoji on a message.
+     *
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param emoji The emoji to remove.
+     * @return A future to tell us if the deletion was successful.
+     */
+    CompletableFuture<Void> removeAllReactionsForEmoji(String channelId, String messageId, Emoji emoji);
+
+    /**
      * Pins this message.
      *
      * @param channelId The id of the message's channel.

--- a/javacord-api/src/main/java/org/javacord/api/event/message/reaction/ReactionRemoveEmojiEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/message/reaction/ReactionRemoveEmojiEvent.java
@@ -1,0 +1,16 @@
+package org.javacord.api.event.message.reaction;
+
+import org.javacord.api.entity.emoji.Emoji;
+
+/**
+ * A reaction remove emoji event.
+ */
+public interface ReactionRemoveEmojiEvent extends ReactionEvent {
+
+    /**
+     * Gets the emoji for this event.
+     *
+     * @return The emoji for this event.
+     */
+    Emoji getEmoji();
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/message/reaction/ReactionRemoveEmojiListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/message/reaction/ReactionRemoveEmojiListener.java
@@ -1,0 +1,24 @@
+package org.javacord.api.listener.message.reaction;
+
+import org.javacord.api.event.message.reaction.ReactionRemoveEmojiEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.channel.TextChannelAttachableListener;
+import org.javacord.api.listener.message.MessageAttachableListener;
+import org.javacord.api.listener.server.ServerAttachableListener;
+
+/**
+ * This listener listens to all of a single reaction being deleted at once.
+ */
+@FunctionalInterface
+public interface ReactionRemoveEmojiListener extends ServerAttachableListener, TextChannelAttachableListener,
+        MessageAttachableListener, GloballyAttachableListener,
+        ObjectAttachableListener {
+
+    /**
+     * This method is called every time all of a single reaction is removed from a message.
+     *
+     * @param event The event.
+     */
+    void onReactionRemoveEmoji(ReactionRemoveEmojiEvent event);
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
@@ -256,7 +256,7 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
     }
 
     /**
-     * Adds an emoji to the list of reactions.
+     * Adds an emoji to the list of reactions or increments the count of the reactions.
      *
      * @param emoji The emoji.
      * @param you Whether this reaction is used by you or not.
@@ -270,7 +270,7 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
     }
 
     /**
-     * Removes an emoji from the list of reactions.
+     * Removes one reaction for an emoji on a message.
      *
      * @param emoji The emoji.
      * @param you Whether this reaction is used by you or not.
@@ -279,6 +279,16 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
         Optional<Reaction> reaction = reactions.stream().filter(r -> emoji.equalsEmoji(r.getEmoji())).findAny();
         reaction.ifPresent(r -> ((ReactionImpl) r).decrementCount(you));
         reactions.removeIf(r -> r.getCount() <= 0);
+    }
+
+    /**
+     * Removes all the reactions for a given emoji on a message.
+     *
+     * @param emoji The emoji.
+     */
+    public void removeAllReactionsForEmoji(Emoji emoji) {
+        Optional<Reaction> reaction = reactions.stream().filter(r -> emoji.equalsEmoji(r.getEmoji())).findAny();
+        reaction.ifPresent(reactions::remove);
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/ReactionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/ReactionImpl.java
@@ -8,6 +8,7 @@ import org.javacord.api.entity.message.Reaction;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -116,6 +117,12 @@ public class ReactionImpl implements Reaction {
     @Override
     public boolean containsYou() {
         return containsYou;
+    }
+
+    @Override
+    public CompletableFuture<Void> remove() {
+        return message.getApi().getUncachedMessageUtil()
+                .removeAllReactionsForEmoji(message.getChannel().getId(), message.getId(), emoji);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
@@ -308,6 +308,29 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
     }
 
     @Override
+    public CompletableFuture<Void> removeAllReactionsForEmoji(long channelId, long messageId, Emoji emoji) {
+        String value = emoji.asUnicodeEmoji().orElseGet(() ->
+                emoji.asCustomEmoji().map(CustomEmoji::getReactionTag).orElse("UNKNOWN"));
+        return new RestRequest<Void>(api, RestMethod.DELETE, RestEndpoint.REACTION)
+                .setUrlParameters(
+                        Long.toUnsignedString(channelId),
+                        Long.toUnsignedString(messageId),
+                        value)
+                .execute(result -> null);
+    }
+
+    @Override
+    public CompletableFuture<Void> removeAllReactionsForEmoji(String channelId, String messageId, Emoji emoji) {
+        try {
+            return removeAllReactionsForEmoji(Long.parseLong(channelId), Long.parseLong(messageId), emoji);
+        } catch (NumberFormatException e) {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            future.completeExceptionally(e);
+            return future;
+        }
+    }
+
+    @Override
     public CompletableFuture<Void> pin(long channelId, long messageId) {
         return new RestRequest<Void>(api, RestMethod.PUT, RestEndpoint.PINS)
                 .setUrlParameters(Long.toUnsignedString(channelId), Long.toUnsignedString(messageId))

--- a/javacord-core/src/main/java/org/javacord/core/event/message/reaction/ReactionRemoveEmojiEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/message/reaction/ReactionRemoveEmojiEventImpl.java
@@ -1,0 +1,34 @@
+package org.javacord.core.event.message.reaction;
+
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.channel.TextChannel;
+import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.event.message.reaction.ReactionRemoveEmojiEvent;
+import org.javacord.core.event.message.RequestableMessageEventImpl;
+
+/**
+ * The implementation of {@link ReactionRemoveEmojiEvent}.
+ */
+public class ReactionRemoveEmojiEventImpl extends RequestableMessageEventImpl implements ReactionRemoveEmojiEvent {
+
+    private final Emoji emoji;
+
+    /**
+     * Creates a new reaction remove emoji event.
+     *
+     * @param api The discord api instance.
+     * @param emoji The emoji of this event.
+     * @param messageId The id of the message.
+     * @param channel The text channel in which the message was sent.
+     */
+    public ReactionRemoveEmojiEventImpl(DiscordApi api, Emoji emoji, long messageId, TextChannel channel) {
+        super(api, messageId, channel);
+        this.emoji = emoji;
+    }
+
+    @Override
+    public Emoji getEmoji() {
+        return emoji;
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
@@ -60,6 +60,7 @@ import org.javacord.core.util.handler.message.MessageDeleteHandler;
 import org.javacord.core.util.handler.message.MessageUpdateHandler;
 import org.javacord.core.util.handler.message.reaction.MessageReactionAddHandler;
 import org.javacord.core.util.handler.message.reaction.MessageReactionRemoveAllHandler;
+import org.javacord.core.util.handler.message.reaction.MessageReactionRemoveEmojiHandler;
 import org.javacord.core.util.handler.message.reaction.MessageReactionRemoveHandler;
 import org.javacord.core.util.handler.user.PresenceUpdateHandler;
 import org.javacord.core.util.handler.user.PresencesReplaceHandler;
@@ -871,6 +872,7 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
         addHandler(new MessageReactionAddHandler(api));
         addHandler(new MessageReactionRemoveAllHandler(api));
         addHandler(new MessageReactionRemoveHandler(api));
+        addHandler(new MessageReactionRemoveEmojiHandler(api));
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/message/reaction/MessageReactionRemoveEmojiHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/message/reaction/MessageReactionRemoveEmojiHandler.java
@@ -1,0 +1,59 @@
+package org.javacord.core.util.handler.message.reaction;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.channel.ServerChannel;
+import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.message.Message;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.event.message.reaction.ReactionRemoveEmojiEvent;
+import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
+import org.javacord.core.entity.message.MessageImpl;
+import org.javacord.core.event.message.reaction.ReactionRemoveEmojiEventImpl;
+import org.javacord.core.util.event.DispatchQueueSelector;
+import org.javacord.core.util.gateway.PacketHandler;
+
+import java.util.Optional;
+
+/**
+ * Handles the message reaction remove emoji packet.
+ */
+public class MessageReactionRemoveEmojiHandler extends PacketHandler {
+
+    /**
+     * Creates a new instance of this class.
+     *
+     * @param api The api.
+     */
+    public MessageReactionRemoveEmojiHandler(DiscordApi api) {
+        super(api, true, "MESSAGE_REACTION_REMOVE_EMOJI");
+    }
+
+    @Override
+    protected void handle(JsonNode packet) {
+        api.getTextChannelById(packet.get("channel_id").asText()).ifPresent(channel -> {
+            long messageId = packet.get("message_id").asLong();
+            Optional<Message> message = api.getCachedMessageById(messageId);
+
+            Emoji emoji;
+            JsonNode emojiJson = packet.get("emoji");
+            if (!emojiJson.has("id") || emojiJson.get("id").isNull()) {
+                emoji = UnicodeEmojiImpl.fromString(emojiJson.get("name").asText());
+            } else {
+                emoji = api.getKnownCustomEmojiOrCreateCustomEmoji(emojiJson);
+            }
+
+            message.ifPresent(msg -> ((MessageImpl) msg).removeAllReactionsForEmoji(emoji));
+
+            ReactionRemoveEmojiEvent event = new ReactionRemoveEmojiEventImpl(api, emoji, messageId, channel);
+
+            Optional<Server> optionalServer = channel.asServerChannel().map(ServerChannel::getServer);
+            api.getEventDispatcher().dispatchReactionRemoveEmojiEvent(
+                    optionalServer.map(DispatchQueueSelector.class::cast).orElse(api),
+                    messageId,
+                    optionalServer.orElse(null),
+                    channel,
+                    event);
+        });
+    }
+}


### PR DESCRIPTION
Adds the MESSAGE_REACTION_REMOVE_EMOJI event and switches Reaction#remove from removing each user's reaction to using the message reaction remove emoji endpoint