### PR TITLE
Don't try to replace empty strings in the PrivacyProtectionLogger

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/logging/PrivacyProtectionLogger.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/logging/PrivacyProtectionLogger.java
@@ -36,7 +36,7 @@ public class PrivacyProtectionLogger extends AbstractLogger {
      * @param privateData The private data.
      */
     public static void addPrivateData(String privateData) {
-        if (privateData != null) {
+        if (privateData != null && !privateData.trim().isEmpty()) {
             privateDataSet.add(privateData);
         }
     }


### PR DESCRIPTION
LogalDeveloper on Discord had put an empty String as the discord token and got rewarded with a log looking like this:

```
2020-10-24 16:45:18.261+0000 INFO org.javacord.core.util.gateway.DiscordWebSocketAdapter **********W**********e**********b**********s**********o**********c**********k**********e**********t********** **********c**********l**********o**********s**********e**********d********** **********w**********i**********t**********h********** **********r**********e**********a**********s**********o**********n********** **********'**********A**********u**********t**********h**********e**********n**********t**********i**********c**********a**********t**********i**********o**********n********** **********f**********a**********i**********l**********e**********d**********.**********'********** **********a**********n**********d********** **********c**********o**********d**********e********** **********A**********U**********T**********H**********E**********N**********T**********I**********C**********A**********T**********I**********O**********N**********_**********F**********A**********I**********L**********E**********D********** **********(**********4**********0**********0**********4**********)********** **********b**********y********** **********s**********e**********r**********v**********e**********r**********!********** {shard=0}
```

Let's not do that.