### PR TITLE
Add USE_SLASH_COMMANDS permission type

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/PermissionType.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/PermissionType.java
@@ -41,7 +41,8 @@ public enum PermissionType {
     MANAGE_NICKNAMES(0x08000000),
     MANAGE_ROLES(0x10000000),
     MANAGE_WEBHOOKS(0x20000000),
-    MANAGE_EMOJIS(0x40000000);
+    MANAGE_EMOJIS(0x40000000),
+    USE_SLASH_COMMANDS(0x80000000);
 
     /**
      * The value of the permission. An integer where only one bit is set (e.g. <code>0b1000</code>).

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2665,6 +2665,27 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     }
 
     /**
+     * Checks if the given user can use slash commands on the server.
+     *
+     * @param user The user to check.
+     * @return Whether the given user can use slash commands or not.
+     */
+    default boolean canUseSlashCommands(User user) {
+        return hasAnyPermission(user,
+                PermissionType.ADMINISTRATOR,
+                PermissionType.USE_SLASH_COMMANDS);
+    }
+
+    /**
+     * Checks if the user of the connected account can use slash commands on the server.
+     *
+     * @return Whether the user of the connected account can use slash commands or not.
+     */
+    default boolean canYouUseSlashCommands() {
+        return canUseSlashCommands(getApi().getYourself());
+    }
+
+    /**
      * Checks if the given user can manage roles on the server.
      *
      * @param user The user to check.


### PR DESCRIPTION
Although it is not documented in the discord permissions, it is available in the client to allow / deny the usage of slash commands