### PR TITLE
Bugfix: Do not request identify ratelimit on resume

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
@@ -447,7 +447,9 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
             websocket.addListener(this);
             websocket.addListener(new WebSocketLogger());
 
-            api.getGatewayIdentifyRatelimiter().requestQuota();
+            if (sessionId == null) {
+                api.getGatewayIdentifyRatelimiter().requestQuota();
+            }
             websocket.connect();
         } catch (Throwable t) {
             logger.warn("An error occurred while connecting to websocket", t);


### PR DESCRIPTION
Due to an error in my own implementation in https://github.com/Javacord/Javacord/pull/619, Javacord is currently requesting an identify ratelimit quota even if resuming a session, which is not necessary. This PR makes sure that it only requests a quota before connecting if the intention is **not** to resume a session (e.g. on first start-up). If the session is invalid and it has to send a fresh ``IDENTIFY``packet, it will still request another quota.