### PR TITLE
Add get server application commands

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -108,6 +108,23 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
     CompletableFuture<ApplicationCommand> getGlobalApplicationCommandById(long commandId);
 
     /**
+     * Gets a list with all application commands for the given server.
+     *
+     * @param server The server to get the application commands from.
+     * @return A list with all application commands from the server.
+     */
+    CompletableFuture<List<ApplicationCommand>> getServerApplicationCommands(Server server);
+
+    /**
+     * Gets a server application command by its id.
+     *
+     * @param server The server to get the application commands from.
+     * @param commandId The id of the server application command.
+     * @return The server application command with the given id.
+     */
+    CompletableFuture<ApplicationCommand> getServerApplicationCommandById(Server server,long commandId);
+
+    /**
      * Gets a utility class to interact with uncached messages.
      *
      * @return A utility class to interact with uncached messages.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -30,6 +30,7 @@ import org.javacord.api.entity.server.invite.RichInvite;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.webhook.IncomingWebhook;
 import org.javacord.api.entity.webhook.Webhook;
+import org.javacord.api.interaction.ApplicationCommand;
 import org.javacord.api.listener.server.ServerAttachableListenerManager;
 
 import java.awt.Color;
@@ -2106,6 +2107,21 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
                         .filter(emoji -> emoji.getName().equalsIgnoreCase(name))
                         .collect(Collectors.toList()));
     }
+
+    /**
+     * Gets a list with all application commands for the given server.
+     *
+     * @return A list with all application commands from the server.
+     */
+    CompletableFuture<List<ApplicationCommand>> getApplicationCommands();
+
+    /**
+     * Gets a server application command by its id.
+     *
+     * @param commandId The id of the server application command.
+     * @return The server application command with the given id.
+     */
+    CompletableFuture<ApplicationCommand> getApplicationCommandById(long commandId);
 
     /**
      * Creates a new channel category builder.

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -1328,21 +1328,37 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     @Override
     public CompletableFuture<List<ApplicationCommand>> getGlobalApplicationCommands() {
         return new RestRequest<List<ApplicationCommand>>(this, RestMethod.GET, RestEndpoint.APPLICATION_COMMANDS)
-            .setUrlParameters(String.valueOf(clientId))
-            .execute(result -> {
-                List<ApplicationCommand> applicationCommands = new ArrayList<>();
-                for (JsonNode applicationCommandJson : result.getJsonBody()) {
-                    applicationCommands.add(new ApplicationCommandImpl(this, applicationCommandJson));
-                }
-                return Collections.unmodifiableList(applicationCommands);
-            });
+                .setUrlParameters(String.valueOf(clientId))
+                .execute(result -> jsonToApplicationCommandList(result.getJsonBody()));
     }
 
     @Override
     public CompletableFuture<ApplicationCommand> getGlobalApplicationCommandById(long commandId) {
         return new RestRequest<ApplicationCommand>(this, RestMethod.GET, RestEndpoint.APPLICATION_COMMANDS)
-            .setUrlParameters(String.valueOf(clientId), String.valueOf(commandId))
-            .execute(result -> new ApplicationCommandImpl(this, result.getJsonBody()));
+                .setUrlParameters(String.valueOf(clientId), String.valueOf(commandId))
+                .execute(result -> new ApplicationCommandImpl(this, result.getJsonBody()));
+    }
+
+    @Override
+    public CompletableFuture<List<ApplicationCommand>> getServerApplicationCommands(Server server) {
+        return new RestRequest<List<ApplicationCommand>>(this, RestMethod.GET, RestEndpoint.SERVER_APPLICATION_COMMANDS)
+                .setUrlParameters(String.valueOf(clientId), server.getIdAsString())
+                .execute(result -> jsonToApplicationCommandList(result.getJsonBody()));
+    }
+
+    @Override
+    public CompletableFuture<ApplicationCommand> getServerApplicationCommandById(Server server, long commandId) {
+        return new RestRequest<ApplicationCommand>(this, RestMethod.GET, RestEndpoint.SERVER_APPLICATION_COMMANDS)
+                .setUrlParameters(String.valueOf(clientId), server.getIdAsString(), String.valueOf(commandId))
+                .execute(result -> new ApplicationCommandImpl(this, result.getJsonBody()));
+    }
+
+    private List<ApplicationCommand> jsonToApplicationCommandList(JsonNode resultJson) {
+        List<ApplicationCommand> applicationCommands = new ArrayList<>();
+        for (JsonNode applicationCommandJson : resultJson) {
+            applicationCommands.add(new ApplicationCommandImpl(this, applicationCommandJson));
+        }
+        return Collections.unmodifiableList(applicationCommands);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -39,6 +39,7 @@ import org.javacord.api.entity.user.UserStatus;
 import org.javacord.api.entity.webhook.IncomingWebhook;
 import org.javacord.api.entity.webhook.Webhook;
 import org.javacord.api.entity.webhook.WebhookType;
+import org.javacord.api.interaction.ApplicationCommand;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.audio.AudioConnectionImpl;
 import org.javacord.core.entity.IconImpl;
@@ -1509,6 +1510,16 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     @Override
     public Collection<KnownCustomEmoji> getCustomEmojis() {
         return Collections.unmodifiableCollection(new ArrayList<>(customEmojis));
+    }
+
+    @Override
+    public CompletableFuture<List<ApplicationCommand>> getApplicationCommands() {
+        return api.getServerApplicationCommands(this);
+    }
+
+    @Override
+    public CompletableFuture<ApplicationCommand> getApplicationCommandById(long commandId) {
+        return api.getServerApplicationCommandById(this, commandId);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandBuilderDelegateImpl.java
@@ -58,7 +58,7 @@ public class ApplicationCommandBuilderDelegateImpl implements ApplicationCommand
     @Override
     public CompletableFuture<ApplicationCommand> createForServer(Server server) {
         return new RestRequest<ApplicationCommand>(
-            server.getApi(), RestMethod.POST, RestEndpoint.GUILD_APPLICATION_COMMANDS)
+            server.getApi(), RestMethod.POST, RestEndpoint.SERVER_APPLICATION_COMMANDS)
             .setUrlParameters(String.valueOf(server.getApi().getClientId()), server.getIdAsString())
             .setBody(getJsonBodyForApplicationCommand())
             .execute(result -> new ApplicationCommandImpl((DiscordApiImpl) server.getApi(), result.getJsonBody()));

--- a/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
@@ -49,7 +49,7 @@ public enum RestEndpoint {
     INTERACTION_RESPONSE("/interactions/%s/%s/callback", 0),
     ORIGINAL_INTERACTION_RESPONSE("/webhooks/%s/%s/messages/@original",0),
     APPLICATION_COMMANDS("/applications/%s/commands", 0),
-    GUILD_APPLICATION_COMMANDS("/applications/%s/guilds/%s/commands", 1);
+    SERVER_APPLICATION_COMMANDS("/applications/%s/guilds/%s/commands",1);
 
     /**
      * The endpoint url (only including the base, not the https://discord.com/api/vXYZ/ "prefix".


### PR DESCRIPTION
# Example usage
Printing all global and a servers application command:
```java
api.getGlobalApplicationCommands().thenAccept(applicationCommands -> applicationCommands.forEach(applicationCommand -> System.out.println(applicationCommand.getName())));
api.getServerApplicationCommands(SERVER).thenAccept(applicationCommands -> applicationCommands.forEach(applicationCommand -> System.out.println(applicationCommand.getName())));
```
Get a specific application command from a server
```java
api.getServerApplicationCommandById(server, APPLICATION_COMMAND_ID).thenAccept(applicationCommand -> System.out.println(applicationCommand.getName());
```