### PR TITLE
Fixed an error when following an announcement channel

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -43,9 +43,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Returns a {@code MessageBuilder} according to this {@code Message}.
      *
-     * @see MessageBuilder#fromMessage(Message)
-     *
      * @return The {@code MessageBuilder}.
+     * @see MessageBuilder#fromMessage(Message)
      */
     default MessageBuilder toMessageBuilder() {
         return MessageBuilder.fromMessage(this);
@@ -54,9 +53,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Returns a {@code WebhookMessageBuilder} according to this {@code Message}.
      *
-     * @see WebhookMessageBuilder#fromMessage(Message)
-     *
      * @return The {@code WebhookMessageBuilder}.
+     * @see WebhookMessageBuilder#fromMessage(Message)
      */
     default WebhookMessageBuilder toWebhookMessageBuilder() {
         return WebhookMessageBuilder.fromMessage(this);
@@ -305,7 +303,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, String content,
-                                        boolean updateContent, EmbedBuilder embed, boolean updateEmbed) {
+                                           boolean updateContent, EmbedBuilder embed, boolean updateEmbed) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, content, updateContent, embed, updateEmbed);
     }
 
@@ -322,7 +320,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, String content,
-                                        boolean updateContent, EmbedBuilder embed, boolean updateEmbed) {
+                                           boolean updateContent, EmbedBuilder embed, boolean updateEmbed) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, content, updateContent, embed, updateEmbed);
     }
 
@@ -676,7 +674,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     *  Gets the link leading to this message.
+     * Gets the link leading to this message.
      *
      * @return The message link.
      * @throws AssertionError If the link is malformed.
@@ -767,12 +765,13 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     MessageAuthor getAuthor();
 
     /**
-     * Gets the id of the message referenced with a reply.
-     * Only present if this message is type {@code MessageType.REPLY}.
+     * Gets the message reference.
+     * The reference to another message for instance a cross-posted / channel follow / pin / reply message.
      *
-     * @return The id of the referenced message.
+     * @return The message reference.
+     * @see <a href="https://discord.com/developers/docs/resources/channel#message-reference-object">Discord docs for message reference</a>
      */
-    Optional<Long> getReferencedMessageId();
+    Optional<MessageReference> getMessageReference();
 
     /**
      * Gets the message referenced with a reply.
@@ -791,9 +790,9 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return The referenced message.
      */
     default Optional<CompletableFuture<Message>> requestReferencedMessage() {
-        return getReferencedMessageId().map(id ->
-                        getReferencedMessage().map(CompletableFuture::completedFuture)
-                .orElseGet(() -> getApi().getMessageById(id, getChannel())));
+        return getMessageReference().map(MessageReference::getMessageId).filter(Optional::isPresent).map(Optional::get)
+                .map(id -> getReferencedMessage().map(CompletableFuture::completedFuture)
+                        .orElseGet(() -> getApi().getMessageById(id, getChannel())));
     }
 
 
@@ -807,7 +806,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Sets if the the message is kept in cache forever.
      *
-     * @param cachedForever  Whether the message should be kept in cache forever or not.
+     * @param cachedForever Whether the message should be kept in cache forever or not.
      */
     void setCachedForever(boolean cachedForever);
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageReference.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageReference.java
@@ -1,0 +1,31 @@
+package org.javacord.api.entity.message;
+
+import java.util.Optional;
+
+/**
+ * This class represents a reference to another message like a cross-posted / channel follow / pin / reply message.
+ */
+public interface MessageReference {
+
+    /**
+     * Gets the id of the originating message.
+     *
+     * @return the message id.
+     */
+    Optional<Long> getMessageId();
+
+    /**
+     * Gets the id of the originating message's channel.
+     *
+     * @return the channel id.
+     */
+    Optional<Long> getChannelId();
+
+    /**
+     * Gets the id of the originating message's server.
+     *
+     * @return the server id.
+     */
+    Optional<Long> getServerId();
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
@@ -10,6 +10,7 @@ import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.MessageActivity;
 import org.javacord.api.entity.message.MessageAttachment;
 import org.javacord.api.entity.message.MessageAuthor;
+import org.javacord.api.entity.message.MessageReference;
 import org.javacord.api.entity.message.MessageType;
 import org.javacord.api.entity.message.Reaction;
 import org.javacord.api.entity.message.embed.Embed;
@@ -102,9 +103,9 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
     private final String nonce;
 
     /**
-     * The id of the message referenced via message reply.
+     * The reference to another message.
      */
-    private final Long referencedMessageId;
+    private final MessageReferenceImpl messageReference;
     /**
      * The message referenced via message reply.
      */
@@ -219,17 +220,13 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
             nonce = null;
         }
 
-        if (data.hasNonNull("message_reference")) {
-            referencedMessageId = data.get("message_reference").get("message_id").asLong();
-        } else {
-            referencedMessageId = null;
-        }
+        messageReference = data.hasNonNull("message_reference")
+                ? new MessageReferenceImpl(data)
+                : null;
 
-        if (data.hasNonNull("referenced_message")) {
-            referencedMessage = api.getOrCreateMessage(channel, data.get("referenced_message"));
-        } else {
-            referencedMessage = null;
-        }
+        referencedMessage = data.hasNonNull("referenced_message")
+                ? api.getOrCreateMessage(channel, data.get("referenced_message"))
+                : null;
     }
 
     /**
@@ -407,8 +404,8 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
     }
 
     @Override
-    public Optional<Long> getReferencedMessageId() {
-        return Optional.ofNullable(referencedMessageId);
+    public Optional<MessageReference> getMessageReference() {
+        return Optional.ofNullable(messageReference);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageReferenceImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageReferenceImpl.java
@@ -1,0 +1,52 @@
+package org.javacord.core.entity.message;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.entity.message.MessageReference;
+
+import java.util.Optional;
+
+/**
+ * The implementation of {@link MessageReference}.
+ */
+public class MessageReferenceImpl implements MessageReference {
+
+    /**
+     * Id of the originating message.
+     */
+    private final Long messageId;
+    /**
+     * Id of the originating message's channel.
+     */
+    private final Long channelId;
+    /**
+     * Id of the originating message's server.
+     */
+    private final Long serverId;
+
+    /**
+     * Creates a new message reference object.
+     *
+     * @param data The json data of the message reference.
+     */
+    public MessageReferenceImpl(JsonNode data) {
+        System.out.println(data);
+        messageId = data.hasNonNull("message_id") ? data.get("message_id").asLong() : null;
+        channelId = data.hasNonNull("channel_id") ? data.get("channel_id").asLong() : null;
+        serverId = data.hasNonNull("guild_id") ? data.get("guild_id").asLong() : null;
+    }
+
+    @Override
+    public Optional<Long> getMessageId() {
+        return Optional.ofNullable(messageId);
+    }
+
+    @Override
+    public Optional<Long> getChannelId() {
+        return Optional.ofNullable(channelId);
+    }
+
+    @Override
+    public Optional<Long> getServerId() {
+        return Optional.ofNullable(serverId);
+    }
+}


### PR DESCRIPTION
Fixes #744 
This also adds the message reference object, which is available when receiving cross-posted / announcement /pin / reply messages which contains some information about the message's origin