### PR TITLE
Add bulk overwrite methods to update and/or create multiple application commands at once

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -30,6 +30,8 @@ import org.javacord.api.entity.user.UserStatus;
 import org.javacord.api.entity.webhook.IncomingWebhook;
 import org.javacord.api.entity.webhook.Webhook;
 import org.javacord.api.interaction.ApplicationCommand;
+import org.javacord.api.interaction.ApplicationCommandBuilder;
+import org.javacord.api.interaction.ApplicationCommandUpdater;
 import org.javacord.api.listener.GloballyAttachableListenerManager;
 import org.javacord.api.util.DiscordRegexPattern;
 import org.javacord.api.util.concurrent.ThreadPool;
@@ -123,6 +125,33 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
      * @return The server application command with the given id.
      */
     CompletableFuture<ApplicationCommand> getServerApplicationCommandById(Server server,long commandId);
+
+    /**
+     * Bulk overwrites the global Application Commands.
+     * This should be preferably used when updating and/or creating multiple
+     * application commands at once instead of {@link ApplicationCommandUpdater#updateGlobal(DiscordApi)} (DiscordApi)}
+     * and {@link ApplicationCommandBuilder#createGlobal(DiscordApi)}
+     *
+     * @param applicationCommandBuilderList A list containing the ApplicationCommandBuilders
+     *     which should should be used to perform the bulk overwrite.
+     * @return A list containing all Application Commands.
+     */
+    CompletableFuture<List<ApplicationCommand>> bulkOverwriteGlobalApplicationCommands(
+            List<ApplicationCommandBuilder> applicationCommandBuilderList);
+
+    /**
+     * Bulk overwrites the servers Application Commands.
+     * This should be preferably used when updating and/or creating multiple
+     * application commands at once instead of {@link ApplicationCommandUpdater#updateForServer(Server)} (Server)}
+     * and {@link ApplicationCommandBuilder#createForServer(Server)}
+     *
+     * @param applicationCommandBuilderList A list containing the ApplicationCommandBuilders.
+     * @param server The server where the bulk overwrite should be performed on
+     *     which should should be used to perform the bulk overwrite.
+     * @return A list containing all Application Commands.
+     */
+    CompletableFuture<List<ApplicationCommand>> bulkOverwriteServerApplicationCommands(
+            List<ApplicationCommandBuilder> applicationCommandBuilderList, Server server);
 
     /**
      * Gets a utility class to interact with uncached messages.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
@@ -56,7 +56,7 @@ public interface ApplicationCommand extends DiscordEntity {
     /**
      * Create a new application command builder with the given name and description.
      * Call {@link ApplicationCommandBuilder#createForServer(Server)} or
-     *     {@link ApplicationCommandBuilder#createGlobal(DiscordApi)} on the returned builder to submit to Discord.
+     * {@link ApplicationCommandBuilder#createGlobal(DiscordApi)} on the returned builder to submit to Discord.
      *
      * @param name The name of the new application command.
      * @param description The description of the new application command.
@@ -71,7 +71,7 @@ public interface ApplicationCommand extends DiscordEntity {
     /**
      * Create a new application command builder with the given name, description and options.
      * Call {@link ApplicationCommandBuilder#createForServer(Server)} or
-     *     {@link ApplicationCommandBuilder#createGlobal(DiscordApi)} on the returned builder to submit to Discord.
+     * {@link ApplicationCommandBuilder#createGlobal(DiscordApi)} on the returned builder to submit to Discord.
      *
      * @param name The name of the new application command.
      * @param description The description of the new application command.
@@ -87,7 +87,7 @@ public interface ApplicationCommand extends DiscordEntity {
     /**
      * Create a new application command builder with the given name, description and options.
      * Call {@link ApplicationCommandBuilder#createForServer(Server)} or
-     *     {@link ApplicationCommandBuilder#createGlobal(DiscordApi)} on the returned builder to submit to Discord.
+     * {@link ApplicationCommandBuilder#createGlobal(DiscordApi)} on the returned builder to submit to Discord.
      *
      * @param name The name of the new application command.
      * @param description The description of the new application command.
@@ -96,6 +96,19 @@ public interface ApplicationCommand extends DiscordEntity {
      */
     static ApplicationCommandBuilder with(String name, String description, List<ApplicationCommandOption> options) {
         return with(name, description).setOptions(options);
+    }
+
+    /**
+     * Create a new prefilled application command builder from the given application command.
+     * Call {@link ApplicationCommandBuilder#createForServer(Server)} or
+     * {@link ApplicationCommandBuilder#createGlobal(DiscordApi)} on the returned builder to submit to Discord.
+     *
+     * @param applicationCommand The application command which the application command builder should be prefilled with.
+     * @return The new prefilled application command builder.
+     */
+    static ApplicationCommandBuilder createPrefilledApplicationCommandBuilder(ApplicationCommand applicationCommand) {
+        return with(applicationCommand.getName(), applicationCommand.getDescription())
+                .setOptions(applicationCommand.getOptions());
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandBuilder.java
@@ -67,6 +67,8 @@ public class ApplicationCommandBuilder {
 
     /**
      * Creates a global application command.
+     * When used to update multiple global application commands at once
+     * {@link DiscordApi#bulkOverwriteGlobalApplicationCommands(List)} should be used instead.
      *
      * @param api The discord api instance.
      * @return The built application command.
@@ -77,11 +79,22 @@ public class ApplicationCommandBuilder {
 
     /**
      * Creates an application command for a specific server.
+     * When used to create multiple server application commands at once
+     * {@link DiscordApi#bulkOverwriteServerApplicationCommands(List, Server)} (List)} should be used instead.
      *
      * @param server The server.
      * @return The built application command.
      */
     public CompletableFuture<ApplicationCommand> createForServer(Server server) {
         return delegate.createForServer(server);
+    }
+
+    /**
+     * Gets the delegate used by the application command builder internally.
+     *
+     * @return The delegate used by this application command builder internally.
+     */
+    public ApplicationCommandBuilderDelegate getDelegate() {
+        return delegate;
     }
 }

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
@@ -74,6 +74,8 @@ public class ApplicationCommandUpdater {
 
     /**
      * Updates a global application command.
+     * When used to update multiple global application commands at once
+     * {@link DiscordApi#bulkOverwriteGlobalApplicationCommands(List)} should be used instead.
      *
      * @param api The DiscordApi instance.
      * @return The updated Application command.
@@ -84,6 +86,8 @@ public class ApplicationCommandUpdater {
 
     /**
      * Updates an application command on the given server.
+     * When used to update multiple server application commands at once
+     * {@link DiscordApi#bulkOverwriteServerApplicationCommands(List, Server)} (List)} should be used instead.
      *
      * @param server The server where the command should be updated.
      * @return The updated Application command.

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandBuilderDelegateImpl.java
@@ -64,7 +64,12 @@ public class ApplicationCommandBuilderDelegateImpl implements ApplicationCommand
             .execute(result -> new ApplicationCommandImpl((DiscordApiImpl) server.getApi(), result.getJsonBody()));
     }
 
-    private ObjectNode getJsonBodyForApplicationCommand() {
+    /**
+     * Gets the JSON body for this application command.
+
+     * @return The JSON of this application command.
+     */
+    public ObjectNode getJsonBodyForApplicationCommand() {
         ObjectNode jsonBody = JsonNodeFactory.instance.objectNode()
                 .put("name", name)
                 .put("description", description);


### PR DESCRIPTION
# Example usage:
```java
ApplicationCommand applicationCommand1 = ...
ApplicationCommand applicationCommand2 = ...

List<ApplicationCommandBuilder> builders = List.of(
ApplicationCommand.createPrefilledApplicationCommandBuilder(applicationCommand1), 
ApplicationCommand.createPrefilledApplicationCommandBuilder(applicationCommand2));

api.bulkOverwriteGlobalApplicationCommands(builders);
```