### PR TITLE
Add support for application commands

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -1,5 +1,6 @@
 package org.javacord.api;
 
+import org.javacord.api.command.ApplicationCommand;
 import org.javacord.api.entity.ApplicationInfo;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.activity.Activity;
@@ -43,6 +44,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -89,6 +91,21 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
      * @return The internally used thread pool.
      */
     ThreadPool getThreadPool();
+
+    /**
+     * Gets a list with all global commands for the application.
+     *
+     * @return A list with all global commands.
+     */
+    CompletableFuture<List<ApplicationCommand>> getGlobalApplicationCommands();
+
+    /**
+     * Gets an application command by its id.
+     *
+     * @param commandId The id of the application command.
+     * @return The application command with the given id.
+     */
+    CompletableFuture<ApplicationCommand> getGlobalApplicationCommandById(long commandId);
 
     /**
      * Gets a utility class to interact with uncached messages.

--- a/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommand.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommand.java
@@ -1,0 +1,51 @@
+package org.javacord.api.command;
+
+import org.javacord.api.entity.DiscordEntity;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public interface ApplicationCommand extends DiscordEntity {
+
+    /**
+     * Gets the unique id of this command.
+     *
+     * @return The unique id of this command.
+     */
+    long getId();
+
+    /**
+     * Gets the unique id of the application that this command belongs to.
+     *
+     * @return The unique application id.
+     */
+    long getApplicationId();
+
+    /**
+     * Gets the name of this command.
+     *
+     * @return The name of this command.
+     */
+    String getName();
+
+    /**
+     * Gets the description of this command.
+     *
+     * @return The description of this command.
+     */
+    String getDescription();
+
+    /**
+     * Gets a list with all options (i.e., parameters) for this command.
+     *
+     * @return A list with all options (i.e., parameters) for this command.
+     */
+    List<ApplicationCommandOption> getOptions();
+
+    /**
+     * Deletes this application command.
+     *
+     * @return A future to check if the deletion was successful.
+     */
+    CompletableFuture<Void> delete();
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandBuilder.java
@@ -1,0 +1,87 @@
+package org.javacord.api.command;
+
+import org.javacord.api.DiscordApi;
+import org.javacord.api.command.internal.ApplicationCommandBuilderDelegate;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.util.internal.DelegateFactory;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This class is used to create new application commands.
+ */
+public class ApplicationCommandBuilder {
+
+    private final ApplicationCommandBuilderDelegate delegate =
+            DelegateFactory.createApplicationCommandBuilderDelegate();
+
+    /**
+     * Creates a new application command builder.
+     */
+    public ApplicationCommandBuilder() { }
+
+    /**
+     * Sets the name of the application command.
+     *
+     * @param name The name.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandBuilder setName(String name) {
+        delegate.setName(name);
+        return this;
+    }
+
+    /**
+     * Sets the description of the application command.
+     *
+     * @param description The name.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandBuilder setDescription(String description) {
+        delegate.setDescription(description);
+        return this;
+    }
+
+    /**
+     * Adds an application command option to the application command.
+     *
+     * @param option The option.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandBuilder addOption(ApplicationCommandOption option) {
+        delegate.addOption(option);
+        return this;
+    }
+
+    /**
+     * Sets the application commands for the application command.
+     *
+     * @param options The options.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandBuilder setOptions(List<ApplicationCommandOption> options) {
+        delegate.setOptions(options);
+        return this;
+    }
+
+    /**
+     * Creates a global application command.
+     *
+     * @param api The discord api instance.
+     * @return The built application command.
+     */
+    public CompletableFuture<ApplicationCommand> createGlobal(DiscordApi api) {
+        return delegate.createGlobal(api);
+    }
+
+    /**
+     * Creates an application command for a specific server.
+     *
+     * @param server The server.
+     * @return The built application command.
+     */
+    public CompletableFuture<ApplicationCommand> createForServer(Server server) {
+        return delegate.createForServer(server);
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandInteractionData.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandInteractionData.java
@@ -1,0 +1,23 @@
+package org.javacord.api.command;
+
+import org.javacord.api.entity.DiscordEntity;
+
+import java.util.List;
+
+public interface ApplicationCommandInteractionData extends DiscordEntity {
+
+    /**
+     * Gets the name of the invoked command.
+     *
+     * @return The name.
+     */
+    String getName();
+
+    /**
+     * Gets a list with the params and values from the user.
+     *
+     * @return A list with the params and values from the user.
+     */
+    List<ApplicationCommandInteractionDataOption> getOptions();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandInteractionDataOption.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandInteractionDataOption.java
@@ -1,0 +1,72 @@
+package org.javacord.api.command;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ApplicationCommandInteractionDataOption {
+
+    /**
+     * Gets the name of the option.
+     *
+     * @return The name.
+     */
+    String getName();
+
+    /**
+     * Checks if the option is a subcommand or group.
+     *
+     * <p>If the option is a subcommand or group, it does have options but no value.
+     * If the option is not a subcommand or group, it does have a value but no options.
+     *
+     * @return If the option is a subcommand or group.
+     */
+    default boolean isSubcommandOrGroup() {
+        return !getValueAsString().isPresent();
+    }
+
+    /**
+     * Gets the string value of this choice.
+     *
+     * <p>If this option is an integer or the option itself is a subcommand or group, the optional will be empty.
+     *
+     * @return The string value of this choice.
+     */
+    Optional<String> getStringValue();
+
+    /**
+     * Gets the integer value of this choice.
+     *
+     * <p>If this option is a string or the option itself is a subcommand or group, the optional will be empty.
+     *
+     * @return The integer value of this choice.
+     */
+    Optional<Integer> getIntValue();
+
+    /**
+     * Gets the value of this choice as a string.
+     *
+     * <p>If this option itself is a subcommand or group, the optional will be empty.
+     * In this case, the {@link #getOptions()} list will contain elements.
+     *
+     * <p>If the value is an integer, its string representation will be returned.
+     *
+     * @return The value of the choice as a string.
+     */
+    default Optional<String> getValueAsString() {
+        if (getStringValue().isPresent())  {
+            return getStringValue();
+        } else {
+            return getIntValue().map(String::valueOf);
+        }
+    }
+
+    /**
+     * Gets a list with all options of this option, if this option denotes a subcommand or group.
+     *
+     * <p>If this option does not denote a subcommand or group, the list will be empty.
+     *
+     * @return A list with all options.
+     */
+    List<ApplicationCommandInteractionDataOption> getOptions();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandOption.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandOption.java
@@ -1,0 +1,54 @@
+package org.javacord.api.command;
+
+import java.util.List;
+
+/**
+ * An application command's option (i.e., a parameter for the command).
+ */
+public interface ApplicationCommandOption {
+
+    /**
+     * Gets the type of this option.
+     *
+     * @return The type.
+     */
+    ApplicationCommandOptionType getType();
+
+    /**
+     * Gets the name of this option.
+     *
+     * @return The name of this option.
+     */
+    String getName();
+
+    /**
+     * Gets the description of this option.
+     *
+     * @return The description of this option.
+     */
+    String getDescription();
+
+    /**
+     * Checks whether or not this option is required.
+     *
+     * @return Whether or not this option is required.
+     */
+    boolean isRequired();
+
+    /**
+     * Gets a list with all choices for this option.
+     *
+     * <p>If this option has any choices, they are the only valid values for a user to pick.
+     *
+     * @return A list with all choices for this option.
+     */
+    List<ApplicationCommandOptionChoice> getChoices();
+
+    /**
+     * If this option is a subcommand or subcommand group type, this nested options will be the parameters.
+     *
+     * @return A list with the nested options.
+     */
+    List<ApplicationCommandOption> getOptions();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandOptionBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandOptionBuilder.java
@@ -1,0 +1,138 @@
+package org.javacord.api.command;
+
+import org.javacord.api.command.internal.ApplicationCommandOptionBuilderDelegate;
+import org.javacord.api.util.internal.DelegateFactory;
+
+import java.util.List;
+
+public class ApplicationCommandOptionBuilder {
+
+    private final ApplicationCommandOptionBuilderDelegate delegate =
+            DelegateFactory.createApplicationCommandOptionBuilderDelegate();
+
+    /**
+     * Creates a new application command option builder.
+     */
+    public ApplicationCommandOptionBuilder() { }
+
+    /**
+     * Sets the type of the application command option.
+     *
+     * @param type The type.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionBuilder setType(ApplicationCommandOptionType type) {
+        delegate.setType(type);
+        return this;
+    }
+
+    /**
+     * Sets the name of the application command option.
+     *
+     * @param name The name.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionBuilder setName(String name) {
+        delegate.setName(name);
+        return this;
+    }
+
+    /**
+     * Sets the description of the application command option.
+     *
+     * @param description The description.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionBuilder setDescription(String description) {
+        delegate.setDescription(description);
+        return this;
+    }
+
+    /**
+     * Sets if the application command option is required.
+     *
+     * @param required Whether or not the option is required.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionBuilder setRequired(boolean required) {
+        delegate.setRequired(required);
+        return this;
+    }
+
+    /**
+     * Adds an choice for the application command option.
+     *
+     * @param choice The choice.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionBuilder addChoice(ApplicationCommandOptionChoice choice) {
+        delegate.addChoice(choice);
+        return this;
+    }
+
+    /**
+     * Adds an string choice for the application command option.
+     *
+     * @param name The name of the choice.
+     * @param value The value of the choice.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionBuilder addChoice(String name, String value) {
+        delegate.addChoice(new ApplicationCommandOptionChoiceBuilder().setName(name).setValue(value).build());
+        return this;
+    }
+
+    /**
+     * Adds an int choice for the application command option.
+     *
+     * @param name The name of the choice.
+     * @param value The value of the choice.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionBuilder addChoice(String name, int value) {
+        delegate.addChoice(new ApplicationCommandOptionChoiceBuilder().setName(name).setValue(value).build());
+        return this;
+    }
+
+    /**
+     * Sets the choices of the application command option.
+     *
+     * @param choices The choices.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionBuilder setChoices(List<ApplicationCommandOptionChoice> choices) {
+        delegate.setChoices(choices);
+        return this;
+    }
+
+    /**
+     * Adds an application command option to the application command option.
+     *
+     * @param option The option.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionBuilder addOption(ApplicationCommandOption option) {
+        delegate.addOption(option);
+        return this;
+    }
+
+    /**
+     * Sets the application commands for the application command option.
+     *
+     * @param options The options.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionBuilder setOptions(List<ApplicationCommandOption> options) {
+        delegate.setOptions(options);
+        return this;
+    }
+
+    /**
+     * Builds the application command option.
+     *
+     * @return The built option.
+     */
+    public ApplicationCommandOption build() {
+        return delegate.build();
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandOptionChoice.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandOptionChoice.java
@@ -1,0 +1,48 @@
+package org.javacord.api.command;
+
+import java.util.Optional;
+
+/**
+ * A choice for an application command option.
+ */
+public interface ApplicationCommandOptionChoice {
+
+    /**
+     * Gets the name of this choice.
+     *
+     * @return The name of the choice.
+     */
+    String getName();
+
+    /**
+     * Gets the string value of this choice.
+     *
+     * <p>If this option is an integer choice, the optional will be empty.
+     *
+     * @return The string value of this choice.
+     */
+    Optional<String> getStringValue();
+
+    /**
+     * Gets the integer value of this choice.
+     *
+     * <p>If this option is an string choice, the optional will be empty.
+     *
+     * @return The integer value of this choice.
+     */
+    Optional<Integer> getIntValue();
+
+    /**
+     * Gets the value of this choice as a string.
+     *
+     * <p>If the value is an integer, its string representation will be returned.
+     *
+     * @return The value of the choice as a string.
+     */
+    default String getValueAsString() {
+        return getStringValue().orElseGet(() -> getIntValue()
+                .map(String::valueOf)
+                .orElseThrow(() ->
+                        new AssertionError("Application command option choice value that's neither a string nor int")));
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandOptionChoiceBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandOptionChoiceBuilder.java
@@ -1,0 +1,57 @@
+package org.javacord.api.command;
+
+import org.javacord.api.command.internal.ApplicationCommandOptionChoiceBuilderDelegate;
+import org.javacord.api.util.internal.DelegateFactory;
+
+public class ApplicationCommandOptionChoiceBuilder {
+
+    private final ApplicationCommandOptionChoiceBuilderDelegate delegate =
+            DelegateFactory.createApplicationCommandOptionChoiceBuilderDelegate();
+
+    /**
+     * Creates a new application command option choice builder.
+     */
+    public ApplicationCommandOptionChoiceBuilder() { }
+
+    /**
+     * Sets the name of the application command option choice.
+     *
+     * @param name The name.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionChoiceBuilder setName(String name) {
+        delegate.setName(name);
+        return this;
+    }
+
+    /**
+     * Sets the string value of the application command option choice.
+     *
+     * @param value The value.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionChoiceBuilder setValue(String value) {
+        delegate.setValue(value);
+        return this;
+    }
+
+    /**
+     * Sets the int value of the application command option choice.
+     *
+     * @param value The value.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandOptionChoiceBuilder setValue(int value) {
+        delegate.setValue(value);
+        return this;
+    }
+
+    /**
+     * Builds the application command option choice.
+     *
+     * @return The application command option choice.
+     */
+    public ApplicationCommandOptionChoice build() {
+        return delegate.build();
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandOptionType.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/ApplicationCommandOptionType.java
@@ -1,0 +1,45 @@
+package org.javacord.api.command;
+
+public enum ApplicationCommandOptionType {
+
+    SUB_COMMAND(1),
+    SUB_COMMAND_GROUP(2),
+    STRING(3),
+    INTEGER(4),
+    BOOLEAN(5),
+    USER(6),
+    CHANNEL(7),
+    ROLE(8),
+    UNKNOWN(-1);
+
+    private final int value;
+
+    ApplicationCommandOptionType(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets integer value that represents this type.
+     *
+     * @return The integer value that represents this type.
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Gets an {@code ApplicationCommandOptionType} by its value.
+     *
+     * @param value The value of the application command option type.
+     * @return The application command option type for the given value,
+     *         or {@link ApplicationCommandOptionType#UNKNOWN} if there's none with the given value.
+     */
+    public static ApplicationCommandOptionType fromValue(int value) {
+        for (ApplicationCommandOptionType type : values()) {
+            if (type.getValue() == value) {
+                return type;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/Interaction.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/Interaction.java
@@ -1,0 +1,67 @@
+package org.javacord.api.command;
+
+import org.javacord.api.entity.DiscordEntity;
+import org.javacord.api.entity.channel.TextChannel;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.entity.user.User;
+
+import java.util.Optional;
+
+public interface Interaction extends DiscordEntity {
+
+    /**
+     * Gets the id of the application that this interaction is for.
+     *
+     * @return The id of the application.
+     */
+    long getApplicationId();
+
+    /**
+     * Gets the type of the interaction.
+     *
+     * @return The type of the interaction.
+     */
+    InteractionType getType();
+
+    /**
+     * Gets the data of the interaction.
+     *
+     * @return The data of the interaction.
+     */
+    Optional<ApplicationCommandInteractionData> getData();
+
+    /**
+     * Gets the server that this interaction was sent from.
+     *
+     * @return The server.
+     */
+    Optional<Server> getServer();
+
+    /**
+     * Gets the channel that this interaction was sent from.
+     *
+     * @return The channel.
+     */
+    Optional<TextChannel> getChannel();
+
+    /**
+     * Gets the invoking user.
+     *
+     * @return The invoking user.
+     */
+    User getUser();
+
+    /**
+     * Gets the continuation token for responding to the interaction.
+     *
+     * @return The token.
+     */
+    String getToken();
+
+    /**
+     * Gets the version.
+     *
+     * @return The version.
+     */
+    int getVersion();
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/InteractionApplicationCommandCallbackData.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/InteractionApplicationCommandCallbackData.java
@@ -1,0 +1,39 @@
+package org.javacord.api.command;
+
+import org.javacord.api.entity.message.embed.Embed;
+import org.javacord.api.entity.message.mention.AllowedMentions;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface InteractionApplicationCommandCallbackData {
+
+    /**
+     * Checks whether or not the response is text to speech.
+     *
+     * @return Whether or not the response is text to speech.
+     */
+    Optional<Boolean> isTts();
+
+    /**
+     * Gets the message content.
+     *
+     * @return The message content.
+     */
+    String getContent();
+
+    /**
+     * Gets a list with all embeds.
+     *
+     * @return A list with all embeds.
+     */
+    List<Embed> getEmbeds();
+
+    /**
+     * Gets a list with all allowed mentions.
+     *
+     * @return A list with all allowed mentions.
+     */
+    List<AllowedMentions> getAllowedMentions();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/InteractionResponse.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/InteractionResponse.java
@@ -1,0 +1,20 @@
+package org.javacord.api.command;
+
+import java.util.Optional;
+
+public interface InteractionResponse {
+
+    /**
+     * Gets the type of the response.
+     *
+     * @return The type.
+     */
+    InteractionResponseType getType();
+
+    /**
+     * Gets the response messages.
+     *
+     * @return The response message.
+     */
+    Optional<InteractionApplicationCommandCallbackData> getData();
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/InteractionResponseType.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/InteractionResponseType.java
@@ -1,0 +1,40 @@
+package org.javacord.api.command;
+
+public enum InteractionResponseType {
+
+    PONG(1),
+    CHANNEL_MESSAGE_WITH_SOURCE(4),
+    DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE(5),
+    UNKNOWN(-1);
+
+    private final int value;
+
+    InteractionResponseType(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets integer value that represents this type.
+     *
+     * @return The integer value that represents this type.
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Gets an {@code InteractionResponseType} by its value.
+     *
+     * @param value The value of the interaction response type.
+     * @return The interaction response type for the given value,
+     *         or {@link InteractionResponseType#UNKNOWN} if there's none with the given value.
+     */
+    public static InteractionResponseType fromValue(int value) {
+        for (InteractionResponseType type : values()) {
+            if (type.getValue() == value) {
+                return type;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/InteractionType.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/InteractionType.java
@@ -1,0 +1,39 @@
+package org.javacord.api.command;
+
+public enum InteractionType {
+
+    PING(1),
+    APPLICATION_COMMAND(2),
+    UNKNOWN(-1);
+
+    private final int value;
+
+    InteractionType(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets integer value that represents this type.
+     *
+     * @return The integer value that represents this type.
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Gets an {@code InteractionType} by its value.
+     *
+     * @param value The value of the interaction type.
+     * @return The interaction type for the given value,
+     *         or {@link InteractionType#UNKNOWN} if there's none with the given value.
+     */
+    public static InteractionType fromValue(int value) {
+        for (InteractionType type : values()) {
+            if (type.getValue() == value) {
+                return type;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/internal/ApplicationCommandBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/internal/ApplicationCommandBuilderDelegate.java
@@ -1,0 +1,60 @@
+package org.javacord.api.command.internal;
+
+import org.javacord.api.DiscordApi;
+import org.javacord.api.command.ApplicationCommand;
+import org.javacord.api.command.ApplicationCommandOption;
+import org.javacord.api.entity.server.Server;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This class is internally used by the {@link org.javacord.api.command.ApplicationCommandBuilder}.
+ * You usually don't want to interact with this object.
+ */
+public interface ApplicationCommandBuilderDelegate {
+
+    /**
+     * Sets the name of the application command.
+     *
+     * @param name The name.
+     */
+    void setName(String name);
+
+    /**
+     * Sets the description of the application command.
+     *
+     * @param description The name.
+     */
+    void setDescription(String description);
+
+    /**
+     * Adds an application command option to the application command.
+     *
+     * @param option The option.
+     */
+    void addOption(ApplicationCommandOption option);
+
+    /**
+     * Sets the application commands for the application command.
+     *
+     * @param options The options.
+     */
+    void setOptions(List<ApplicationCommandOption> options);
+
+    /**
+     * Creates a global application command.
+     *
+     * @param api The discord api instance.
+     * @return The built application command.
+     */
+    CompletableFuture<ApplicationCommand> createGlobal(DiscordApi api);
+
+    /**
+     * Creates an application command for a specific server.
+     *
+     * @param server The server.
+     * @return The built application command.
+     */
+    CompletableFuture<ApplicationCommand> createForServer(Server server);
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/internal/ApplicationCommandOptionBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/internal/ApplicationCommandOptionBuilderDelegate.java
@@ -1,0 +1,77 @@
+package org.javacord.api.command.internal;
+
+import org.javacord.api.command.ApplicationCommandOption;
+import org.javacord.api.command.ApplicationCommandOptionChoice;
+import org.javacord.api.command.ApplicationCommandOptionType;
+
+import java.util.List;
+
+/**
+ * This class is internally used by the {@link org.javacord.api.command.ApplicationCommandOptionBuilder}.
+ * You usually don't want to interact with this object.
+ */
+public interface ApplicationCommandOptionBuilderDelegate {
+
+    /**
+     * Sets the type of the application command option.
+     *
+     * @param type The type.
+     */
+    void setType(ApplicationCommandOptionType type);
+
+    /**
+     * Sets the name of the application command option.
+     *
+     * @param name The name.
+     */
+    void setName(String name);
+
+    /**
+     * Sets the description of the application command option.
+     *
+     * @param description The description.
+     */
+    void setDescription(String description);
+
+    /**
+     * Sets if the application command option is required.
+     *
+     * @param required Whether or not the option is required.
+     */
+    void setRequired(boolean required);
+
+    /**
+     * Adds an choice for the application command option.
+     *
+     * @param choice The choice.
+     */
+    void addChoice(ApplicationCommandOptionChoice choice);
+
+    /**
+     * Sets the choices of the application command option.
+     *
+     * @param choices The choices.
+     */
+    void setChoices(List<ApplicationCommandOptionChoice> choices);
+
+    /**
+     * Adds an application command option to the application command option.
+     *
+     * @param option The option.
+     */
+    void addOption(ApplicationCommandOption option);
+
+    /**
+     * Sets the application commands for the application command option.
+     *
+     * @param options The options.
+     */
+    void setOptions(List<ApplicationCommandOption> options);
+
+    /**
+     * Build the application command option.
+     *
+     * @return The built option.
+     */
+    ApplicationCommandOption build();
+}

--- a/javacord-api/src/main/java/org/javacord/api/command/internal/ApplicationCommandOptionChoiceBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/command/internal/ApplicationCommandOptionChoiceBuilderDelegate.java
@@ -1,0 +1,39 @@
+package org.javacord.api.command.internal;
+
+import org.javacord.api.command.ApplicationCommandOptionChoice;
+
+/**
+ * This class is internally used by the {@link org.javacord.api.command.ApplicationCommandOptionChoiceBuilder}.
+ * You usually don't want to interact with this object.
+ */
+public interface ApplicationCommandOptionChoiceBuilderDelegate {
+
+    /**
+     * Sets the name of the application command option choice.
+     *
+     * @param name The name.
+     */
+    void setName(String name);
+
+    /**
+     * Sets the string value of the application command option choice.
+     *
+     * @param value The value.
+     */
+    void setValue(String value);
+
+    /**
+     * Sets the int value of the application command option choice.
+     *
+     * @param value The value.
+     */
+    void setValue(int value);
+
+    /**
+     * Builds the application command option choice.
+     *
+     * @return The application command option choice.
+     */
+    ApplicationCommandOptionChoice build();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/event/channel/server/ServerChannelEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/channel/server/ServerChannelEvent.java
@@ -1,6 +1,7 @@
 package org.javacord.api.event.channel.server;
 
 import org.javacord.api.entity.channel.ServerChannel;
+import org.javacord.api.entity.server.Server;
 import org.javacord.api.event.channel.ChannelEvent;
 import org.javacord.api.event.server.ServerEvent;
 
@@ -12,4 +13,8 @@ public interface ServerChannelEvent extends ServerEvent, ChannelEvent {
     @Override
     ServerChannel getChannel();
 
+    @Override
+    default Server getServer() {
+        return getChannel().getServer();
+    }
 }

--- a/javacord-api/src/main/java/org/javacord/api/event/channel/server/text/ServerTextChannelEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/channel/server/text/ServerTextChannelEvent.java
@@ -11,5 +11,4 @@ public interface ServerTextChannelEvent extends ServerChannelEvent, TextChannelE
 
     @Override
     ServerTextChannel getChannel();
-
 }

--- a/javacord-api/src/main/java/org/javacord/api/event/command/InteractionCreateEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/command/InteractionCreateEvent.java
@@ -1,0 +1,17 @@
+package org.javacord.api.event.command;
+
+import org.javacord.api.command.Interaction;
+import org.javacord.api.event.Event;
+
+/**
+ * An interaction create event.
+ */
+public interface InteractionCreateEvent extends Event {
+
+    /**
+     * Gets the created interaction.
+     *
+     * @return The interaction.
+     */
+    Interaction getInteraction();
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/command/InteractionCreateListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/command/InteractionCreateListener.java
@@ -1,0 +1,23 @@
+package org.javacord.api.listener.command;
+
+import org.javacord.api.event.command.InteractionCreateEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.channel.TextChannelAttachableListener;
+import org.javacord.api.listener.server.ServerAttachableListener;
+import org.javacord.api.listener.user.UserAttachableListener;
+
+/**
+ * This listener listens to interaction creations.
+ */
+@FunctionalInterface
+public interface InteractionCreateListener extends ServerAttachableListener, UserAttachableListener,
+        TextChannelAttachableListener, GloballyAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called every time an interaction is created.
+     *
+     * @param event The event.
+     */
+    void onInteractionCreate(InteractionCreateEvent event);
+}

--- a/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactory.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactory.java
@@ -2,6 +2,9 @@ package org.javacord.api.util.internal;
 
 import org.javacord.api.DiscordApi;
 import org.javacord.api.audio.internal.AudioSourceBaseDelegate;
+import org.javacord.api.command.internal.ApplicationCommandBuilderDelegate;
+import org.javacord.api.command.internal.ApplicationCommandOptionBuilderDelegate;
+import org.javacord.api.command.internal.ApplicationCommandOptionChoiceBuilderDelegate;
 import org.javacord.api.entity.channel.GroupChannel;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.ServerTextChannel;
@@ -325,6 +328,33 @@ public class DelegateFactory {
      */
     public static AudioSourceBaseDelegate createAudioSourceBaseDelegate(DiscordApi api) {
         return delegateFactoryDelegate.createAudioSourceBaseDelegate(api);
+    }
+
+    /**
+     * Creates a new application command builder delegate.
+     *
+     * @return The application command builder delegate.
+     */
+    public static ApplicationCommandBuilderDelegate createApplicationCommandBuilderDelegate() {
+        return delegateFactoryDelegate.createApplicationCommandBuilderDelegate();
+    }
+
+    /**
+     * Creates a new application command option builder delegate.
+     *
+     * @return The application command option builder delegate.
+     */
+    public static ApplicationCommandOptionBuilderDelegate createApplicationCommandOptionBuilderDelegate() {
+        return delegateFactoryDelegate.createApplicationCommandOptionBuilderDelegate();
+    }
+
+    /**
+     * Creates a new application command option choice builder delegate.
+     *
+     * @return The application command option choice builder delegate.
+     */
+    public static ApplicationCommandOptionChoiceBuilderDelegate createApplicationCommandOptionChoiceBuilderDelegate() {
+        return delegateFactoryDelegate.createApplicationCommandOptionChoiceBuilderDelegate();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactoryDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactoryDelegate.java
@@ -2,6 +2,9 @@ package org.javacord.api.util.internal;
 
 import org.javacord.api.DiscordApi;
 import org.javacord.api.audio.internal.AudioSourceBaseDelegate;
+import org.javacord.api.command.internal.ApplicationCommandBuilderDelegate;
+import org.javacord.api.command.internal.ApplicationCommandOptionBuilderDelegate;
+import org.javacord.api.command.internal.ApplicationCommandOptionChoiceBuilderDelegate;
 import org.javacord.api.entity.channel.GroupChannel;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.ServerTextChannel;
@@ -250,5 +253,26 @@ public interface DelegateFactoryDelegate {
      * @return A new discord exception validator.
      */
     DiscordExceptionValidator createDiscordExceptionValidator();
+
+    /**
+     * Creates a new application command builder delegate.
+     *
+     * @return The application command builder delegate.
+     */
+    ApplicationCommandBuilderDelegate createApplicationCommandBuilderDelegate();
+
+    /**
+     * Creates a new application command option builder delegate.
+     *
+     * @return The application command option builder delegate.
+     */
+    ApplicationCommandOptionBuilderDelegate createApplicationCommandOptionBuilderDelegate();
+
+    /**
+     * Creates a new application command option choice builder delegate.
+     *
+     * @return The application command option choice builder delegate.
+     */
+    ApplicationCommandOptionChoiceBuilderDelegate createApplicationCommandOptionChoiceBuilderDelegate();
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.javacord.api.AccountType;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.Javacord;
+import org.javacord.api.command.ApplicationCommand;
 import org.javacord.api.entity.ApplicationInfo;
 import org.javacord.api.entity.activity.Activity;
 import org.javacord.api.entity.activity.ActivityType;
@@ -44,6 +45,7 @@ import org.javacord.api.util.event.ListenerManager;
 import org.javacord.api.util.ratelimit.LocalRatelimiter;
 import org.javacord.api.util.ratelimit.Ratelimiter;
 import org.javacord.core.audio.AudioConnectionImpl;
+import org.javacord.core.command.ApplicationCommandImpl;
 import org.javacord.core.entity.activity.ActivityImpl;
 import org.javacord.core.entity.activity.ApplicationInfoImpl;
 import org.javacord.core.entity.emoji.CustomEmojiImpl;
@@ -1321,6 +1323,26 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     @Override
     public ThreadPool getThreadPool() {
         return threadPool;
+    }
+
+    @Override
+    public CompletableFuture<List<ApplicationCommand>> getGlobalApplicationCommands() {
+        return new RestRequest<List<ApplicationCommand>>(this, RestMethod.GET, RestEndpoint.APPLICATION_COMMANDS)
+            .setUrlParameters(String.valueOf(clientId))
+            .execute(result -> {
+                List<ApplicationCommand> applicationCommands = new ArrayList<>();
+                for (JsonNode applicationCommandJson : result.getJsonBody()) {
+                    applicationCommands.add(new ApplicationCommandImpl(this, applicationCommandJson));
+                }
+                return Collections.unmodifiableList(applicationCommands);
+            });
+    }
+
+    @Override
+    public CompletableFuture<ApplicationCommand> getGlobalApplicationCommandById(long commandId) {
+        return new RestRequest<ApplicationCommand>(this, RestMethod.GET, RestEndpoint.APPLICATION_COMMANDS)
+            .setUrlParameters(String.valueOf(clientId), String.valueOf(commandId))
+            .execute(result -> new ApplicationCommandImpl(this, result.getJsonBody()));
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandBuilderDelegateImpl.java
@@ -1,0 +1,82 @@
+package org.javacord.core.command;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.command.ApplicationCommand;
+import org.javacord.api.command.ApplicationCommandOption;
+import org.javacord.api.command.internal.ApplicationCommandBuilderDelegate;
+import org.javacord.api.entity.server.Server;
+import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.util.rest.RestEndpoint;
+import org.javacord.core.util.rest.RestMethod;
+import org.javacord.core.util.rest.RestRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class ApplicationCommandBuilderDelegateImpl implements ApplicationCommandBuilderDelegate {
+
+    private String name;
+    private String description;
+    private List<ApplicationCommandOption> options = new ArrayList<>();
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public void addOption(ApplicationCommandOption option) {
+        options.add(option);
+    }
+
+    @Override
+    public void setOptions(List<ApplicationCommandOption> options) {
+        if (options == null) {
+            this.options.clear();
+        } else {
+            this.options = new ArrayList<>(options);
+        }
+    }
+
+    @Override
+    public CompletableFuture<ApplicationCommand> createGlobal(DiscordApi api) {
+        return new RestRequest<ApplicationCommand>(api, RestMethod.POST, RestEndpoint.APPLICATION_COMMANDS)
+            .setUrlParameters(String.valueOf(api.getClientId()))
+            .setBody(getJsonBodyForApplicationCommand())
+            .execute(result -> new ApplicationCommandImpl((DiscordApiImpl) api, result.getJsonBody()));
+    }
+
+    @Override
+    public CompletableFuture<ApplicationCommand> createForServer(Server server) {
+        return new RestRequest<ApplicationCommand>(
+            server.getApi(), RestMethod.POST, RestEndpoint.GUILD_APPLICATION_COMMANDS)
+            .setUrlParameters(String.valueOf(server.getApi().getClientId()), server.getIdAsString())
+            .setBody(getJsonBodyForApplicationCommand())
+            .execute(result -> new ApplicationCommandImpl((DiscordApiImpl) server.getApi(), result.getJsonBody()));
+    }
+
+    private ObjectNode getJsonBodyForApplicationCommand() {
+        ObjectNode jsonBody = JsonNodeFactory.instance.objectNode()
+                .put("name", name)
+                .put("description", description);
+
+        if (!options.isEmpty()) {
+            ArrayNode jsonOptions = jsonBody.putArray("options");
+            options.stream()
+                .map(ApplicationCommandOptionImpl.class::cast)
+                .map(ApplicationCommandOptionImpl::toJsonNode)
+                .forEach(jsonOptions::add);
+        }
+
+        return jsonBody;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandImpl.java
@@ -1,0 +1,82 @@
+package org.javacord.core.command;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.command.ApplicationCommand;
+import org.javacord.api.command.ApplicationCommandOption;
+import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.util.rest.RestEndpoint;
+import org.javacord.core.util.rest.RestMethod;
+import org.javacord.core.util.rest.RestRequest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class ApplicationCommandImpl implements ApplicationCommand {
+
+    private final DiscordApiImpl api;
+    private final long id;
+    private final long applicationId;
+    private final String name;
+    private final String description;
+    private final List<ApplicationCommandOption> options;
+
+    /**
+     * Class constructor.
+     *
+     * @param api The api instance.
+     * @param data The json data of the application command.
+     */
+    public ApplicationCommandImpl(DiscordApiImpl api, JsonNode data) {
+        this.api = api;
+        id = data.get("id").asLong();
+        applicationId = data.get("application_id").asLong();
+        name = data.get("name").asText();
+        description = data.get("description").asText();
+        options = new ArrayList<>();
+        if (data.has("options")) {
+            for (JsonNode optionJson : data.get("options")) {
+                options.add(new ApplicationCommandOptionImpl(optionJson));
+            }
+        }
+    }
+
+    @Override
+    public DiscordApi getApi() {
+        return api;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public long getApplicationId() {
+        return applicationId;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public List<ApplicationCommandOption> getOptions() {
+        return Collections.unmodifiableList(options);
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+        return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.APPLICATION_COMMANDS)
+            .setUrlParameters(String.valueOf(getApplicationId()), getIdAsString())
+            .execute(result -> null);
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandInteractionDataImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandInteractionDataImpl.java
@@ -1,0 +1,59 @@
+package org.javacord.core.command;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.command.ApplicationCommandInteractionData;
+import org.javacord.api.command.ApplicationCommandInteractionDataOption;
+import org.javacord.core.DiscordApiImpl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ApplicationCommandInteractionDataImpl implements ApplicationCommandInteractionData {
+
+    private final DiscordApiImpl api;
+
+    private final long id;
+    private final String name;
+    private final List<ApplicationCommandInteractionDataOption> options;
+
+    /**
+     * Class constructor.
+     *
+     * @param api The api instance.
+     * @param jsonData The json data of the interaction data.
+     */
+    public ApplicationCommandInteractionDataImpl(DiscordApiImpl api, JsonNode jsonData) {
+        this.api = api;
+
+        id = jsonData.get("id").asLong();
+        name = jsonData.get("name").asText();
+        options = new ArrayList<>();
+        if (jsonData.has("options") && jsonData.get("options").isArray()) {
+            for (JsonNode optionJson : jsonData.get("options")) {
+                options.add(new ApplicationCommandInteractionDataOptionImpl(optionJson));
+            }
+        }
+    }
+
+    @Override
+    public DiscordApi getApi() {
+        return api;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public List<ApplicationCommandInteractionDataOption> getOptions() {
+        return Collections.unmodifiableList(options);
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandInteractionDataOptionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandInteractionDataOptionImpl.java
@@ -1,0 +1,64 @@
+package org.javacord.core.command;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.command.ApplicationCommandInteractionDataOption;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class ApplicationCommandInteractionDataOptionImpl implements ApplicationCommandInteractionDataOption {
+
+    private final String name;
+    private final String stringValue;
+    private final Integer intValue;
+    private final List<ApplicationCommandInteractionDataOption> options;
+
+    /**
+     * Class constructor.
+     *
+     * @param jsonData The json data of the option.
+     */
+    public ApplicationCommandInteractionDataOptionImpl(JsonNode jsonData) {
+        name = jsonData.get("name").asText();
+        JsonNode valueNode = jsonData.get("value");
+
+        if (valueNode != null && valueNode.isTextual()) {
+            stringValue = valueNode.asText();
+            intValue = null;
+        } else if (valueNode != null && valueNode.isInt()) {
+            intValue = valueNode.asInt();
+            stringValue = null;
+        } else {
+            intValue = null;
+            stringValue = null;
+        }
+        options = new ArrayList<>();
+        if (jsonData.has("options") && jsonData.get("options").isArray()) {
+            for (JsonNode optionJson : jsonData.get("options")) {
+                options.add(new ApplicationCommandInteractionDataOptionImpl(optionJson));
+            }
+        }
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Optional<String> getStringValue() {
+        return Optional.ofNullable(stringValue);
+    }
+
+    @Override
+    public Optional<Integer> getIntValue() {
+        return Optional.ofNullable(intValue);
+    }
+
+    @Override
+    public List<ApplicationCommandInteractionDataOption> getOptions() {
+        return Collections.unmodifiableList(options);
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandOptionBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandOptionBuilderDelegateImpl.java
@@ -1,0 +1,72 @@
+package org.javacord.core.command;
+
+import org.javacord.api.command.ApplicationCommandOption;
+import org.javacord.api.command.ApplicationCommandOptionChoice;
+import org.javacord.api.command.ApplicationCommandOptionType;
+import org.javacord.api.command.internal.ApplicationCommandOptionBuilderDelegate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ApplicationCommandOptionBuilderDelegateImpl implements ApplicationCommandOptionBuilderDelegate {
+
+    private ApplicationCommandOptionType type;
+    private String name;
+    private String description;
+    private boolean required;
+    private List<ApplicationCommandOptionChoice> choices = new ArrayList<>();
+    private List<ApplicationCommandOption> options = new ArrayList<>();
+
+    @Override
+    public void setType(ApplicationCommandOptionType type) {
+        this.type = type;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    @Override
+    public void addChoice(ApplicationCommandOptionChoice choice) {
+        choices.add(choice);
+    }
+
+    @Override
+    public void setChoices(List<ApplicationCommandOptionChoice> choices) {
+        if (choices == null) {
+            this.choices.clear();
+        } else {
+            this.choices = new ArrayList<>(choices);
+        }
+    }
+
+    @Override
+    public void addOption(ApplicationCommandOption option) {
+        options.add(option);
+    }
+
+    @Override
+    public void setOptions(List<ApplicationCommandOption> options) {
+        if (options == null) {
+            this.options.clear();
+        } else {
+            this.options = new ArrayList<>(options);
+        }
+    }
+
+    @Override
+    public ApplicationCommandOption build() {
+        return new ApplicationCommandOptionImpl(type, name, description, required, choices, options);
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandOptionChoiceBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandOptionChoiceBuilderDelegateImpl.java
@@ -1,0 +1,34 @@
+package org.javacord.core.command;
+
+import org.javacord.api.command.ApplicationCommandOptionChoice;
+import org.javacord.api.command.internal.ApplicationCommandOptionChoiceBuilderDelegate;
+
+public class ApplicationCommandOptionChoiceBuilderDelegateImpl
+        implements ApplicationCommandOptionChoiceBuilderDelegate {
+
+    private String name;
+    private String stringValue;
+    private Integer intValue;
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void setValue(String value) {
+        stringValue = value;
+        intValue = null;
+    }
+
+    @Override
+    public void setValue(int value) {
+        stringValue = null;
+        intValue = value;
+    }
+
+    @Override
+    public ApplicationCommandOptionChoice build() {
+        return new ApplicationCommandOptionChoiceImpl(name, stringValue, intValue);
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandOptionChoiceImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandOptionChoiceImpl.java
@@ -1,0 +1,75 @@
+package org.javacord.core.command;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.command.ApplicationCommandOptionChoice;
+
+import java.util.Optional;
+
+public class ApplicationCommandOptionChoiceImpl implements ApplicationCommandOptionChoice {
+
+    private final String name;
+    private final String stringValue;
+    private final Integer intValue;
+
+    /**
+     * Class constructor.
+     *
+     * @param data The json data of the choice.
+     */
+    public ApplicationCommandOptionChoiceImpl(JsonNode data) {
+        name = data.get("name").asText();
+        if (data.get("value").isTextual()) {
+            stringValue = data.get("value").textValue();
+        } else {
+            stringValue = null;
+        }
+        if (data.get("value").isInt()) {
+            intValue = data.get("value").intValue();
+        } else {
+            intValue = null;
+        }
+    }
+
+    /**
+     * Class constructor.
+     *
+     * @param name The name of the choice.
+     * @param stringValue The string value of the choice or null if it is an int value.
+     * @param intValue The int value of the choice or null if it is a string value.
+     */
+    public ApplicationCommandOptionChoiceImpl(String name, String stringValue, Integer intValue) {
+        this.name = name;
+        this.stringValue = stringValue;
+        this.intValue = intValue;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Optional<String> getStringValue() {
+        return Optional.ofNullable(stringValue);
+    }
+
+    @Override
+    public Optional<Integer> getIntValue() {
+        return Optional.ofNullable(intValue);
+    }
+
+    /**
+     * Creates a json node with the choice's data.
+     *
+     * @return The json node.
+     */
+    public JsonNode toJsonNode() {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put("name", name);
+        getIntValue().ifPresent(value -> node.put("value", value));
+        getStringValue().ifPresent(value -> node.put("value", value));
+        return node;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandOptionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/command/ApplicationCommandOptionImpl.java
@@ -1,0 +1,126 @@
+package org.javacord.core.command;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.command.ApplicationCommandOption;
+import org.javacord.api.command.ApplicationCommandOptionChoice;
+import org.javacord.api.command.ApplicationCommandOptionType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ApplicationCommandOptionImpl implements ApplicationCommandOption {
+
+    private final ApplicationCommandOptionType type;
+    private final String name;
+    private final String description;
+    private final boolean required;
+    private final List<ApplicationCommandOptionChoice> choices;
+    private final List<ApplicationCommandOption> options;
+
+    /**
+     * Class constructor.
+     *
+     * @param data The json data of the application command option.
+     */
+    public ApplicationCommandOptionImpl(JsonNode data) {
+        type = ApplicationCommandOptionType.fromValue(data.get("type").intValue());
+        name = data.get("name").asText();
+        description = data.get("description").asText();
+        required = data.has("required") && data.get("required").asBoolean(false);
+        choices = new ArrayList<>();
+        if (data.has("choices")) {
+            for (JsonNode choiceJson : data.get("choices")) {
+                choices.add(new ApplicationCommandOptionChoiceImpl(choiceJson));
+            }
+        }
+
+        options = new ArrayList<>();
+        if (data.has("options")) {
+            for (JsonNode optionJson : data.get("options")) {
+                options.add(new ApplicationCommandOptionImpl(optionJson));
+            }
+        }
+    }
+
+    /**
+     * Class constructor.
+     *
+     * @param type The type.
+     * @param name The name.
+     * @param description The description.
+     * @param required If the option is required.
+     * @param choices The choices.
+     * @param options The options.
+     */
+    public ApplicationCommandOptionImpl(
+            ApplicationCommandOptionType type,
+            String name,
+            String description,
+            boolean required,
+            List<ApplicationCommandOptionChoice> choices,
+            List<ApplicationCommandOption> options
+    ) {
+        this.type = type;
+        this.name = name;
+        this.description = description;
+        this.required = required;
+        this.choices = choices;
+        this.options = options;
+    }
+
+    @Override
+    public ApplicationCommandOptionType getType() {
+        return type;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public boolean isRequired() {
+        return required;
+    }
+
+    @Override
+    public List<ApplicationCommandOptionChoice> getChoices() {
+        return Collections.unmodifiableList(choices);
+    }
+
+    @Override
+    public List<ApplicationCommandOption> getOptions() {
+        return Collections.unmodifiableList(options);
+    }
+
+    /**
+     * Creates a json node with the option's data.
+     *
+     * @return The json node.
+     */
+    public JsonNode toJsonNode() {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put("type", type.getValue());
+        node.put("name", name);
+        node.put("description", description);
+        node.put("required", required);
+        if (!choices.isEmpty()) {
+            ArrayNode jsonChoices = node.putArray("choices");
+            choices.forEach(choice -> jsonChoices.add(((ApplicationCommandOptionChoiceImpl) choice).toJsonNode()));
+        }
+        if (!options.isEmpty()) {
+            ArrayNode jsonOptions = node.putArray("options");
+            options.forEach(option -> jsonOptions.add(((ApplicationCommandOptionImpl) option).toJsonNode()));
+        }
+        return node;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/command/InteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/command/InteractionImpl.java
@@ -1,0 +1,129 @@
+package org.javacord.core.command;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.logging.log4j.Logger;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.command.ApplicationCommandInteractionData;
+import org.javacord.api.command.Interaction;
+import org.javacord.api.command.InteractionType;
+import org.javacord.api.entity.channel.ServerChannel;
+import org.javacord.api.entity.channel.TextChannel;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.entity.user.User;
+import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
+import org.javacord.core.util.logging.LoggerUtil;
+
+import java.util.Optional;
+
+public class InteractionImpl implements Interaction {
+
+    private static final Logger logger = LoggerUtil.getLogger(InteractionImpl.class);
+
+    private final DiscordApiImpl api;
+    private final TextChannel channel;
+
+    private final long id;
+    private final long applicationId;
+    private final InteractionType type;
+    private final ApplicationCommandInteractionData data;
+    private final MemberImpl member;
+    private final UserImpl user;
+    private final String token;
+    private final int version;
+
+    /**
+     * Class constructor.
+     *
+     * @param api The api instance.
+     * @param channel The channel in which the interaction happened. Can be {@code null}.
+     * @param jsonData The json data of the interaction.
+     */
+    public InteractionImpl(DiscordApiImpl api, TextChannel channel, JsonNode jsonData) {
+        this.api = api;
+        this.channel = channel;
+
+        id = jsonData.get("id").asLong();
+        applicationId = jsonData.get("application_id").asLong();
+        type = InteractionType.fromValue(jsonData.get("type").asInt());
+        if (jsonData.has("data")) {
+            data = new ApplicationCommandInteractionDataImpl(api, jsonData.get("data"));
+        } else {
+            data = null;
+        }
+        if (jsonData.hasNonNull("member")) {
+            member = new MemberImpl(
+                    api,
+                    (ServerImpl) getServer().orElseThrow(AssertionError::new),
+                    jsonData.get("member"),
+                    null
+            );
+            user = (UserImpl) member.getUser();
+        } else if (jsonData.hasNonNull("user")) {
+            user = new UserImpl(api, jsonData.get("user"), (JsonNode) null, null);
+            member = null;
+        } else {
+            user = null;
+            member = null;
+            logger.error("Received interaction without a member AND without a user field");
+        }
+        token = jsonData.get("token").asText();
+        version = jsonData.get("version").asInt();
+    }
+
+    @Override
+    public DiscordApi getApi() {
+        return api;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public long getApplicationId() {
+        return applicationId;
+    }
+
+    @Override
+    public InteractionType getType() {
+        return type;
+    }
+
+    @Override
+    public Optional<ApplicationCommandInteractionData> getData() {
+        return Optional.ofNullable(data);
+    }
+
+    @Override
+    public Optional<Server> getServer() {
+        if (channel instanceof ServerChannel) {
+            return Optional.of(((ServerChannel) channel).getServer());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<TextChannel> getChannel() {
+        return Optional.ofNullable(channel);
+    }
+
+    @Override
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public String getToken() {
+        return token;
+    }
+
+    @Override
+    public int getVersion() {
+        return version;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/event/command/InteractionCreateEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/command/InteractionCreateEventImpl.java
@@ -1,0 +1,29 @@
+package org.javacord.core.event.command;
+
+import org.javacord.api.command.Interaction;
+import org.javacord.api.event.command.InteractionCreateEvent;
+import org.javacord.core.event.EventImpl;
+
+/**
+ * The implementation of {@link InteractionCreateEventImpl}.
+ */
+public class InteractionCreateEventImpl extends EventImpl implements InteractionCreateEvent {
+
+    private final Interaction interaction;
+
+    /**
+     * Creates a new interaction create event.
+     *
+     * @param interaction The created interaction.
+     */
+    public InteractionCreateEventImpl(Interaction interaction) {
+        super(interaction.getApi());
+        this.interaction = interaction;
+    }
+
+    @Override
+    public Interaction getInteraction() {
+        return interaction;
+    }
+}
+

--- a/javacord-core/src/main/java/org/javacord/core/util/DelegateFactoryDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/DelegateFactoryDelegateImpl.java
@@ -2,6 +2,9 @@ package org.javacord.core.util;
 
 import org.javacord.api.DiscordApi;
 import org.javacord.api.audio.internal.AudioSourceBaseDelegate;
+import org.javacord.api.command.internal.ApplicationCommandBuilderDelegate;
+import org.javacord.api.command.internal.ApplicationCommandOptionBuilderDelegate;
+import org.javacord.api.command.internal.ApplicationCommandOptionChoiceBuilderDelegate;
 import org.javacord.api.entity.channel.GroupChannel;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.ServerTextChannel;
@@ -41,6 +44,9 @@ import org.javacord.core.AccountUpdaterDelegateImpl;
 import org.javacord.core.DiscordApiBuilderDelegateImpl;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.audio.AudioSourceBaseDelegateImpl;
+import org.javacord.core.command.ApplicationCommandBuilderDelegateImpl;
+import org.javacord.core.command.ApplicationCommandOptionBuilderDelegateImpl;
+import org.javacord.core.command.ApplicationCommandOptionChoiceBuilderDelegateImpl;
 import org.javacord.core.entity.channel.ChannelCategoryBuilderDelegateImpl;
 import org.javacord.core.entity.channel.ChannelUpdaterDelegateImpl;
 import org.javacord.core.entity.channel.ServerChannelUpdaterDelegateImpl;
@@ -194,6 +200,21 @@ public class DelegateFactoryDelegateImpl implements DelegateFactoryDelegate {
     @Override
     public AudioSourceBaseDelegate createAudioSourceBaseDelegate(DiscordApi api) {
         return new AudioSourceBaseDelegateImpl(api);
+    }
+
+    @Override
+    public ApplicationCommandBuilderDelegate createApplicationCommandBuilderDelegate() {
+        return new ApplicationCommandBuilderDelegateImpl();
+    }
+
+    @Override
+    public ApplicationCommandOptionBuilderDelegate createApplicationCommandOptionBuilderDelegate() {
+        return new ApplicationCommandOptionBuilderDelegateImpl();
+    }
+
+    @Override
+    public ApplicationCommandOptionChoiceBuilderDelegate createApplicationCommandOptionChoiceBuilderDelegate() {
+        return new ApplicationCommandOptionChoiceBuilderDelegateImpl();
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
@@ -40,6 +40,7 @@ import org.javacord.core.util.handler.channel.ChannelUpdateHandler;
 import org.javacord.core.util.handler.channel.WebhooksUpdateHandler;
 import org.javacord.core.util.handler.channel.invite.InviteCreateHandler;
 import org.javacord.core.util.handler.channel.invite.InviteDeleteHandler;
+import org.javacord.core.util.handler.command.InteractionCreateHandler;
 import org.javacord.core.util.handler.guild.GuildBanAddHandler;
 import org.javacord.core.util.handler.guild.GuildBanRemoveHandler;
 import org.javacord.core.util.handler.guild.GuildCreateHandler;
@@ -831,6 +832,9 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
         //invite
         addHandler(new InviteCreateHandler(api));
         addHandler(new InviteDeleteHandler(api));
+
+        // command
+        addHandler(new InteractionCreateHandler(api));
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/command/InteractionCreateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/command/InteractionCreateHandler.java
@@ -1,0 +1,47 @@
+package org.javacord.core.util.handler.command;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.channel.TextChannel;
+import org.javacord.api.event.command.InteractionCreateEvent;
+import org.javacord.core.command.InteractionImpl;
+import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.event.command.InteractionCreateEventImpl;
+import org.javacord.core.util.gateway.PacketHandler;
+
+/**
+ * Handles the guild create packet.
+ */
+public class InteractionCreateHandler extends PacketHandler {
+
+    /**
+     * Creates a new instance of this class.
+     *
+     * @param api The api.
+     */
+    public InteractionCreateHandler(DiscordApi api) {
+        super(api, true, "INTERACTION_CREATE");
+    }
+
+    @Override
+    public void handle(JsonNode packet) {
+        TextChannel channel = null;
+        if (packet.hasNonNull("channel_id")) {
+            channel = api.getTextChannelById(packet.get("channel_id").asLong()).orElse(null);
+        }
+
+        InteractionImpl interaction = new InteractionImpl(api, channel, packet);
+        InteractionCreateEvent event = new InteractionCreateEventImpl(interaction);
+
+        ServerImpl server = (ServerImpl) interaction.getServer().orElse(null);
+
+        api.getEventDispatcher().dispatchInteractionCreateEvent(
+                server == null ? api : server,
+                server,
+                interaction.getChannel().orElse(null),
+                interaction.getUser(),
+                event
+        );
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
@@ -44,7 +44,10 @@ public enum RestEndpoint {
     BAN("/guilds/%s/bans", 0),
     CURRENT_USER("/users/@me"),
     AUDIT_LOG("/guilds/%s/audit-logs", 0),
-    CUSTOM_EMOJI("/guilds/%s/emojis", 0);
+    CUSTOM_EMOJI("/guilds/%s/emojis", 0),
+    INTERACTION_RESPONSE("/interactions/%s/%s/callback", 0),
+    APPLICATION_COMMANDS("/applications/%s/commands", 0),
+    GUILD_APPLICATION_COMMANDS("/applications/%s/guilds/%s/commands", 1);
 
     /**
      * The endpoint url (only including the base, not the https://discord.com/api/vXYZ/ "prefix".


### PR DESCRIPTION
This PR adds support for creating and receiving application interactions (i.e., [slash commands](https://discord.com/developers/docs/interactions/slash-commands)). It does _**not**_ add support for responding to interactions.

The implementation is super low-level and sticks as close to the official Discord API as possible.
Convenience methods can be added in upcoming PRs (e.g., for extracting simple options without having to use the Java streaming api).

### Implemented TODO's

* [x] Receiving interactions
* [x] Creating interactions
* [x] Deleting interactions
* [x] Get global interactions

## Example usage for creating new application commands

### Simple ban command (Global)
```java
ApplicationCommand command = new ApplicationCommandBuilder()
    .setName("ban")
    .setDescription("Bans a user")
    .addOption(
        new ApplicationCommandOptionBuilder()
            .setName("user")
            .setDescription("The user to ban")
            .setRequired(true)
            .setType(ApplicationCommandOptionType.USER)
            .build()
    )
    .createGlobal(api)
    .join();
```

### A command to search the Javacord wiki (Server specific)
```java
Server javacordServer = api.getServerById(151037561152733184L).orElseThrow(AssertionError::new);
ApplicationCommand command = new ApplicationCommandBuilder()
    .setName("wiki")
    .setDescription("Searches the Javacord wiki")
    .addOption(
        new ApplicationCommandOptionBuilder()
            .setName("searchText")
            .setDescription("What should be searched for")
            .setRequired(true)
            .setType(ApplicationCommandOptionType.STRING)
            .build()
    )
    .addOption(
        new ApplicationCommandOptionBuilder()
            .setName("context")
            .setDescription("What places should be searched")
            .setRequired(false)
            .setType(ApplicationCommandOptionType.STRING)
            .addChoice("title", "title")
            .addChoice("full", "full")
            .build()
    )
    .createForServer(javacordServer)
    .join();
```
![image](https://user-images.githubusercontent.com/5033001/113322930-9c407b80-9315-11eb-849e-0f1adbaceb15.png)

## Example usage for receiving interactions

### Wiki command

```java
api.addInteractionCreateListener(event -> {
    ApplicationCommandInteractionData data = event.getInteraction().getData()
        .orElse(null);
    
    if (data == null || !data.getName().equals("wiki")) {
        return;
    }
    
    String context = data.getOptions().stream()
        .filter(option -> option.getName().equals("context"))
        .map(ApplicationCommandInteractionDataOption::getStringValue)
        .findAny()
        .map(Optional::get)
        .orElse("title");

    String searchText = data.getOptions().stream()
        .filter(option -> option.getName().equals("searchtext"))
        .map(ApplicationCommandInteractionDataOption::getStringValue)
        .findAny()
        .map(Optional::get)
        .orElseThrow(() -> new AssertionError("Missing field that is required"));
    
    // TODO Handle interaction
});
```

