### PR TITLE
Move user updates from PresenceUpdateHandler to GuildMemberUpdateHandler

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/handler/user/PresenceUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/user/PresenceUpdateHandler.java
@@ -6,20 +6,13 @@ import io.vavr.collection.Map;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.DiscordClient;
 import org.javacord.api.entity.activity.Activity;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.user.UserStatus;
 import org.javacord.api.event.user.UserChangeActivityEvent;
-import org.javacord.api.event.user.UserChangeAvatarEvent;
-import org.javacord.api.event.user.UserChangeDiscriminatorEvent;
-import org.javacord.api.event.user.UserChangeNameEvent;
 import org.javacord.api.event.user.UserChangeStatusEvent;
 import org.javacord.core.entity.activity.ActivityImpl;
 import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.entity.user.UserPresence;
 import org.javacord.core.event.user.UserChangeActivityEventImpl;
-import org.javacord.core.event.user.UserChangeAvatarEventImpl;
-import org.javacord.core.event.user.UserChangeDiscriminatorEventImpl;
-import org.javacord.core.event.user.UserChangeNameEventImpl;
 import org.javacord.core.event.user.UserChangeStatusEventImpl;
 import org.javacord.core.util.gateway.PacketHandler;
 
@@ -48,7 +41,6 @@ public class PresenceUpdateHandler extends PacketHandler {
         // ignore the guild_id and send to all mutual servers instead or we must track the properties per server
         // or all packets after the first do not detect a change and will not send around an event for the server
         long userId = packet.get("user").get("id").asLong();
-        UserImpl oldUser = api.getCachedUserById(userId).map(UserImpl.class::cast).orElse(null);
 
         AtomicReference<UserPresence> presence = new AtomicReference<>(
                 api.getEntityCache().get().getUserPresenceCache().getPresenceByUserId(userId)
@@ -108,39 +100,6 @@ public class PresenceUpdateHandler extends PacketHandler {
         api.updateUserPresence(userId, p -> presence.get());
 
         dispatchUserStatusChangeEventIfChangeDetected(userId, newStatus, oldStatus, newClientStatus, oldClientStatus);
-
-        boolean userChanged = false;
-        UserImpl updatedUser = null;
-        if (oldUser != null) {
-            updatedUser = oldUser.replacePartialUserData(packet.get("user"));
-        }
-        if (oldUser != null && packet.get("user").has("username")) {
-            String newName = packet.get("user").get("username").asText();
-            String oldName = oldUser.getName();
-            if (!oldName.equals(newName)) {
-                dispatchUserChangeNameEvent(updatedUser, newName, oldName);
-                userChanged = true;
-            }
-        }
-        if (oldUser != null && packet.get("user").has("discriminator")) {
-            String newDiscriminator = packet.get("user").get("discriminator").asText();
-            String oldDiscriminator = oldUser.getDiscriminator();
-            if (!oldDiscriminator.equals(newDiscriminator)) {
-                dispatchUserChangeDiscriminatorEvent(updatedUser, newDiscriminator, oldDiscriminator);
-                userChanged = true;
-            }
-        }
-        if (oldUser != null && packet.get("user").has("avatar")) {
-            String newAvatarHash = packet.get("user").get("avatar").asText(null);
-            String oldAvatarHash = oldUser.getAvatarHash();
-            if (!Objects.deepEquals(newAvatarHash, oldAvatarHash)) {
-                dispatchUserChangeAvatarEvent(updatedUser, newAvatarHash, oldAvatarHash);
-                userChanged = true;
-            }
-        }
-        if (oldUser != null && userChanged) {
-            api.updateUserOfAllMembers(updatedUser);
-        }
     }
 
     private void dispatchUserActivityChangeEvent(long userId, Set<Activity> newActivities,
@@ -184,39 +143,4 @@ public class PresenceUpdateHandler extends PacketHandler {
                 event
         );
     }
-
-    private void dispatchUserChangeNameEvent(User user, String newName, String oldName) {
-        UserChangeNameEvent event = new UserChangeNameEventImpl(user, newName, oldName);
-
-        api.getEventDispatcher().dispatchUserChangeNameEvent(
-                api,
-                user.getMutualServers(),
-                Collections.singleton(user),
-                event
-        );
-    }
-
-    private void dispatchUserChangeDiscriminatorEvent(User user, String newDiscriminator, String oldDiscriminator) {
-        UserChangeDiscriminatorEvent event =
-                new UserChangeDiscriminatorEventImpl(user, newDiscriminator, oldDiscriminator);
-
-        api.getEventDispatcher().dispatchUserChangeDiscriminatorEvent(
-                api,
-                user.getMutualServers(),
-                Collections.singleton(user),
-                event
-        );
-    }
-
-    private void dispatchUserChangeAvatarEvent(User user, String newAvatarHash, String oldAvatarHash) {
-        UserChangeAvatarEvent event = new UserChangeAvatarEventImpl(user, newAvatarHash, oldAvatarHash);
-
-        api.getEventDispatcher().dispatchUserChangeAvatarEvent(
-                api,
-                user.getMutualServers(),
-                Collections.singleton(user),
-                event
-        );
-    }
-
 }


### PR DESCRIPTION
This PR moves the handling of base user updates (username, discriminator, avatar) from the PresenceUpdateHandler to the GuildMemberUpdateHandler.

https://github.com/discord/discord-api-docs/pull/1307#issuecomment-581561519
This comment from Discord suggests that they fire a ``GUILD_MEMBER_UPDATE``event if a user changes so bots can opt out of receiving presences just for this purpose. I tested it myself, and Discord is indeed firing one ``GUILD_MEMBER_UPDATE``packet per mutual guild once a user changes their name.

Moving the whole logic makes sense as handling presences is a huge computational burden, and users might want to disable it while still receiving user updates; additionally, ``GUILD_MEMBER_UPDATE``events are much less frequent and should be used for updating the user cache even if presence updates are enabled to improve performance. 

Currently, Javacord is not updating the base user based on the user object in ``GUILD_MEMBER_UPDATE``events, and only listens to changes to the base user data in presence updates. Therefore, this PR moves the whole handling of base user updates to the Guild Member Update Handler.
