### PR TITLE
Allow banning users by id

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1818,7 +1818,7 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      * @return A future to check if the ban was successful.
      */
     default CompletableFuture<Void> banUser(User user) {
-        return banUser(user, 0, null);
+        return banUser(user.getId(), 0, null);
     }
 
     /**
@@ -1829,7 +1829,7 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      * @return A future to check if the ban was successful.
      */
     default CompletableFuture<Void> banUser(User user, int deleteMessageDays) {
-        return banUser(user, deleteMessageDays, null);
+        return banUser(user.getId(), deleteMessageDays, null);
     }
 
     /**
@@ -1840,7 +1840,73 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      * @param reason The reason for the ban.
      * @return A future to check if the ban was successful.
      */
-    CompletableFuture<Void> banUser(User user, int deleteMessageDays, String reason);
+    default CompletableFuture<Void> banUser(User user, int deleteMessageDays, String reason) {
+        return banUser(user.getId(), deleteMessageDays, reason);
+    }
+
+    /**
+     * Bans the given user from the server.
+     *
+     * @param userId The id of the user to ban.
+     * @return A future to check if the ban was successful.
+     */
+    default CompletableFuture<Void> banUser(String userId) {
+        return banUser(userId, 0, null);
+    }
+
+    /**
+     * Bans the given user from the server.
+     *
+     * @param userId The id of the user to ban.
+     * @return A future to check if the ban was successful.
+     */
+    default CompletableFuture<Void> banUser(long userId) {
+        return banUser(Long.toUnsignedString(userId));
+    }
+
+    /**
+     * Bans the given user from the server.
+     *
+     * @param userId The id of the user to ban.
+     * @param deleteMessageDays The number of days to delete messages for (0-7).
+     * @return A future to check if the ban was successful.
+     */
+    default CompletableFuture<Void> banUser(String userId, int deleteMessageDays) {
+        return banUser(userId, deleteMessageDays, null);
+    }
+
+    /**
+     * Bans the given user from the server.
+     *
+     * @param userId The id of the user to ban.
+     * @param deleteMessageDays The number of days to delete messages for (0-7).
+     * @return A future to check if the ban was successful.
+     */
+    default CompletableFuture<Void> banUser(long userId, int deleteMessageDays) {
+        return banUser(Long.toUnsignedString(userId), deleteMessageDays);
+    }
+
+    /**
+     * Bans the given user from the server.
+     *
+     * @param userId The id of the user to ban.
+     * @param deleteMessageDays The number of days to delete messages for (0-7).
+     * @param reason The reason for the ban.
+     * @return A future to check if the ban was successful.
+     */
+    CompletableFuture<Void> banUser(String userId, int deleteMessageDays, String reason);
+
+    /**
+     * Bans the given user from the server.
+     *
+     * @param userId The id of the user to ban.
+     * @param deleteMessageDays The number of days to delete messages for (0-7).
+     * @param reason The reason for the ban.
+     * @return A future to check if the ban was successful.
+     */
+    default CompletableFuture<Void> banUser(long userId, int deleteMessageDays, String reason) {
+        return banUser(Long.toUnsignedString(userId), deleteMessageDays, reason);
+    }
 
     /**
      * Unbans the given user from the server.

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1364,9 +1364,9 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     }
 
     @Override
-    public CompletableFuture<Void> banUser(User user, int deleteMessageDays, String reason) {
+    public CompletableFuture<Void> banUser(String userId, int deleteMessageDays, String reason) {
         RestRequest<Void> request = new RestRequest<Void>(getApi(), RestMethod.PUT, RestEndpoint.BAN)
-                .setUrlParameters(getIdAsString(), user.getIdAsString())
+                .setUrlParameters(getIdAsString(), userId)
                 .addQueryParameter("delete_message_days", String.valueOf(deleteMessageDays));
         if (reason != null) {
             request.addQueryParameter("reason", reason);


### PR DESCRIPTION
This can be useful if you want to ban users that aren't in the cache. (You can ban users that aren't on the server.)
With this you don't have to request the users from discord and can just ban them.