### PR TITLE
Fixed audio auto reconnect

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/AudioWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/AudioWebSocketAdapter.java
@@ -220,10 +220,14 @@ public class AudioWebSocketAdapter extends WebSocketAdapter {
                             )
                     );
                 }
+                // Websocket Code 4014 is thrown after a DISCONNECT through stuff like a kick or a voice channel got deleted.
+                // It should never try to reconnect if this is thrown instead of a move.
+
+                //TODO There are multiple reasons if a bot got disconnected. We have to filter that and if the bot got moved we reconnect.
+
+                //Stay disconnected , and close the audio connection.
                 disconnect();
-                // TODO There are multiple reasons for a disconnect close code and we do not want to reconnect
-                //  for all of them (e.g., when the channel was deleted).
-                connection.reconnect();
+                connection.close();
                 break;
             case UNKNOWN_ERROR:
             case UNKNOWN_OPCODE:


### PR DESCRIPTION
Hey i just looked into you code and fixed that problem. There is also a TODO for the people who can figure out the reason for the disconnect like move. Right now everything works with kicking the bot. I suggest to write a Event for the ChannelDisconnectEvent so the developer can also shut down the lavaplayer because the music is still running after this kick. As i said I only fixed the auto reconnect problem. The fix for the still playing but not in the channel problem should be done after creating a AudioDisconnectListener where devs can stop lavaplayer on that event. Hope you like my first pr. I am open for everything and I am also about to write that event. 