### PR TITLE
Change precision on retry_after and fix to NPE when API banned

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/ratelimit/RatelimitManager.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/ratelimit/RatelimitManager.java
@@ -182,8 +182,9 @@ public class RatelimitManager {
 
         // Check if we received a 429 response
         if (result.getResponse().code() == 429) {
-            int retryAfter =
-                    result.getJsonBody().isNull() ? 0 : result.getJsonBody().get("retry_after").asInt();
+            long retryAfter =
+                    result.getJsonBody().isNull()
+                            ? 0 : (long) (result.getJsonBody().get("retry_after").asDouble() * 1000);
 
             if (global) {
                 // We hit a global ratelimit. Time to panic!


### PR DESCRIPTION
Uses millisecond precision for the `retry_after` JSON value.
Attempts to detect Cloudflare API ban responses by checking for the missing `Via` header.

I've had a couple of larger bots testing the `retry_after` change for a while with success, but I'm not able to get myself cloudflare banned so I'm unable to test that.

Fixes #752 