### PR TITLE
Expose UnicodeEmoji Implementation.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/emoji/UnicodeEmoji.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/emoji/UnicodeEmoji.java
@@ -1,8 +1,4 @@
-package org.javacord.core.entity.emoji;
-
-import org.javacord.api.entity.emoji.CustomEmoji;
-import org.javacord.api.entity.emoji.Emoji;
-import org.javacord.api.entity.emoji.KnownCustomEmoji;
+package org.javacord.api.entity.emoji;
 
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -10,13 +6,13 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * The representation of a unicode {@link Emoji}.
  */
-public class UnicodeEmojiImpl implements Emoji {
+public class UnicodeEmoji implements Emoji {
 
     /**
      * A static map which contains all unicode emojis.
      */
-    // Can be static, because unicode emojis are unique, even for different discord accounts/shards.
-    private static final ConcurrentHashMap<String, UnicodeEmojiImpl> unicodeEmojis = new ConcurrentHashMap<>();
+    // Can be static, because unicode emojis are really unique, even for different discord accounts/shards.
+    private static final ConcurrentHashMap<String, UnicodeEmoji> unicodeEmojis = new ConcurrentHashMap<>();
 
     /**
      * The emoji string.
@@ -28,7 +24,7 @@ public class UnicodeEmojiImpl implements Emoji {
      *
      * @param emoji The emoji string.
      */
-    private UnicodeEmojiImpl(String emoji) {
+    private UnicodeEmoji(String emoji) {
         this.emoji = emoji;
     }
 
@@ -38,8 +34,8 @@ public class UnicodeEmojiImpl implements Emoji {
      * @param emoji The emoji string.
      * @return The object, representing the emoji from the given string.
      */
-    public static UnicodeEmojiImpl fromString(String emoji) {
-        return unicodeEmojis.computeIfAbsent(emoji, key -> new UnicodeEmojiImpl(emoji));
+    public static UnicodeEmoji fromString(String emoji) {
+        return unicodeEmojis.computeIfAbsent(emoji, UnicodeEmoji::new);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/activity/ActivityImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/activity/ActivityImpl.java
@@ -6,8 +6,8 @@ import org.javacord.api.entity.activity.ActivityAssets;
 import org.javacord.api.entity.activity.ActivityParty;
 import org.javacord.api.entity.activity.ActivityType;
 import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.emoji.UnicodeEmoji;
 import org.javacord.core.DiscordApiImpl;
-import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -58,7 +58,7 @@ public class ActivityImpl implements Activity {
             if (emoji.has("id")) {
                 this.emoji = api.getKnownCustomEmojiOrCreateCustomEmoji(emoji);
             } else {
-                this.emoji = UnicodeEmojiImpl.fromString(emoji.get("name").asText());
+                this.emoji = UnicodeEmoji.fromString(emoji.get("name").asText());
             }
         } else {
             this.emoji = null;

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
@@ -6,6 +6,7 @@ import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.emoji.CustomEmoji;
 import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.emoji.UnicodeEmoji;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.MessageActivity;
 import org.javacord.api.entity.message.MessageAttachment;
@@ -19,7 +20,6 @@ import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.util.DiscordRegexPattern;
 import org.javacord.core.DiscordApiImpl;
-import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 import org.javacord.core.entity.message.component.ActionRowImpl;
 import org.javacord.core.entity.message.embed.EmbedImpl;
 import org.javacord.core.entity.server.ServerImpl;
@@ -475,40 +475,40 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
 
     @Override
     public CompletableFuture<Void> addReactions(String... unicodeEmojis) {
-        return addReactions(Arrays.stream(unicodeEmojis).map(UnicodeEmojiImpl::fromString).toArray(Emoji[]::new));
+        return addReactions(Arrays.stream(unicodeEmojis).map(UnicodeEmoji::fromString).toArray(Emoji[]::new));
     }
 
     @Override
     public CompletableFuture<Void> removeReactionByEmoji(User user, String unicodeEmoji) {
-        return removeReactionByEmoji(user, UnicodeEmojiImpl.fromString(unicodeEmoji));
+        return removeReactionByEmoji(user, UnicodeEmoji.fromString(unicodeEmoji));
     }
 
     @Override
     public CompletableFuture<Void> removeReactionByEmoji(String unicodeEmoji) {
-        return removeReactionByEmoji(UnicodeEmojiImpl.fromString(unicodeEmoji));
+        return removeReactionByEmoji(UnicodeEmoji.fromString(unicodeEmoji));
     }
 
     @Override
     public CompletableFuture<Void> removeReactionsByEmoji(User user, String... unicodeEmojis) {
         return removeReactionsByEmoji(user,
-                Arrays.stream(unicodeEmojis).map(UnicodeEmojiImpl::fromString).toArray(Emoji[]::new));
+                Arrays.stream(unicodeEmojis).map(UnicodeEmoji::fromString).toArray(Emoji[]::new));
     }
 
     @Override
     public CompletableFuture<Void> removeReactionsByEmoji(String... unicodeEmojis) {
         return removeReactionsByEmoji(
-                Arrays.stream(unicodeEmojis).map(UnicodeEmojiImpl::fromString).toArray(Emoji[]::new));
+                Arrays.stream(unicodeEmojis).map(UnicodeEmoji::fromString).toArray(Emoji[]::new));
     }
 
     @Override
     public CompletableFuture<Void> removeOwnReactionByEmoji(String unicodeEmoji) {
-        return removeOwnReactionByEmoji(UnicodeEmojiImpl.fromString(unicodeEmoji));
+        return removeOwnReactionByEmoji(UnicodeEmoji.fromString(unicodeEmoji));
     }
 
     @Override
     public CompletableFuture<Void> removeOwnReactionsByEmoji(String... unicodeEmojis) {
         return removeOwnReactionsByEmoji(
-                Arrays.stream(unicodeEmojis).map(UnicodeEmojiImpl::fromString).toArray(Emoji[]::new));
+                Arrays.stream(unicodeEmojis).map(UnicodeEmoji::fromString).toArray(Emoji[]::new));
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/ReactionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/ReactionImpl.java
@@ -3,10 +3,10 @@ package org.javacord.core.entity.message;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.emoji.UnicodeEmoji;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.Reaction;
 import org.javacord.core.DiscordApiImpl;
-import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -48,7 +48,7 @@ public class ReactionImpl implements Reaction {
 
         JsonNode emojiJson = data.get("emoji");
         if (!emojiJson.has("id") || emojiJson.get("id").isNull()) {
-            emoji = UnicodeEmojiImpl.fromString(emojiJson.get("name").asText());
+            emoji = UnicodeEmoji.fromString(emojiJson.get("name").asText());
         } else {
             emoji = ((DiscordApiImpl) message.getApi()).getKnownCustomEmojiOrCreateCustomEmoji(emojiJson);
         }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/component/ButtonImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/component/ButtonImpl.java
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.entity.emoji.CustomEmoji;
 import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.emoji.UnicodeEmoji;
 import org.javacord.api.entity.message.component.Button;
 import org.javacord.api.entity.message.component.ButtonStyle;
 import org.javacord.api.entity.message.component.ComponentType;
 import org.javacord.core.entity.emoji.CustomEmojiImpl;
-import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 
 import java.util.Optional;
 
@@ -50,7 +50,7 @@ public class ButtonImpl extends ComponentImpl implements Button {
                 this.emoji = new CustomEmojiImpl(null, id, name, isAnimated);
             } else {
                 String name = emojiObj.get("name").asText();
-                this.emoji = UnicodeEmojiImpl.fromString(name);
+                this.emoji = UnicodeEmoji.fromString(name);
             }
         } else {
             this.emoji = null;

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/component/SelectMenuOptionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/component/SelectMenuOptionImpl.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.emoji.UnicodeEmoji;
 import org.javacord.api.entity.message.component.SelectMenuOption;
 import org.javacord.core.entity.emoji.CustomEmojiImpl;
-import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 
 import java.util.Optional;
 
@@ -34,7 +34,7 @@ public class SelectMenuOptionImpl implements SelectMenuOption {
                 this.emoji = new CustomEmojiImpl(null, id, name, isAnimated);
             } else {
                 String name = emojiObj.get("name").asText();
-                this.emoji = UnicodeEmojiImpl.fromString(name);
+                this.emoji = UnicodeEmoji.fromString(name);
             }
         } else {
             this.emoji = null;

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/component/internal/ButtonBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/component/internal/ButtonBuilderDelegateImpl.java
@@ -2,11 +2,11 @@ package org.javacord.core.entity.message.component.internal;
 
 import org.javacord.api.entity.emoji.CustomEmoji;
 import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.emoji.UnicodeEmoji;
 import org.javacord.api.entity.message.component.Button;
 import org.javacord.api.entity.message.component.ButtonStyle;
 import org.javacord.api.entity.message.component.ComponentType;
 import org.javacord.api.entity.message.component.internal.ButtonBuilderDelegate;
-import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 import org.javacord.core.entity.message.component.ButtonImpl;
 
 import java.util.Optional;
@@ -90,7 +90,7 @@ public class ButtonBuilderDelegateImpl implements ButtonBuilderDelegate {
 
     @Override
     public void setEmoji(String unicode) {
-        this.emoji = UnicodeEmojiImpl.fromString(unicode);
+        this.emoji = UnicodeEmoji.fromString(unicode);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/event/message/MessageEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/message/MessageEventImpl.java
@@ -4,13 +4,13 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.emoji.UnicodeEmoji;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.Reaction;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.message.MessageEvent;
-import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 import org.javacord.core.event.EventImpl;
 
 import java.util.Arrays;
@@ -115,7 +115,7 @@ public abstract class MessageEventImpl extends EventImpl implements MessageEvent
     @Override
     public CompletableFuture<Void> addReactionsToMessage(String... unicodeEmojis) {
         return addReactionsToMessage(Arrays.stream(unicodeEmojis)
-                                             .map(UnicodeEmojiImpl::fromString)
+                                             .map(UnicodeEmoji::fromString)
                                              .toArray(Emoji[]::new));
     }
 
@@ -131,7 +131,7 @@ public abstract class MessageEventImpl extends EventImpl implements MessageEvent
 
     @Override
     public CompletableFuture<Void> removeReactionByEmojiFromMessage(User user, String unicodeEmoji) {
-        return removeReactionByEmojiFromMessage(user, UnicodeEmojiImpl.fromString(unicodeEmoji));
+        return removeReactionByEmojiFromMessage(user, UnicodeEmoji.fromString(unicodeEmoji));
     }
 
     @Override
@@ -146,7 +146,7 @@ public abstract class MessageEventImpl extends EventImpl implements MessageEvent
 
     @Override
     public CompletableFuture<Void> removeReactionByEmojiFromMessage(String unicodeEmoji) {
-        return removeReactionByEmojiFromMessage(UnicodeEmojiImpl.fromString(unicodeEmoji));
+        return removeReactionByEmojiFromMessage(UnicodeEmoji.fromString(unicodeEmoji));
     }
 
     @Override
@@ -160,7 +160,7 @@ public abstract class MessageEventImpl extends EventImpl implements MessageEvent
     public CompletableFuture<Void> removeReactionsByEmojiFromMessage(User user, String... unicodeEmojis) {
         return removeReactionsByEmojiFromMessage(
                 user, Arrays.stream(unicodeEmojis)
-                        .map(UnicodeEmojiImpl::fromString)
+                        .map(UnicodeEmoji::fromString)
                         .toArray(Emoji[]::new));
     }
 
@@ -175,7 +175,7 @@ public abstract class MessageEventImpl extends EventImpl implements MessageEvent
     @Override
     public CompletableFuture<Void> removeReactionsByEmojiFromMessage(String... unicodeEmojis) {
         return removeReactionsByEmojiFromMessage(Arrays.stream(unicodeEmojis)
-                                                         .map(UnicodeEmojiImpl::fromString)
+                                                         .map(UnicodeEmoji::fromString)
                                                          .toArray(Emoji[]::new));
     }
 
@@ -186,7 +186,7 @@ public abstract class MessageEventImpl extends EventImpl implements MessageEvent
 
     @Override
     public CompletableFuture<Void> removeOwnReactionByEmojiFromMessage(String unicodeEmoji) {
-        return removeOwnReactionByEmojiFromMessage(UnicodeEmojiImpl.fromString(unicodeEmoji));
+        return removeOwnReactionByEmojiFromMessage(UnicodeEmoji.fromString(unicodeEmoji));
     }
 
     @Override
@@ -197,7 +197,7 @@ public abstract class MessageEventImpl extends EventImpl implements MessageEvent
     @Override
     public CompletableFuture<Void> removeOwnReactionsByEmojiFromMessage(String... unicodeEmojis) {
         return removeOwnReactionsByEmojiFromMessage(Arrays.stream(unicodeEmojis)
-                                                            .map(UnicodeEmojiImpl::fromString)
+                                                            .map(UnicodeEmoji::fromString)
                                                             .toArray(Emoji[]::new));
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/message/reaction/MessageReactionAddHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/message/reaction/MessageReactionAddHandler.java
@@ -5,11 +5,11 @@ import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.emoji.UnicodeEmoji;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.event.message.reaction.ReactionAddEvent;
 import org.javacord.core.entity.channel.PrivateChannelImpl;
-import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 import org.javacord.core.entity.message.MessageImpl;
 import org.javacord.core.entity.server.ServerImpl;
 import org.javacord.core.entity.user.Member;
@@ -70,7 +70,7 @@ public class MessageReactionAddHandler extends PacketHandler {
         Emoji emoji;
         JsonNode emojiJson = packet.get("emoji");
         if (!emojiJson.has("id") || emojiJson.get("id").isNull()) {
-            emoji = UnicodeEmojiImpl.fromString(emojiJson.get("name").asText());
+            emoji = UnicodeEmoji.fromString(emojiJson.get("name").asText());
         } else {
             emoji = api.getKnownCustomEmojiOrCreateCustomEmoji(emojiJson);
         }

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/message/reaction/MessageReactionRemoveHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/message/reaction/MessageReactionRemoveHandler.java
@@ -6,11 +6,11 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.emoji.UnicodeEmoji;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.event.message.reaction.ReactionRemoveEvent;
 import org.javacord.core.entity.channel.PrivateChannelImpl;
-import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 import org.javacord.core.entity.message.MessageImpl;
 import org.javacord.core.event.message.reaction.ReactionRemoveEventImpl;
 import org.javacord.core.util.event.DispatchQueueSelector;
@@ -60,7 +60,7 @@ public class MessageReactionRemoveHandler extends PacketHandler {
         Emoji emoji;
         JsonNode emojiJson = packet.get("emoji");
         if (!emojiJson.has("id") || emojiJson.get("id").isNull()) {
-            emoji = UnicodeEmojiImpl.fromString(emojiJson.get("name").asText());
+            emoji = UnicodeEmoji.fromString(emojiJson.get("name").asText());
         } else {
             emoji = api.getKnownCustomEmojiOrCreateCustomEmoji(emojiJson);
         }


### PR DESCRIPTION
# What
 - provide equals and hashCode methods for all `Emoji` implementations
 - rename `UnicodeEmojiImpl` to `UnicodeEmoji`
 - expose `UnicodeEmoji` in the API project

# Why
Consider the following use case:
A developer wishes to have a bot react to reactions added to a certain message. The actions will be different per emoji and the developer opts to store them in a `Map<Emoji, Action>`. The developer wishes for both unicode and custom emojis to be possible keys for this map.

## The Issue
With the current implementation, the developer is not able to obtain a unicode emoji object without depending on the core artifact.

### Possible Solution 1: Two Maps
The developer could use two maps, `Map<String, Action>` for unicode emojis and `Map<CustomEmoji, Action>` for custom emojis. This defeats the purpose of having `Emoji` as a unifying interface and has a negative impact on readability. Also, it adds further complexity to concurrency concerns.

### Possible Solution 2: Round Trip
The developer could use `Message#addReactions()` with the unicode emojis as strings to obtain the same emojis as `Emoji` instances. This is needlessly complex and would require a context in which the bot could send (and, for cleanup, remove) reactions without bothering server users.

### Possible Solution 3: Custom Implementation
The developer could write their own `UnicodeEmoji` class implementing the `Emoji` interface. This is possible, but to work properly still requires the `equals` and `hashCode` methods to be implemented in an implementation-agnostic manner in the `CustomEmojiImpl` class. It would also require the developer to follow a hidden contract with regards to their own implementations.

### Possible Solution 4: Exposing the Implementation
This is the solution implemented by this pull request. The `UnicodeEmojiImpl` is self-contained and therefore can be safely moved to the api module. The only issue there might be is users trying to use `UnicodeEmoji#fromString` with the name of an emoji rather than its code points. This could be addressed by a simple check for typically present chars like `_` or `:` and a corresponding `IllegalArgumentException` being thrown.