### PR TITLE
Fix global ratelimiter math and correct / update javadocs

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -126,8 +126,8 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
      *
      * <p>**Note:** This method returns an {@code Optional} for historic reasons.
      * If you did not provide a ratelimiter by yourself, this method will return a {@link LocalRatelimiter}
-     * which is set to {@code} request per {@code 111.1 ms}. This ratelimiter is shared by every bot with the same token
-     * in the same Java program.
+     * which is set to {@code 5} requests per {@code 112 ms}, resulting in about 45 requests per second.
+     * This ratelimiter is shared by every bot with the same token in the same Java program.
      *
      * @return The current global ratelimiter.
      */

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
@@ -79,8 +79,12 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
     /**
      * Sets a ratelimiter that can be used to control global ratelimits.
      *
-     * <p>By default, no ratelimiter is set, but for large bots or special use-cases, it can be useful to provide
-     * a ratelimiter with a hardcoded ratelimit to prevent hitting the global ratelimit.
+     * <p>If you don't provide a ratelimiter by yourself, Javacord will use a default ratelimiter
+     * which is set to {@code 5} requests per {@code 112 ms}, resulting in about 45 requests per second.
+     * The default ratelimiter will be shared by every bot with the same token in the same Java program.
+     *
+     * <p>If you provide a custom ratelimiter, you have to make sure to use the exact same ratelimiter instance
+     * with all Javacord instances, or otherwise synchronize the global ratelimit across shards.
      *
      * <p>An easy implementation is available with the {@link LocalRatelimiter}.
      *

--- a/javacord-api/src/main/java/org/javacord/api/util/ratelimit/LocalRatelimiter.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/ratelimit/LocalRatelimiter.java
@@ -18,19 +18,19 @@ import java.time.Duration;
  * </ul>
  * For the 50 requests / 1 second ratelimit, these rules allow the following ratelimits (only a subset):
  * <ul>
- * <li>About {@code 1} request per {@code 20.5 ms}
- *     ({@code amount = 1} and {@code bucketDuration = Duration.ofMillis((long) Math.ceil(1D / 49D))})
- * <li>About {@code 5} request per {@code 111.1 ms}
- *     ({@code amount = 5} and {@code bucketDuration = Duration.ofMillis((long) Math.ceil(5D / 45D))}).
+ * <li>About {@code 1} request per {@code 21 ms}
+ *     ({@code amount = 1} and {@code bucketDuration = Duration.ofMillis((long) Math.ceil(1000D / 49D))})
+ * <li>About {@code 5} request per {@code 112 ms}
+ *     ({@code amount = 5} and {@code bucketDuration = Duration.ofMillis((long) Math.ceil(5000D / 45D))}).
  * <li>{@code 10} request per {@code 250 ms}
- *     ({@code amount = 10} and {@code bucketDuration = Duration.ofMillis((long) Math.ceil(10D / 40D))}).
+ *     ({@code amount = 10} and {@code bucketDuration = Duration.ofMillis((long) Math.ceil(10000D / 40D))}).
  * <li>{@code 25} request per {@code 1 sec}
- *     ({@code amount = 25} and {@code bucketDuration = Duration.ofMillis((long) Math.ceil(10D / 40D))}).
+ *     ({@code amount = 25} and {@code bucketDuration = Duration.ofMillis((long) Math.ceil(25000D / 25D))}).
  * </ul>
  * Choosing a lower {@code amount} increases the maximum throughput but can limits your ability to perform actions
  * in bulk.
  *
- * @see <a href="https://javacord.org/r/local-ratelimiter">Related wiki article</a>
+ * @see <a href="https://javacord.org/wiki/advanced-topics/ratelimits.html">Related wiki article</a>
  * @see DiscordApiBuilder#setGlobalRatelimiter(Ratelimiter)
  */
 public class LocalRatelimiter implements Ratelimiter {
@@ -125,7 +125,7 @@ public class LocalRatelimiter implements Ratelimiter {
         }
 
         // Reset the limit when the last reset timestamp is past
-        if (System.nanoTime() > nextResetNanos) {
+        if (System.nanoTime() >= nextResetNanos) {
             remainingQuota = amount;
             try {
                 nextResetNanos = System.nanoTime() + bucketDuration.toNanos();

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -1374,7 +1374,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
         if (globalRatelimiter == null) {
             Ratelimiter ratelimiter = defaultGlobalRatelimiter.computeIfAbsent(
                     getToken(),
-                    (token) -> new LocalRatelimiter(5, Duration.ofMillis((long) Math.ceil(5D / 45D))));
+                    (token) -> new LocalRatelimiter(5, Duration.ofMillis(112L)));
             return Optional.of(ratelimiter);
         }
         return Optional.of(globalRatelimiter);


### PR DESCRIPTION
I've fixed the bad math of the default global ratelimiter as discussed on Discord.

I've replaced the recommended formula to calculate the bucket duration, because to be honest, the old one was just wrong or I did not understand it correctly. I'm open for discussion, but the one I suggested will work (see examples in this table).
![grafik](https://user-images.githubusercontent.com/23171488/116575385-e0bc3880-a90e-11eb-893d-9b7f7e2e2822.png)


Additionally, I updated and corrected a few documentation lines around the global ratelimiter. For example, a documentation in the builder said that Javacord will not use a global ratelimiter if none is set by the users, which is wrong (we have default global ratelimiters).