### PR TITLE
Add methods to update application commands

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
@@ -48,4 +48,14 @@ public interface ApplicationCommand extends DiscordEntity {
      * @return A future to check if the deletion was successful.
      */
     CompletableFuture<Void> delete();
+
+    /**
+     * Creates an application command updater from this ApplicationCommand instance.
+     *
+     * @return The application command updater for this ApplicationCommand instance.
+     */
+    default ApplicationCommandUpdater createApplicationCommandUpdater() {
+        return new ApplicationCommandUpdater(this.getId());
+    }
+
 }

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
@@ -1,0 +1,94 @@
+package org.javacord.api.interaction;
+
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.interaction.internal.ApplicationCommandUpdaterDelegate;
+import org.javacord.api.util.internal.DelegateFactory;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class ApplicationCommandUpdater {
+
+    /**
+     * The account delegate used by this instance.
+     */
+    private final ApplicationCommandUpdaterDelegate delegate;
+
+    /**
+     * Creates a new application command updater.
+     *
+     * @param commandId The application command id which should be updated.
+     */
+    public ApplicationCommandUpdater(long commandId) {
+        delegate = DelegateFactory.createApplicationCommandUpdaterDelegate(commandId);
+    }
+
+    /**
+     * Sets the new name of the application command.
+     *
+     * @param name The name to set.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandUpdater setName(String name) {
+        delegate.setName(name);
+        return this;
+    }
+
+    /**
+     * Sets the new description of the application command.
+     *
+     * @param description The description to set.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandUpdater setDescription(String description) {
+        delegate.setDescription(description);
+        return this;
+    }
+
+    /**
+     * Sets the new application command options.
+     *
+     * @param applicationCommandOptions The application command options to set.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandUpdater setApplicationCommandOptions(
+            List<ApplicationCommandOption> applicationCommandOptions) {
+        delegate.setOptions(applicationCommandOptions);
+        return this;
+    }
+
+    /**
+     * Sets the new application command default permission. When set to `false` no one will be able to use this command
+     * until you overwrite it.
+     * Disallowing the usage of this command includes absolutely every user even Administrators, Server owners
+     * and in direct messages.
+     *
+     * @param defaultPermission The default permission to set.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandUpdater setDefaultPermission(boolean defaultPermission) {
+        delegate.setDefaultPermission(defaultPermission);
+        return this;
+    }
+
+    /**
+     * Updates a global application command.
+     *
+     * @param api The DiscordApi instance.
+     * @return The updated Application command.
+     */
+    public CompletableFuture<ApplicationCommand> updateGlobal(DiscordApi api) {
+        return delegate.updateGlobal(api);
+    }
+
+    /**
+     * Updates an application command on the given server.
+     *
+     * @param server The server where the command should be updated.
+     * @return The updated Application command.
+     */
+    public CompletableFuture<ApplicationCommand> updateForServer(Server server) {
+        return delegate.updateForServer(server);
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandUpdaterDelegate.java
@@ -1,0 +1,56 @@
+package org.javacord.api.interaction.internal;
+
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.interaction.ApplicationCommand;
+import org.javacord.api.interaction.ApplicationCommandOption;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public interface ApplicationCommandUpdaterDelegate {
+
+    /**
+     * Sets the new name of the application command.
+     *
+     * @param name The name to set.
+     */
+    void setName(String name);
+
+    /**
+     * Sets the new description of the application command.
+     *
+     * @param description The description to set.
+     */
+    void setDescription(String description);
+
+    /**
+     * Sets the new application command options.
+     *
+     * @param applicationCommandOptions The application command options to set.
+     */
+    void setOptions(List<ApplicationCommandOption> applicationCommandOptions);
+
+    /**
+     * Sets the new application command default permission.
+     *
+     * @param defaultPermission The default permission to set.
+     */
+    void setDefaultPermission(boolean defaultPermission);
+
+    /**
+     * Performs the queued update.
+     *
+     * @param api The DiscordApi.
+     * @return A future with the updated application command to check if the update was successful.
+     */
+    CompletableFuture<ApplicationCommand> updateGlobal(DiscordApi api);
+
+    /**
+     * Performs the queued update.
+     *
+     * @param server The server where the command should be updated.
+     * @return A future with the updated application command to check if the update was successful.
+     */
+    CompletableFuture<ApplicationCommand> updateForServer(Server server);
+}

--- a/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactory.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactory.java
@@ -38,6 +38,7 @@ import org.javacord.api.entity.webhook.internal.WebhookUpdaterDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionChoiceBuilderDelegate;
+import org.javacord.api.interaction.internal.ApplicationCommandUpdaterDelegate;
 import org.javacord.api.internal.AccountUpdaterDelegate;
 import org.javacord.api.internal.DiscordApiBuilderDelegate;
 import org.javacord.api.util.exception.DiscordExceptionValidator;
@@ -267,6 +268,16 @@ public class DelegateFactory {
      */
     public static AccountUpdaterDelegate createAccountUpdaterDelegate(DiscordApi api) {
         return delegateFactoryDelegate.createAccountUpdaterDelegate(api);
+    }
+
+    /**
+     * Creates a new application command updater delegate.
+     *
+     * @param commandId The application command id.
+     * @return A new application command updater delegate.
+     */
+    public static ApplicationCommandUpdaterDelegate createApplicationCommandUpdaterDelegate(long commandId) {
+        return delegateFactoryDelegate.createApplicationCommandUpdaterDelegate(commandId);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactoryDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactoryDelegate.java
@@ -38,6 +38,7 @@ import org.javacord.api.entity.webhook.internal.WebhookUpdaterDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionChoiceBuilderDelegate;
+import org.javacord.api.interaction.internal.ApplicationCommandUpdaterDelegate;
 import org.javacord.api.internal.AccountUpdaterDelegate;
 import org.javacord.api.internal.DiscordApiBuilderDelegate;
 import org.javacord.api.util.exception.DiscordExceptionValidator;
@@ -177,6 +178,14 @@ public interface DelegateFactoryDelegate {
      * @return A new account updater delegate.
      */
     AccountUpdaterDelegate createAccountUpdaterDelegate(DiscordApi api);
+
+    /**
+     * Creates a new application command updater delegate.
+     *
+     * @param commandId The application command id.
+     * @return A new application command updater delegate.
+     */
+    ApplicationCommandUpdaterDelegate createApplicationCommandUpdaterDelegate(long commandId);
 
     /**
      * Creates a new group channel updater delegate.

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandOptionBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandOptionBuilderDelegateImpl.java
@@ -24,7 +24,7 @@ public class ApplicationCommandOptionBuilderDelegateImpl implements ApplicationC
 
     @Override
     public void setName(String name) {
-        this.name = name;
+        this.name = name.toLowerCase();
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandUpdaterDelegateImpl.java
@@ -1,0 +1,121 @@
+package org.javacord.core.interaction;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.interaction.ApplicationCommand;
+import org.javacord.api.interaction.ApplicationCommandOption;
+import org.javacord.api.interaction.internal.ApplicationCommandUpdaterDelegate;
+import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.util.rest.RestEndpoint;
+import org.javacord.core.util.rest.RestMethod;
+import org.javacord.core.util.rest.RestRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The implementation of {@link ApplicationCommandUpdaterDelegate}.
+ */
+public class ApplicationCommandUpdaterDelegateImpl implements ApplicationCommandUpdaterDelegate {
+
+    /**
+     * The application command id.
+     */
+    private final long commandId;
+
+    /**
+     * The application command name.
+     */
+    private String name = null;
+
+    /**
+     * The application command description.
+     */
+    private String description = null;
+
+    /**
+     * The application command options.
+     */
+    private List<ApplicationCommandOption> applicationCommandOptions = new ArrayList<>();
+
+    /**
+     * The application command default permission.
+     */
+    private boolean defaultPermission = true;
+
+    /**
+     * Creates a new account updater delegate.
+     *
+     * @param commandId The discord api instance.
+     */
+    public ApplicationCommandUpdaterDelegateImpl(long commandId) {
+        this.commandId = commandId;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public void setOptions(List<ApplicationCommandOption> applicationCommandOptions) {
+        this.applicationCommandOptions = applicationCommandOptions;
+    }
+
+    @Override
+    public void setDefaultPermission(boolean defaultPermission) {
+        this.defaultPermission = defaultPermission;
+    }
+
+    private void prepareBody(ObjectNode body) {
+        if (name != null && !name.isEmpty()) {
+            body.put("name", name);
+        }
+
+        if (description != null && !description.isEmpty()) {
+            body.put("description", description);
+        }
+
+        if (!applicationCommandOptions.isEmpty()) {
+            ArrayNode array = body.putArray("options");
+            for (ApplicationCommandOption applicationCommandOption : applicationCommandOptions) {
+                array.add(((ApplicationCommandOptionImpl) applicationCommandOption).toJsonNode());
+            }
+        }
+
+        body.put("default_permission", defaultPermission);
+    }
+
+    @Override
+    public CompletableFuture<ApplicationCommand> updateGlobal(DiscordApi api) {
+        ObjectNode body = JsonNodeFactory.instance.objectNode();
+        prepareBody(body);
+
+        return new RestRequest<ApplicationCommand>(api, RestMethod.PATCH, RestEndpoint.APPLICATION_COMMANDS)
+                .setUrlParameters(String.valueOf(api.getClientId()), String.valueOf(commandId))
+                .setBody(body)
+                .execute(result -> new ApplicationCommandImpl((DiscordApiImpl) api, result.getJsonBody()));
+    }
+
+    @Override
+    public CompletableFuture<ApplicationCommand> updateForServer(Server server) {
+        ObjectNode body = JsonNodeFactory.instance.objectNode();
+        prepareBody(body);
+
+        return new RestRequest<ApplicationCommand>(server.getApi(), RestMethod.PATCH,
+                RestEndpoint.SERVER_APPLICATION_COMMANDS)
+                .setUrlParameters(String.valueOf(server.getApi().getClientId()),
+                        server.getIdAsString(), String.valueOf(commandId))
+                .setBody(body)
+                .execute(result -> new ApplicationCommandImpl((DiscordApiImpl) server.getApi(), result.getJsonBody()));
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/DelegateFactoryDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/DelegateFactoryDelegateImpl.java
@@ -38,6 +38,7 @@ import org.javacord.api.entity.webhook.internal.WebhookUpdaterDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionChoiceBuilderDelegate;
+import org.javacord.api.interaction.internal.ApplicationCommandUpdaterDelegate;
 import org.javacord.api.internal.AccountUpdaterDelegate;
 import org.javacord.api.internal.DiscordApiBuilderDelegate;
 import org.javacord.api.util.exception.DiscordExceptionValidator;
@@ -75,6 +76,7 @@ import org.javacord.core.entity.webhook.WebhookUpdaterDelegateImpl;
 import org.javacord.core.interaction.ApplicationCommandBuilderDelegateImpl;
 import org.javacord.core.interaction.ApplicationCommandOptionBuilderDelegateImpl;
 import org.javacord.core.interaction.ApplicationCommandOptionChoiceBuilderDelegateImpl;
+import org.javacord.core.interaction.ApplicationCommandUpdaterDelegateImpl;
 import org.javacord.core.util.exception.DiscordExceptionValidatorImpl;
 import org.javacord.core.util.logging.ExceptionLoggerDelegateImpl;
 
@@ -166,6 +168,11 @@ public class DelegateFactoryDelegateImpl implements DelegateFactoryDelegate {
     @Override
     public AccountUpdaterDelegate createAccountUpdaterDelegate(DiscordApi api) {
         return new AccountUpdaterDelegateImpl(((DiscordApiImpl) api));
+    }
+
+    @Override
+    public ApplicationCommandUpdaterDelegate createApplicationCommandUpdaterDelegate(long commandId) {
+        return new ApplicationCommandUpdaterDelegateImpl(commandId);
     }
 
     @Override


### PR DESCRIPTION
# Example usage
Given is an application command `/say [text]` with a String argument called text.
To update the argument name from an application command on a sever:
```java
ApplicationCommandOption option = new ApplicationCommandOptionBuilder().setName("new_text")
                .setRequired(true).setType(ApplicationCommandOptionType.STRING).build();

new ApplicationCommandUpdater(APPLICATION_COMMAND_ID)
                .setApplicationCommandOptions(Collections.singletonList(option)).updateForServer(server);
```
Other ways to create an ApplicationCommandUpdater:
```java
ApplicationCommand.createApplicationCommandUpdater(APPLICATION_COMMAND).setName("xy").update(DISCORD_API);
ApplicationCommand.createApplicationCommandUpdater(APPLICATION_COMMAND_ID).setName("xy").update(DISCORD_API);
```