### PR TITLE
Interaction response

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Flag.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Flag.java
@@ -1,0 +1,55 @@
+package org.javacord.api.entity.message;
+
+/**
+ * Represents a message flag type.
+ */
+public enum Flag {
+
+    /**
+     * An ephemeral message (only visible for the user).
+     */
+    EPHEMERAL(64),
+
+    /**
+     * An unknown flag.
+     */
+    UNKNOWN(-1);
+
+    /**
+     * The id of the flag.
+     */
+    private final int id;
+
+    /**
+     * Creates a new message flag type.
+     *
+     * @param id The id of the type.
+     */
+    Flag(int id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the id of the message flag type.
+     *
+     * @return The id of the message flag type.
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Gets the message flag type by its id.
+     *
+     * @param id The id of the message flag type.
+     * @return The message flag type with the given id or {@link Flag#UNKNOWN} if unknown id.
+     */
+    public static Flag getFlagTypeById(int id) {
+        switch (id) {
+            case 64:
+                return EPHEMERAL;
+            default:
+                return UNKNOWN;
+        }
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/InteractionMessageBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/InteractionMessageBuilder.java
@@ -1,15 +1,12 @@
 package org.javacord.api.entity.message;
 
-import org.javacord.api.DiscordApi;
+import org.javacord.api.command.Interaction;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.Mentionable;
-import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
-import org.javacord.api.entity.message.internal.MessageBuilderDelegate;
+import org.javacord.api.entity.message.internal.InteractionMessageBuilderDelegate;
 import org.javacord.api.entity.message.mention.AllowedMentions;
-import org.javacord.api.entity.user.User;
-import org.javacord.api.entity.webhook.IncomingWebhook;
-import org.javacord.api.util.DiscordRegexPattern;
+import org.javacord.api.event.command.InteractionCreateEvent;
 import org.javacord.api.util.internal.DelegateFactory;
 
 import java.awt.image.BufferedImage;
@@ -17,36 +14,11 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
 
-/**
- * This class can help you to create messages.
- */
-public class MessageBuilder {
+public class InteractionMessageBuilder {
 
-    /**
-     * The message delegate used by this instance.
-     */
-    protected final MessageBuilderDelegate delegate = DelegateFactory.createMessageBuilderDelegate();
-
-    /**
-     * Creates a message builder from a message.
-     *
-     * @param message The message to copy.
-     * @return A message builder which would produce the same text as the given message.
-     */
-    public static MessageBuilder fromMessage(Message message) {
-        MessageBuilder builder = new MessageBuilder();
-        builder.getStringBuilder().append(message.getContent());
-        if (!message.getEmbeds().isEmpty()) {
-            builder.setEmbed(message.getEmbeds().get(0).toBuilder());
-        }
-        for (MessageAttachment attachment : message.getAttachments()) {
-            // Since spoiler status is encoded in the file name, it is copied automatically.
-            builder.addAttachment(attachment.getUrl());
-        }
-        return builder;
-    }
+    protected final InteractionMessageBuilderDelegate delegate =
+            DelegateFactory.createInteractionMessageBuilderDelegate();
 
     /**
      * Appends code to the message.
@@ -55,7 +27,7 @@ public class MessageBuilder {
      * @param code The code.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder appendCode(String language, String code) {
+    public InteractionMessageBuilder appendCode(String language, String code) {
         delegate.appendCode(language, code);
         return this;
     }
@@ -67,7 +39,7 @@ public class MessageBuilder {
      * @param decorations The decorations of the string.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder append(String message, MessageDecoration... decorations) {
+    public InteractionMessageBuilder append(String message, MessageDecoration... decorations) {
         delegate.append(message, decorations);
         return this;
     }
@@ -78,7 +50,7 @@ public class MessageBuilder {
      * @param entity The entity to mention.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder append(Mentionable entity) {
+    public InteractionMessageBuilder append(Mentionable entity) {
         delegate.append(entity);
         return this;
     }
@@ -90,7 +62,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see StringBuilder#append(Object)
      */
-    public MessageBuilder append(Object object) {
+    public InteractionMessageBuilder append(Object object) {
         delegate.append(object);
         return this;
     }
@@ -100,7 +72,7 @@ public class MessageBuilder {
      *
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder appendNewLine() {
+    public InteractionMessageBuilder appendNewLine() {
         delegate.appendNewLine();
         return this;
     }
@@ -113,20 +85,62 @@ public class MessageBuilder {
      * @param content The new content of the message.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder setContent(String content) {
+    public InteractionMessageBuilder setContent(String content) {
         delegate.setContent(content);
         return this;
     }
 
     /**
-     * Sets the embed of the message.
+     * Adds the embed to the message.
      *
-     * @param embed The embed to set.
+     * @param embed The embed to add.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder setEmbed(EmbedBuilder embed) {
-        delegate.removeAllEmbeds();
+    public InteractionMessageBuilder addEmbed(EmbedBuilder embed) {
         delegate.addEmbed(embed);
+        return this;
+    }
+
+    /**
+     * Adds the embeds to the message.
+     *
+     * @param embeds The embeds to add.
+     * @return The current instance in order to chain call methods.
+     */
+    public InteractionMessageBuilder addEmbeds(EmbedBuilder... embeds) {
+        delegate.addEmbeds(embeds);
+        return this;
+    }
+
+    /**
+     * Removes the embed from the message.
+     *
+     * @param embed The embed to remove.
+     * @return The current instance in order to chain call methods.
+     */
+    public InteractionMessageBuilder removeEmbed(EmbedBuilder embed) {
+        delegate.removeEmbed(embed);
+        return this;
+    }
+
+    /**
+     * Removes the embeds from the message.
+     *
+     * @param embeds The embeds to remove.
+     * @return The current instance in order to chain call methods.
+     */
+    public InteractionMessageBuilder removeEmbeds(EmbedBuilder... embeds) {
+        delegate.removeEmbeds(embeds);
+        return this;
+    }
+
+    /**
+     * Removes all embeds from the message.
+     *
+     * @return The current instance in order to chain call methods.
+     */
+    public InteractionMessageBuilder removeAllEmbeds() {
+        delegate.removeAllEmbeds();
         return this;
     }
 
@@ -136,7 +150,7 @@ public class MessageBuilder {
      * @param tts Whether the message should be text to speech or not.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder setTts(boolean tts) {
+    public InteractionMessageBuilder setTts(boolean tts) {
         delegate.setTts(tts);
         return this;
     }
@@ -149,7 +163,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachment(BufferedImage, String)
      */
-    public MessageBuilder addFile(BufferedImage image, String fileName) {
+    public InteractionMessageBuilder addFile(BufferedImage image, String fileName) {
         delegate.addFile(image, fileName);
         return this;
     }
@@ -161,7 +175,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachment(File)
      */
-    public MessageBuilder addFile(File file) {
+    public InteractionMessageBuilder addFile(File file) {
         delegate.addFile(file);
         return this;
     }
@@ -173,7 +187,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachment(Icon)
      */
-    public MessageBuilder addFile(Icon icon) {
+    public InteractionMessageBuilder addFile(Icon icon) {
         delegate.addFile(icon);
         return this;
     }
@@ -185,7 +199,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachment(URL)
      */
-    public MessageBuilder addFile(URL url) {
+    public InteractionMessageBuilder addFile(URL url) {
         delegate.addFile(url);
         return this;
     }
@@ -198,7 +212,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachment(byte[], String)
      */
-    public MessageBuilder addFile(byte[] bytes, String fileName) {
+    public InteractionMessageBuilder addFile(byte[] bytes, String fileName) {
         delegate.addFile(bytes, fileName);
         return this;
     }
@@ -211,7 +225,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachment(InputStream, String)
      */
-    public MessageBuilder addFile(InputStream stream, String fileName) {
+    public InteractionMessageBuilder addFile(InputStream stream, String fileName) {
         delegate.addFile(stream, fileName);
         return this;
     }
@@ -224,7 +238,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachmentAsSpoiler(BufferedImage, String)
      */
-    public MessageBuilder addFileAsSpoiler(BufferedImage image, String fileName) {
+    public InteractionMessageBuilder addFileAsSpoiler(BufferedImage image, String fileName) {
         delegate.addFile(image, "SPOILER_" + fileName);
         return this;
     }
@@ -236,7 +250,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachmentAsSpoiler(File)
      */
-    public MessageBuilder addFileAsSpoiler(File file) {
+    public InteractionMessageBuilder addFileAsSpoiler(File file) {
         delegate.addFileAsSpoiler(file);
         return this;
     }
@@ -248,7 +262,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachmentAsSpoiler(Icon)
      */
-    public MessageBuilder addFileAsSpoiler(Icon icon) {
+    public InteractionMessageBuilder addFileAsSpoiler(Icon icon) {
         delegate.addFileAsSpoiler(icon);
         return this;
     }
@@ -260,7 +274,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachment(URL)
      */
-    public MessageBuilder addFileAsSpoiler(URL url) {
+    public InteractionMessageBuilder addFileAsSpoiler(URL url) {
         delegate.addFileAsSpoiler(url);
         return this;
     }
@@ -273,7 +287,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachmentAsSpoiler(byte[], String)
      */
-    public MessageBuilder addFileAsSpoiler(byte[] bytes, String fileName) {
+    public InteractionMessageBuilder addFileAsSpoiler(byte[] bytes, String fileName) {
         delegate.addFile(bytes, "SPOILER_" + fileName);
         return this;
     }
@@ -286,7 +300,7 @@ public class MessageBuilder {
      * @return The current instance in order to chain call methods.
      * @see #addAttachment(InputStream, String)
      */
-    public MessageBuilder addFileAsSpoiler(InputStream stream, String fileName) {
+    public InteractionMessageBuilder addFileAsSpoiler(InputStream stream, String fileName) {
         delegate.addFile(stream, "SPOILER_" + fileName);
         return this;
     }
@@ -298,7 +312,7 @@ public class MessageBuilder {
      * @param fileName The file name of the image.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachment(BufferedImage image, String fileName) {
+    public InteractionMessageBuilder addAttachment(BufferedImage image, String fileName) {
         delegate.addAttachment(image, fileName);
         return this;
     }
@@ -309,7 +323,7 @@ public class MessageBuilder {
      * @param file The file to add as an attachment.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachment(File file) {
+    public InteractionMessageBuilder addAttachment(File file) {
         delegate.addAttachment(file);
         return this;
     }
@@ -320,7 +334,7 @@ public class MessageBuilder {
      * @param icon The icon to add as an attachment.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachment(Icon icon) {
+    public InteractionMessageBuilder addAttachment(Icon icon) {
         delegate.addAttachment(icon);
         return this;
     }
@@ -331,7 +345,7 @@ public class MessageBuilder {
      * @param url The url of the attachment.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachment(URL url) {
+    public InteractionMessageBuilder addAttachment(URL url) {
         delegate.addAttachment(url);
         return this;
     }
@@ -343,7 +357,7 @@ public class MessageBuilder {
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachment(byte[] bytes, String fileName) {
+    public InteractionMessageBuilder addAttachment(byte[] bytes, String fileName) {
         delegate.addAttachment(bytes, fileName);
         return this;
     }
@@ -355,7 +369,7 @@ public class MessageBuilder {
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachment(InputStream stream, String fileName) {
+    public InteractionMessageBuilder addAttachment(InputStream stream, String fileName) {
         delegate.addAttachment(stream, fileName);
         return this;
     }
@@ -367,7 +381,7 @@ public class MessageBuilder {
      * @param fileName The file name of the image.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachmentAsSpoiler(BufferedImage image, String fileName) {
+    public InteractionMessageBuilder addAttachmentAsSpoiler(BufferedImage image, String fileName) {
         delegate.addAttachment(image, "SPOILER_" + fileName);
         return this;
     }
@@ -378,7 +392,7 @@ public class MessageBuilder {
      * @param file The file to add as an attachment.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachmentAsSpoiler(File file) {
+    public InteractionMessageBuilder addAttachmentAsSpoiler(File file) {
         delegate.addAttachmentAsSpoiler(file);
         return this;
     }
@@ -389,7 +403,7 @@ public class MessageBuilder {
      * @param icon The icon to add as an attachment.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachmentAsSpoiler(Icon icon) {
+    public InteractionMessageBuilder addAttachmentAsSpoiler(Icon icon) {
         delegate.addAttachmentAsSpoiler(icon);
         return this;
     }
@@ -400,7 +414,7 @@ public class MessageBuilder {
      * @param url The url of the attachment.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachmentAsSpoiler(URL url) {
+    public InteractionMessageBuilder addAttachmentAsSpoiler(URL url) {
         delegate.addAttachmentAsSpoiler(url);
         return this;
     }
@@ -412,7 +426,7 @@ public class MessageBuilder {
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachmentAsSpoiler(byte[] bytes, String fileName) {
+    public InteractionMessageBuilder addAttachmentAsSpoiler(byte[] bytes, String fileName) {
         delegate.addAttachment(bytes, "SPOILER_" + fileName);
         return this;
     }
@@ -424,7 +438,7 @@ public class MessageBuilder {
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder addAttachmentAsSpoiler(InputStream stream, String fileName) {
+    public InteractionMessageBuilder addAttachmentAsSpoiler(InputStream stream, String fileName) {
         delegate.addAttachment(stream, "SPOILER_" + fileName);
         return this;
     }
@@ -435,41 +449,19 @@ public class MessageBuilder {
      * @param allowedMentions The mention object.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder setAllowedMentions(AllowedMentions allowedMentions) {
+    public InteractionMessageBuilder setAllowedMentions(AllowedMentions allowedMentions) {
         delegate.setAllowedMentions(allowedMentions);
         return this;
     }
 
     /**
-     * Sets the message to reply to.
+     * Sets the flag of the message.
      *
-     * @param message The the message to reply to.
+     * @param flag The flag enum type.
      * @return The current instance in order to chain call methods.
      */
-    public MessageBuilder replyTo(Message message) {
-        delegate.replyTo(message.getId());
-        return this;
-    }
-
-    /**
-     * Sets the message to reply to.
-     *
-     * @param messageId The id of the message to reply to.
-     * @return The current instance in order to chain call methods.
-     */
-    public MessageBuilder replyTo(long messageId) {
-        delegate.replyTo(messageId);
-        return this;
-    }
-
-    /**
-     * Sets the nonce of the message.
-     *
-     * @param nonce The nonce to set.
-     * @return The current instance in order to chain call methods.
-     */
-    public MessageBuilder setNonce(String nonce) {
-        delegate.setNonce(nonce);
+    public InteractionMessageBuilder setFlag(Flag flag) {
+        delegate.setFlag(flag);
         return this;
     }
 
@@ -483,87 +475,65 @@ public class MessageBuilder {
     }
 
     /**
-     * Sends the message.
+     * Sends the first response message.
+     * This can only be done once after you want to respond to an interaction the FIRST time.
+     * Responding directly to an interaction limits you to not being able to upload anything.
+     * Therefore i.e. {@link EmbedBuilder#setFooter(String, File)} will not work and you have to use the String methods
+     * for attachments like {@link EmbedBuilder#setFooter(String, String)} if available.
+     * If you want to upload attachments use {@link #editOriginalResponse(Interaction)} instead.
      *
-     * @param user The user to which the message should be sent.
-     * @return The sent message.
+     * @param interaction The interaction to send the response.
+     * @return The CompletableFuture when your message was sent.
      */
-    public CompletableFuture<Message> send(User user) {
-        return delegate.send(user);
+    public CompletableFuture<Void> sendInitialResponse(Interaction interaction) {
+        return delegate.sendInitialResponse(interaction);
     }
 
     /**
-     * Sends the message.
+     * Edits your original sent response.
+     * Your original response may be sent by {@link #sendInitialResponse(Interaction)}
+     * or by deciding to respond through {@link InteractionCreateEvent#respondLater()} which sends a "loading state"
+     * as your first response.
+     * In comparison to {@link #sendInitialResponse(Interaction)} this method allows you to upload attachments
+     * with your message.
      *
-     * @param channel The channel in which the message should be sent.
+     * @param interaction The interaction to send the response.
      * @return The sent message.
      */
-    public CompletableFuture<Message> send(TextChannel channel) {
-        return delegate.send(channel);
+    public CompletableFuture<Message> editOriginalResponse(Interaction interaction) {
+        return delegate.editOriginalResponse(interaction);
     }
 
     /**
-     * Sends the message.
+     * Sends a followup message to an interaction.
      *
-     * @param webhook The webhook from which the message should be sent.
+     * @param interaction The interaction to send the followup message to.
      * @return The sent message.
      */
-    public CompletableFuture<Message> send(IncomingWebhook webhook) {
-        return delegate.send(webhook);
+    public CompletableFuture<Message> sendFollowupMessage(Interaction interaction) {
+        return delegate.sendFollowupMessage(interaction);
     }
 
     /**
-     * Sends the message.
+     * Edits a followup message from an interaction.
      *
-     * @param messageable The receiver of the message.
-     * @return The sent message.
+     * @param interaction The interaction where the edited message belongs to.
+     * @param messageId The message id of the followup message which should be edited.
+     * @return The edited message.
      */
-    public CompletableFuture<Message> send(Messageable messageable) {
-        return delegate.send(messageable);
+    public CompletableFuture<Message> editFollowupMessage(Interaction interaction, long messageId) {
+        return editFollowupMessage(interaction, Long.toUnsignedString(messageId));
     }
 
     /**
-     * Sends the message.
+     * Edits a followup message from an interaction.
      *
-     * @param api The api instance needed to send and return the message.
-     * @param webhookId The id of the webhook from which the message should be sent.
-     * @param webhookToken The token of the webhook from which the message should be sent.
-     * @return The sent message.
+     * @param interaction The interaction where the edited message belongs to.
+     * @param messageId The message id of the followup message which should be edited.
+     * @return The edited message.
      */
-    public CompletableFuture<Message> sendWithWebhook(DiscordApi api, long webhookId, String webhookToken) {
-        return delegate.sendWithWebhook(api, Long.toUnsignedString(webhookId), webhookToken);
-    }
-
-    /**
-     * Sends the message.
-     *
-     * @param api The api instance needed to send and return the message.
-     * @param webhookId The id of the webhook from which the message should be sent.
-     * @param webhookToken The token of the webhook from which the message should be sent.
-     * @return The sent message.
-     */
-    public CompletableFuture<Message> sendWithWebhook(DiscordApi api, String webhookId, String webhookToken) {
-        return delegate.sendWithWebhook(api, webhookId, webhookToken);
-    }
-
-    /**
-     * Sends the message.
-     *
-     * @param api The api instance needed to send the message.
-     * @param webhookUrl The url of the webhook from which the message should be sent.
-     *
-     * @return The sent message.
-     * @throws IllegalArgumentException If the link isn't valid.
-     */
-    public CompletableFuture<Message> sendWithWebhook(DiscordApi api, String webhookUrl)
-                                                        throws IllegalArgumentException {
-        Matcher matcher = DiscordRegexPattern.WEBHOOK_URL.matcher(webhookUrl);
-
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException("The webhook url has an invalid format");
-        }
-
-        return sendWithWebhook(api, matcher.group("id"), matcher.group("token"));
+    public CompletableFuture<Message> editFollowupMessage(Interaction interaction, String messageId) {
+        return delegate.editFollowupMessage(interaction, messageId);
     }
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/InteractionMessageBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/InteractionMessageBuilder.java
@@ -13,6 +13,8 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
 
 public class InteractionMessageBuilder {
@@ -455,13 +457,24 @@ public class InteractionMessageBuilder {
     }
 
     /**
-     * Sets the flag of the message.
+     * Sets the message flags of the message.
      *
-     * @param flag The flag enum type.
+     * @param messageFlags The message flags enum type.
      * @return The current instance in order to chain call methods.
      */
-    public InteractionMessageBuilder setFlag(Flag flag) {
-        delegate.setFlag(flag);
+    public InteractionMessageBuilder setFlags(MessageFlag... messageFlags) {
+        setFlags(EnumSet.copyOf(Arrays.asList(messageFlags)));
+        return this;
+    }
+
+    /**
+     * Sets the message flags of the message.
+     *
+     * @param messageFlags An EnumSet of message flag enum type.
+     * @return The current instance in order to chain call methods.
+     */
+    public InteractionMessageBuilder setFlags(EnumSet<MessageFlag> messageFlags) {
+        delegate.setFlags(messageFlags);
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageFlag.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageFlag.java
@@ -3,7 +3,7 @@ package org.javacord.api.entity.message;
 /**
  * Represents a message flag type.
  */
-public enum Flag {
+public enum MessageFlag {
 
     /**
      * An ephemeral message (only visible for the user).
@@ -25,7 +25,7 @@ public enum Flag {
      *
      * @param id The id of the type.
      */
-    Flag(int id) {
+    MessageFlag(int id) {
         this.id = id;
     }
 
@@ -42,9 +42,9 @@ public enum Flag {
      * Gets the message flag type by its id.
      *
      * @param id The id of the message flag type.
-     * @return The message flag type with the given id or {@link Flag#UNKNOWN} if unknown id.
+     * @return The message flag type with the given id or {@link MessageFlag#UNKNOWN} if unknown id.
      */
-    public static Flag getFlagTypeById(int id) {
+    public static MessageFlag getFlagTypeById(int id) {
         switch (id) {
             case 64:
                 return EPHEMERAL;

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/WebhookMessageBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/WebhookMessageBuilder.java
@@ -564,7 +564,6 @@ public class WebhookMessageBuilder {
      * @param api The api instance needed to send and return the message.
      * @param webhookId The id of the webhook from which the message should be sent.
      * @param webhookToken The token of the webhook from which the message should be sent.
-     *
      * @return The sent message.
      */
     public CompletableFuture<Message> send(DiscordApi api, long webhookId, String webhookToken) {
@@ -577,7 +576,6 @@ public class WebhookMessageBuilder {
      * @param api The api instance needed to send and return the message.
      * @param webhookId The id of the webhook from which the message should be sent.
      * @param webhookToken The token of the webhook from which the message should be sent.
-     *
      * @return The sent message.
      */
     public CompletableFuture<Message> send(DiscordApi api, String webhookId, String webhookToken) {
@@ -589,7 +587,6 @@ public class WebhookMessageBuilder {
      *
      * @param api The api instance needed to send the message.
      * @param webhookUrl The url of the webhook from which the message should be sent.
-     *
      * @return The sent message.
      * @throws IllegalArgumentException If the link isn't valid.
      */
@@ -607,7 +604,6 @@ public class WebhookMessageBuilder {
      * Sends the message without waiting for a response.
      *
      * @param webhook The webhook from which the message should be sent.
-     *
      * @return A CompletableFuture indicating whether or not sending the request to discord was successful.
      */
     public CompletableFuture<Void> sendSilently(IncomingWebhook webhook) {
@@ -620,7 +616,6 @@ public class WebhookMessageBuilder {
      * @param api The api instance needed to send the message.
      * @param webhookId The id of the webhook from which the message should be sent.
      * @param webhookToken The token of the webhook from which the message should be sent.
-     *
      * @return A CompletableFuture indicating whether or not sending the request to discord was successful.
      */
     public CompletableFuture<Void> sendSilently(DiscordApi api, long webhookId, String webhookToken) {
@@ -633,7 +628,6 @@ public class WebhookMessageBuilder {
      * @param api The api instance needed to send the message.
      * @param webhookId The id of the webhook from which the message should be sent.
      * @param webhookToken The token of the webhook from which the message should be sent.
-     *
      * @return A CompletableFuture indicating whether or not sending the request to discord was successful.
      */
     public CompletableFuture<Void> sendSilently(DiscordApi api, String webhookId, String webhookToken) {
@@ -645,7 +639,6 @@ public class WebhookMessageBuilder {
      *
      * @param api The api instance needed to send the message.
      * @param webhookUrl The url of the webhook from which the message should be sent.
-     *
      * @return A CompletableFuture indicating whether or not sending the request to discord was successful.
      * @throws IllegalArgumentException If the link isn't valid.
      */

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/internal/InteractionMessageBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/internal/InteractionMessageBuilderDelegate.java
@@ -1,19 +1,20 @@
 package org.javacord.api.entity.message.internal;
 
 import org.javacord.api.command.Interaction;
-import org.javacord.api.entity.message.Flag;
 import org.javacord.api.entity.message.Message;
+import org.javacord.api.entity.message.MessageFlag;
 
+import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
 
 public interface InteractionMessageBuilderDelegate extends WebhookMessageBuilderBaseDelegate {
 
     /**
-     * Sets the flag of the message.
+     * Sets the message flags of the message.
      *
-     * @param flag The flag of the message.
+     * @param messageFlags The message flag of the message.
      */
-    void setFlag(Flag flag);
+    void setFlags(EnumSet<MessageFlag> messageFlags);
 
     /**
      * Sends the message.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/internal/InteractionMessageBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/internal/InteractionMessageBuilderDelegate.java
@@ -1,0 +1,51 @@
+package org.javacord.api.entity.message.internal;
+
+import org.javacord.api.command.Interaction;
+import org.javacord.api.entity.message.Flag;
+import org.javacord.api.entity.message.Message;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface InteractionMessageBuilderDelegate extends WebhookMessageBuilderBaseDelegate {
+
+    /**
+     * Sets the flag of the message.
+     *
+     * @param flag The flag of the message.
+     */
+    void setFlag(Flag flag);
+
+    /**
+     * Sends the message.
+     *
+     * @param interaction The interaction where the message should be sent to.
+     * @return The completable future when the message has been sent.
+     */
+    CompletableFuture<Void> sendInitialResponse(Interaction interaction);
+
+    /**
+     * Edits the message.
+     *
+     * @param interaction The interaction where the message should be sent to.
+     * @return The sent message.
+     */
+    CompletableFuture<Message> editOriginalResponse(Interaction interaction);
+
+    /**
+     * Sends the message as a followup message.
+     *
+     * @param interaction The interaction where the message should be sent to.
+     * @return The sent message.
+     */
+    CompletableFuture<Message> sendFollowupMessage(Interaction interaction);
+
+    /**
+     * Edits the message.
+     *
+     * @param interaction The interaction where the message should be sent to.
+     * @param messageId The message id of the followup message which should be edited.
+     * @return The sent message.
+     */
+    CompletableFuture<Message> editFollowupMessage(Interaction interaction, String messageId);
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/internal/WebhookMessageBuilderBaseDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/internal/WebhookMessageBuilderBaseDelegate.java
@@ -1,0 +1,43 @@
+package org.javacord.api.entity.message.internal;
+
+import org.javacord.api.entity.message.embed.EmbedBuilder;
+
+/**
+ * You usually don't want to interact with this object.
+ */
+public interface WebhookMessageBuilderBaseDelegate extends MessageBuilderDelegate {
+
+    /**
+     * Adds the embed to the message.
+     *
+     * @param embed The embed to add.
+     */
+    void addEmbed(EmbedBuilder embed);
+
+    /**
+     * Adds the embeds to the message.
+     *
+     * @param embeds The embeds to add.
+     */
+    void addEmbeds(EmbedBuilder... embeds);
+
+    /**
+     * Removes the embed from the message.
+     *
+     * @param embed The embed to remove.
+     */
+    void removeEmbed(EmbedBuilder embed);
+
+    /**
+     * Removes the embeds from the message.
+     *
+     * @param embeds The embeds to remove.
+     */
+    void removeEmbeds(EmbedBuilder... embeds);
+
+    /**
+     * Removes all embeds from the message.
+     */
+    void removeAllEmbeds();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/internal/WebhookMessageBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/internal/WebhookMessageBuilderDelegate.java
@@ -5,7 +5,6 @@ import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.MessageAuthor;
 import org.javacord.api.entity.message.WebhookMessageBuilder;
-import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.webhook.IncomingWebhook;
 
@@ -16,40 +15,7 @@ import java.util.concurrent.CompletableFuture;
  * This class is internally used by the {@link WebhookMessageBuilder} to create messages.
  * You usually don't want to interact with this object.
  */
-public interface WebhookMessageBuilderDelegate extends MessageBuilderDelegate {
-
-    /**
-     * Adds the embed to the message.
-     *
-     * @param embed The embed to add.
-     */
-    void addEmbed(EmbedBuilder embed);
-
-    /**
-     * Adds the embeds to the message.
-     *
-     * @param embeds The embeds to add.
-     */
-    void addEmbeds(EmbedBuilder... embeds);
-
-    /**
-     * Removes the embed from the message.
-     *
-     * @param embed The embed to remove.
-     */
-    void removeEmbed(EmbedBuilder embed);
-
-    /**
-     * Removes the embeds from the message.
-     *
-     * @param embeds The embeds to remove.
-     */
-    void removeEmbeds(EmbedBuilder... embeds);
-
-    /**
-     * Removes all embeds from the message.
-     */
-    void removeAllEmbeds();
+public interface WebhookMessageBuilderDelegate extends WebhookMessageBuilderBaseDelegate {
 
     /**
      * Sets the display name of the webhook.

--- a/javacord-api/src/main/java/org/javacord/api/event/command/InteractionCreateEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/command/InteractionCreateEvent.java
@@ -1,7 +1,10 @@
 package org.javacord.api.event.command;
 
 import org.javacord.api.command.Interaction;
+import org.javacord.api.entity.message.InteractionMessageBuilder;
 import org.javacord.api.event.Event;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * An interaction create event.
@@ -14,4 +17,27 @@ public interface InteractionCreateEvent extends Event {
      * @return The interaction.
      */
     Interaction getInteraction();
+
+    /**
+     * Send a response to a slash command. Must be executed withing 3 seconds or the token will be invalidated.
+     * If it may take longer to respond, use {@link #respondLater()}.
+     *
+     * @return The InteractionMessageBuilder to respond to the interaction.
+     */
+    InteractionMessageBuilder respond();
+
+    /**
+     * Send a "loading state" as your first response. You can edit and send followup messages withing 15 minutes.
+     *
+     * @return A Completable future when the "loading state" response has been sent.
+     */
+    CompletableFuture<Void> respondLater();
+
+    /**
+     * Deletes the initial response.
+     *
+     * @return The completable future when the message has been deleted.
+     */
+    CompletableFuture<Void> deleteInitialResponse();
+
 }

--- a/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactory.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactory.java
@@ -20,6 +20,7 @@ import org.javacord.api.entity.emoji.KnownCustomEmoji;
 import org.javacord.api.entity.emoji.internal.CustomEmojiBuilderDelegate;
 import org.javacord.api.entity.emoji.internal.CustomEmojiUpdaterDelegate;
 import org.javacord.api.entity.message.embed.internal.EmbedBuilderDelegate;
+import org.javacord.api.entity.message.internal.InteractionMessageBuilderDelegate;
 import org.javacord.api.entity.message.internal.MessageBuilderDelegate;
 import org.javacord.api.entity.message.internal.WebhookMessageBuilderDelegate;
 import org.javacord.api.entity.message.mention.internal.AllowedMentionsBuilderDelegate;
@@ -119,6 +120,15 @@ public class DelegateFactory {
      */
     public static MessageBuilderDelegate createMessageBuilderDelegate() {
         return delegateFactoryDelegate.createMessageBuilderDelegate();
+    }
+
+    /**
+     * Creates a new webhook message builder delegate.
+     *
+     * @return A new webhook message builder delegate.
+     */
+    public static InteractionMessageBuilderDelegate createInteractionMessageBuilderDelegate() {
+        return delegateFactoryDelegate.createInteractionMessageBuilderDelegate();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactoryDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactoryDelegate.java
@@ -20,6 +20,7 @@ import org.javacord.api.entity.emoji.KnownCustomEmoji;
 import org.javacord.api.entity.emoji.internal.CustomEmojiBuilderDelegate;
 import org.javacord.api.entity.emoji.internal.CustomEmojiUpdaterDelegate;
 import org.javacord.api.entity.message.embed.internal.EmbedBuilderDelegate;
+import org.javacord.api.entity.message.internal.InteractionMessageBuilderDelegate;
 import org.javacord.api.entity.message.internal.MessageBuilderDelegate;
 import org.javacord.api.entity.message.internal.WebhookMessageBuilderDelegate;
 import org.javacord.api.entity.message.mention.internal.AllowedMentionsBuilderDelegate;
@@ -73,6 +74,13 @@ public interface DelegateFactoryDelegate {
      * @return A new message builder delegate.
      */
     MessageBuilderDelegate createMessageBuilderDelegate();
+
+    /**
+     * Creates a new interaction message builder delegate.
+     *
+     * @return A new interaction message builder delegate.
+     */
+    InteractionMessageBuilderDelegate createInteractionMessageBuilderDelegate();
 
     /**
      * Creates a new webhook message builder delegate.

--- a/javacord-core/src/main/java/org/javacord/core/command/InteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/command/InteractionImpl.java
@@ -62,7 +62,7 @@ public class InteractionImpl implements Interaction {
             );
             user = (UserImpl) member.getUser();
         } else if (jsonData.hasNonNull("user")) {
-            user = new UserImpl(api, jsonData.get("user"), (JsonNode) null, null);
+            user = new UserImpl(api, jsonData.get("user"), (MemberImpl) null, null);
             member = null;
         } else {
             user = null;

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionCallbackType.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionCallbackType.java
@@ -1,0 +1,79 @@
+package org.javacord.core.entity.message;
+
+/**
+ * Represents an interaction callback type.
+ */
+public enum InteractionCallbackType {
+
+    /**
+     * ACK a Ping.
+     */
+    PONG(1),
+    /**
+     * Respond to an interaction with a message.
+     */
+    ChannelMessageWithSource(4),
+    /**
+     * ACK an interaction and edit a response later, the user sees a loading state.
+     */
+    DeferredChannelMessageWithSource(5),
+    /**
+     * For components, ACK an interaction and edit the original message later; the user does not see a loading state.
+     */
+    DeferredUpdateMessage(6),
+    /**
+     * For components, edit the message the component was attached to.
+     */
+    UpdateMessage(7),
+
+    /**
+     * An unknown interaction callback type.
+     */
+    UNKNOWN(-1);
+
+    /**
+     * The id of the interaction callback type.
+     */
+    private final int id;
+
+    /**
+     * Creates a new interaction callback type.
+     *
+     * @param id The id of the interaction callback type.
+     */
+    InteractionCallbackType(int id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the id of the interaction callback type.
+     *
+     * @return The id of the interaction callback type.
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Gets the interaction callback type by its id.
+     *
+     * @param id The id of the interaction callback type.
+     * @return The interaction callback type with the given id or {@link InteractionCallbackType#UNKNOWN} if unknown id.
+     */
+    public static InteractionCallbackType getInteractionCallbackTypeById(int id) {
+        switch (id) {
+            case 1:
+                return PONG;
+            case 4:
+                return ChannelMessageWithSource;
+            case 5:
+                return DeferredChannelMessageWithSource;
+            case 6:
+                return DeferredUpdateMessage;
+            case 7:
+                return UpdateMessage;
+            default:
+                return UNKNOWN;
+        }
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionMessageBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionMessageBuilderDelegateImpl.java
@@ -1,0 +1,130 @@
+package org.javacord.core.entity.message;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.command.Interaction;
+import org.javacord.api.entity.message.Flag;
+import org.javacord.api.entity.message.Message;
+import org.javacord.api.entity.message.internal.InteractionMessageBuilderDelegate;
+import org.javacord.core.entity.message.embed.EmbedBuilderDelegateImpl;
+import org.javacord.core.util.FileContainer;
+import org.javacord.core.util.rest.RestEndpoint;
+import org.javacord.core.util.rest.RestMethod;
+import org.javacord.core.util.rest.RestRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+
+public class InteractionMessageBuilderDelegateImpl extends WebhookMessageBuilderBaseDelegateImpl
+        implements InteractionMessageBuilderDelegate {
+
+    /**
+     * The flag of the message.
+     */
+    private Flag flag = null;
+
+    @Override
+    public void setFlag(Flag flag) {
+        this.flag = flag;
+    }
+
+    @Override
+    public CompletableFuture<Void> sendInitialResponse(Interaction interaction) {
+        ObjectNode topBody = JsonNodeFactory.instance.objectNode();
+        topBody.put("type", 4);
+        ObjectNode body = topBody.putObject("data");
+        prepareInteractionWebhookBodyParts(body);
+
+        return new RestRequest<Void>(interaction.getApi(),
+                RestMethod.POST, RestEndpoint.INTERACTION_RESPONSE)
+                .setUrlParameters(interaction.getIdAsString(), interaction.getToken())
+                .setBody(topBody)
+                .execute(result -> null);
+    }
+
+    @Override
+    public CompletableFuture<Message> editOriginalResponse(Interaction interaction) {
+        RestRequest<Message> request = new RestRequest<Message>(interaction.getApi(),
+                RestMethod.PATCH, RestEndpoint.ORIGINAL_INTERACTION_RESPONSE)
+                .setUrlParameters(Long.toUnsignedString(interaction.getApplicationId()), interaction.getToken());
+
+        return executeResponse(request);
+    }
+
+    @Override
+    public CompletableFuture<Message> sendFollowupMessage(Interaction interaction) {
+        RestRequest<Message> request = new RestRequest<Message>(interaction.getApi(),
+                RestMethod.POST, RestEndpoint.WEBHOOK_SEND)
+                .setUrlParameters(Long.toUnsignedString(interaction.getApplicationId()), interaction.getToken());
+
+        return executeResponse(request);
+    }
+
+    @Override
+    public CompletableFuture<Message> editFollowupMessage(Interaction interaction, String messageId) {
+        RestRequest<Message> request = new RestRequest<Message>(interaction.getApi(), RestMethod.POST,
+                RestEndpoint.WEBHOOK_MESSAGE)
+                .setUrlParameters(Long.toUnsignedString(interaction.getApplicationId()),
+                        interaction.getToken(), messageId);
+
+        return executeResponse(request);
+    }
+
+    private CompletableFuture<Message> executeResponse(RestRequest<Message> request) {
+        ObjectNode body = JsonNodeFactory.instance.objectNode();
+        prepareInteractionWebhookBodyParts(body);
+
+        return checkForAttachmentsAndExecuteRequest(request, body);
+    }
+
+    private void prepareInteractionWebhookBodyParts(ObjectNode body) {
+        prepareCommonWebhookMessageBodyParts(body);
+        if (null != flag) {
+            body.put("flags", flag.getId());
+        }
+    }
+
+    private CompletableFuture<Message> checkForAttachmentsAndExecuteRequest(RestRequest<Message> request,
+                                                                            ObjectNode body) {
+        if (!attachments.isEmpty() || (embeds.size() > 0 && embeds.get(0).requiresAttachments())) {
+            CompletableFuture<Message> future = new CompletableFuture<>();
+            // We access files etc. so this should be async
+            request.getApi().getThreadPool().getExecutorService().submit(() -> {
+                try {
+                    List<FileContainer> tempAttachments = new ArrayList<>(attachments);
+                    // Add the attachments required for the embed
+                    if (embeds.size() > 0) {
+                        tempAttachments.addAll(
+                                ((EmbedBuilderDelegateImpl) embeds.get(0).getDelegate()).getRequiredAttachments());
+                    }
+
+                    addMultipartBodyToRequest(request, body, tempAttachments, request.getApi());
+
+                    request.execute(result -> request.getApi().getOrCreateMessage(
+                            request.getApi().getTextChannelById(result.getJsonBody().get("channel_id").asLong())
+                                    .orElseThrow(() -> new NoSuchElementException("Textchannel is not cached")),
+                            result.getJsonBody()))
+                            .whenComplete((message, throwable) -> {
+                                if (throwable != null) {
+                                    future.completeExceptionally(throwable);
+                                } else {
+                                    future.complete(message);
+                                }
+                            });
+                } catch (Throwable t) {
+                    future.completeExceptionally(t);
+                }
+            });
+            return future;
+        } else {
+            request.setBody(body);
+            return request.execute(result -> request.getApi().getOrCreateMessage(
+                    request.getApi().getTextChannelById(result.getJsonBody().get("channel_id").asLong())
+                            .orElseThrow(() -> new NoSuchElementException("Textchannel is not cached")),
+                    result.getJsonBody()));
+        }
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionMessageBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionMessageBuilderDelegateImpl.java
@@ -3,8 +3,8 @@ package org.javacord.core.entity.message;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.command.Interaction;
-import org.javacord.api.entity.message.Flag;
 import org.javacord.api.entity.message.Message;
+import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.entity.message.internal.InteractionMessageBuilderDelegate;
 import org.javacord.core.entity.message.embed.EmbedBuilderDelegateImpl;
 import org.javacord.core.util.FileContainer;
@@ -13,6 +13,7 @@ import org.javacord.core.util.rest.RestMethod;
 import org.javacord.core.util.rest.RestRequest;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
@@ -21,19 +22,19 @@ public class InteractionMessageBuilderDelegateImpl extends WebhookMessageBuilder
         implements InteractionMessageBuilderDelegate {
 
     /**
-     * The flag of the message.
+     * The message flags of the message.
      */
-    private Flag flag = null;
+    private EnumSet<MessageFlag> messageFlags = null;
 
     @Override
-    public void setFlag(Flag flag) {
-        this.flag = flag;
+    public void setFlags(EnumSet<MessageFlag> messageFlags) {
+        this.messageFlags = messageFlags;
     }
 
     @Override
     public CompletableFuture<Void> sendInitialResponse(Interaction interaction) {
         ObjectNode topBody = JsonNodeFactory.instance.objectNode();
-        topBody.put("type", 4);
+        topBody.put("type", InteractionCallbackType.ChannelMessageWithSource.getId());
         ObjectNode body = topBody.putObject("data");
         prepareInteractionWebhookBodyParts(body);
 
@@ -81,8 +82,8 @@ public class InteractionMessageBuilderDelegateImpl extends WebhookMessageBuilder
 
     private void prepareInteractionWebhookBodyParts(ObjectNode body) {
         prepareCommonWebhookMessageBodyParts(body);
-        if (null != flag) {
-            body.put("flags", flag.getId());
+        if (null != messageFlags) {
+            body.put("flags", messageFlags.stream().mapToInt(MessageFlag::getId).sum());
         }
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/WebhookMessageBuilderBaseDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/WebhookMessageBuilderBaseDelegateImpl.java
@@ -1,0 +1,36 @@
+package org.javacord.core.entity.message;
+
+import org.apache.logging.log4j.Logger;
+import org.javacord.api.entity.message.embed.EmbedBuilder;
+import org.javacord.api.entity.message.internal.WebhookMessageBuilderBaseDelegate;
+import org.javacord.core.util.logging.LoggerUtil;
+
+import java.util.Arrays;
+
+/**
+ * The implementation of {@link WebhookMessageBuilderBaseDelegate}.
+ */
+public class WebhookMessageBuilderBaseDelegateImpl extends MessageBuilderDelegateImpl
+        implements WebhookMessageBuilderBaseDelegate {
+
+    /**
+     * The logger of this class.
+     */
+    private static final Logger logger = LoggerUtil.getLogger(WebhookMessageBuilderBaseDelegateImpl.class);
+
+    @Override
+    public void addEmbeds(EmbedBuilder... embeds) {
+        this.embeds.addAll(Arrays.asList(embeds));
+    }
+
+    @Override
+    public void removeEmbed(EmbedBuilder embed) {
+        this.embeds.remove(embed);
+    }
+
+    @Override
+    public void removeEmbeds(EmbedBuilder... embeds) {
+        this.embeds.removeAll(Arrays.asList(embeds));
+    }
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/WebhookMessageBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/WebhookMessageBuilderDelegateImpl.java
@@ -4,19 +4,18 @@ import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.message.Message;
-import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.message.internal.WebhookMessageBuilderDelegate;
 import org.javacord.api.entity.webhook.IncomingWebhook;
 import org.javacord.core.util.logging.LoggerUtil;
+
 import java.net.URL;
-import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * The implementation of {@link WebhookMessageBuilderDelegate}.
  */
-public class WebhookMessageBuilderDelegateImpl
-        extends MessageBuilderDelegateImpl implements WebhookMessageBuilderDelegate {
+public class WebhookMessageBuilderDelegateImpl extends WebhookMessageBuilderBaseDelegateImpl
+        implements WebhookMessageBuilderDelegate {
 
     /**
      * The logger of this class.
@@ -32,21 +31,6 @@ public class WebhookMessageBuilderDelegateImpl
      * The display name the webhook should use.
      */
     private String displayName = null;
-
-    @Override
-    public void addEmbeds(EmbedBuilder... embeds) {
-        this.embeds.addAll(Arrays.asList(embeds));
-    }
-
-    @Override
-    public void removeEmbed(EmbedBuilder embed) {
-        this.embeds.remove(embed);
-    }
-
-    @Override
-    public void removeEmbeds(EmbedBuilder... embeds) {
-        this.embeds.removeAll(Arrays.asList(embeds));
-    }
 
     @Override
     public void setDisplayName(String displayName) {

--- a/javacord-core/src/main/java/org/javacord/core/event/command/InteractionCreateEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/command/InteractionCreateEventImpl.java
@@ -3,6 +3,7 @@ package org.javacord.core.event.command;
 import org.javacord.api.command.Interaction;
 import org.javacord.api.entity.message.InteractionMessageBuilder;
 import org.javacord.api.event.command.InteractionCreateEvent;
+import org.javacord.core.entity.message.InteractionCallbackType;
 import org.javacord.core.event.EventImpl;
 import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
@@ -15,7 +16,8 @@ import java.util.concurrent.CompletableFuture;
  */
 public class InteractionCreateEventImpl extends EventImpl implements InteractionCreateEvent {
 
-    private static final String RESPOND_LATER_BODY = "{\"type\": 5}";
+    private static final String RESPOND_LATER_BODY =
+            "{\"type\": " + InteractionCallbackType.DeferredChannelMessageWithSource.getId() + "}";
 
     private final Interaction interaction;
 

--- a/javacord-core/src/main/java/org/javacord/core/event/command/InteractionCreateEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/command/InteractionCreateEventImpl.java
@@ -1,13 +1,21 @@
 package org.javacord.core.event.command;
 
 import org.javacord.api.command.Interaction;
+import org.javacord.api.entity.message.InteractionMessageBuilder;
 import org.javacord.api.event.command.InteractionCreateEvent;
 import org.javacord.core.event.EventImpl;
+import org.javacord.core.util.rest.RestEndpoint;
+import org.javacord.core.util.rest.RestMethod;
+import org.javacord.core.util.rest.RestRequest;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The implementation of {@link InteractionCreateEventImpl}.
  */
 public class InteractionCreateEventImpl extends EventImpl implements InteractionCreateEvent {
+
+    private static final String RESPOND_LATER_BODY = "{\"type\": 5}";
 
     private final Interaction interaction;
 
@@ -25,5 +33,25 @@ public class InteractionCreateEventImpl extends EventImpl implements Interaction
     public Interaction getInteraction() {
         return interaction;
     }
-}
 
+    @Override
+    public InteractionMessageBuilder respond() {
+        return new InteractionMessageBuilder();
+    }
+
+    @Override
+    public CompletableFuture<Void> respondLater() {
+        return new RestRequest<Void>(this.api, RestMethod.POST, RestEndpoint.INTERACTION_RESPONSE)
+                .setUrlParameters(interaction.getIdAsString(), interaction.getToken())
+                .setBody(RESPOND_LATER_BODY)
+                .execute(result -> null);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteInitialResponse() {
+        return new RestRequest<Void>(interaction.getApi(),
+                RestMethod.DELETE, RestEndpoint.ORIGINAL_INTERACTION_RESPONSE)
+                .setUrlParameters(Long.toUnsignedString(interaction.getApplicationId()), interaction.getToken())
+                .execute(result -> null);
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/DelegateFactoryDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/DelegateFactoryDelegateImpl.java
@@ -20,6 +20,7 @@ import org.javacord.api.entity.emoji.KnownCustomEmoji;
 import org.javacord.api.entity.emoji.internal.CustomEmojiBuilderDelegate;
 import org.javacord.api.entity.emoji.internal.CustomEmojiUpdaterDelegate;
 import org.javacord.api.entity.message.embed.internal.EmbedBuilderDelegate;
+import org.javacord.api.entity.message.internal.InteractionMessageBuilderDelegate;
 import org.javacord.api.entity.message.internal.MessageBuilderDelegate;
 import org.javacord.api.entity.message.internal.WebhookMessageBuilderDelegate;
 import org.javacord.api.entity.message.mention.internal.AllowedMentionsBuilderDelegate;
@@ -56,6 +57,7 @@ import org.javacord.core.entity.channel.ServerVoiceChannelBuilderDelegateImpl;
 import org.javacord.core.entity.channel.ServerVoiceChannelUpdaterDelegateImpl;
 import org.javacord.core.entity.emoji.CustomEmojiBuilderDelegateImpl;
 import org.javacord.core.entity.emoji.CustomEmojiUpdaterDelegateImpl;
+import org.javacord.core.entity.message.InteractionMessageBuilderDelegateImpl;
 import org.javacord.core.entity.message.MessageBuilderDelegateImpl;
 import org.javacord.core.entity.message.WebhookMessageBuilderDelegateImpl;
 import org.javacord.core.entity.message.embed.EmbedBuilderDelegateImpl;
@@ -95,6 +97,11 @@ public class DelegateFactoryDelegateImpl implements DelegateFactoryDelegate {
     @Override
     public MessageBuilderDelegate createMessageBuilderDelegate() {
         return new MessageBuilderDelegateImpl();
+    }
+
+    @Override
+    public InteractionMessageBuilderDelegate createInteractionMessageBuilderDelegate() {
+        return new InteractionMessageBuilderDelegateImpl();
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
@@ -40,12 +40,14 @@ public enum RestEndpoint {
     SERVER_INVITE("/guilds/%s/invites", 0),
     WEBHOOK("/webhooks/%s", 0),
     WEBHOOK_SEND("/webhooks/%s/%s", 0),
+    WEBHOOK_MESSAGE("/webhooks/%s/%s/messages/%s",0),
     INVITE("/invites/%s"),
     BAN("/guilds/%s/bans", 0),
     CURRENT_USER("/users/@me"),
     AUDIT_LOG("/guilds/%s/audit-logs", 0),
     CUSTOM_EMOJI("/guilds/%s/emojis", 0),
     INTERACTION_RESPONSE("/interactions/%s/%s/callback", 0),
+    ORIGINAL_INTERACTION_RESPONSE("/webhooks/%s/%s/messages/@original",0),
     APPLICATION_COMMANDS("/applications/%s/commands", 0),
     GUILD_APPLICATION_COMMANDS("/applications/%s/guilds/%s/commands", 1);
 


### PR DESCRIPTION
This implements the ability to respond to interactions.
Also fixed a hard coded limit for webhook embeds in the message builder.

Internal PR implementations:
* [x] Responding to an interaction
* [x]  Followup messages

Issue implementations:
* [x] Respond to application commands

Usage example:
The most basic response to receiving an interaction is by simply sending your initial response.
```java
api.addInteractionCreateListener(event -> {
    //Both are the same
    event.respond().setContent("Initial Response").sendInitialResponse(event.getInteraction());
    new InteractionMessageBuilder().setContent("Initial Response").sendInitialResponse(event.getInteraction());
    //Delete your initial response
    event.deleteInitialResponse();
});
```
You can also hide your response from other user with setting the EPHEMERAL flag for the message
```java
api.addInteractionCreateListener(event -> {
    event.respond().setContent("Initial Response").setFlag(Flag.EPHEMERAL).sendInitialResponse(event.getInteraction());
});
```
It's also possible to respond to an interaction later but for a maximum of 15 minutes after the first time you have answered to an interaction with your first response or through #respondLater()
```java
api.addInteractionCreateListener(event -> {
    event.respondLater().thenAccept(unused -> {
        //Edit your original response. In this case you edit the "loading state" response
        new InteractionMessageBuilder().setContent("Deferred Response").editOriginalResponse(event.getInteraction());
        //
        //... 5minutes later
        //
        new InteractionMessageBuilder().setContent("Followup Message").sendFollowupMessage(event.getInteraction()).thenAccept(message -> {
            new InteractionMessageBuilder().setContent("Edited followup message").editFollowupMessage(event.getInteraction(), message.getId());
        });
    });
});
```
