### PR TITLE
Added Get Guild Member endpoint

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1795,6 +1795,24 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     }
 
     /**
+     * Requests a server member.
+     *
+     * @param user The user to request as a member.
+     * @return A future to get a server member if it exists in the server.
+     */
+    default CompletableFuture<User> requestMember(User user) {
+        return requestMember(user.getId());
+    }
+
+    /**
+     * Requests a server member.
+     *
+     * @param userId The user id of the member to request.
+     * @return A future to get a server member if it exists in the server.
+     */
+    CompletableFuture<User> requestMember(long userId);
+
+    /**
      * Undeafens the given user on the server.
      *
      * @param user The user to undeafen.

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1406,6 +1406,13 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     }
 
     @Override
+    public CompletableFuture<User> requestMember(long userId) {
+        return new RestRequest<User>(getApi(), RestMethod.GET, RestEndpoint.SERVER_MEMBER)
+                .setUrlParameters(getIdAsString(), Long.toUnsignedString(userId))
+                .execute(result ->  new MemberImpl(api, this, result.getJsonBody(), null).getUser());
+    }
+
+    @Override
     public CompletableFuture<Void> kickUser(User user, String reason) {
         return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.SERVER_MEMBER)
                 .setUrlParameters(getIdAsString(), user.getIdAsString())


### PR DESCRIPTION
This adds the possibility to get a member of a server outside of an event. So it's no longer required to activate the GUILD_MEMBERS intent if you just want to get the users roles for instance.