### PR TITLE
Incoming webhooks token fix

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/TextChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/TextChannel.java
@@ -841,7 +841,15 @@ public interface TextChannel extends Channel, Messageable, TextChannelAttachable
     CompletableFuture<List<Webhook>> getWebhooks();
 
     /**
-     * Gets a list of all incoming webhooks in this channel.
+     * Gets a list of all incoming webhooks in this channel, they are not guaranteed to have an accessible token.
+     *
+     * @return A list of all incoming webhooks in this channel.
+     */
+    CompletableFuture<List<Webhook>> getAllIncomingWebhooks();
+
+    /**
+     * Gets a list of incoming webhooks in this channel.
+     * This method only returns webhooks with a token, that the bot can access.
      *
      * @return A list of all incoming webhooks in this channel.
      */

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2013,7 +2013,15 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     CompletableFuture<List<Webhook>> getWebhooks();
 
     /**
-     * Gets a list of all incoming webhooks in this server.
+     * Gets a list of all incoming webhooks in this server, they are not guaranteed to have an accessible token.
+     *
+     * @return A list of all incoming webhooks in this server.
+     */
+    CompletableFuture<List<Webhook>> getAllIncomingWebhooks();
+
+    /**
+     * Gets a list of incoming webhooks in this server.
+     * This method only returns webhooks with a token, that the bot can access.
      *
      * @return A list of all incoming webhooks in this server.
      */

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/InternalTextChannel.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/InternalTextChannel.java
@@ -187,17 +187,17 @@ public interface InternalTextChannel extends TextChannel, InternalTextChannelAtt
     }
 
     @Override
+    default CompletableFuture<List<Webhook>> getAllIncomingWebhooks() {
+        return new RestRequest<List<Webhook>>(getApi(), RestMethod.GET, RestEndpoint.CHANNEL_WEBHOOK)
+                .setUrlParameters(getIdAsString())
+                .execute(result -> WebhookImpl.createAllIncomingWebhooksFromJsonArray(getApi(), result.getJsonBody()));
+    }
+
+    @Override
     default CompletableFuture<List<IncomingWebhook>> getIncomingWebhooks() {
         return new RestRequest<List<IncomingWebhook>>(getApi(), RestMethod.GET, RestEndpoint.CHANNEL_WEBHOOK)
                 .setUrlParameters(getIdAsString())
-                .execute(result -> {
-                    List<IncomingWebhook> webhooks = new ArrayList<>();
-                    for (JsonNode webhookJson : result.getJsonBody()) {
-                        if (webhookJson.get("type").asText().equals("1")) {
-                            webhooks.add(new IncomingWebhookImpl(getApi(), webhookJson));
-                        }
-                    }
-                    return Collections.unmodifiableList(webhooks);
-                });
+                .execute(result ->
+                        IncomingWebhookImpl.createIncomingWebhooksFromJsonArray(getApi(), result.getJsonBody()));
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -39,7 +39,6 @@ import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.user.UserStatus;
 import org.javacord.api.entity.webhook.IncomingWebhook;
 import org.javacord.api.entity.webhook.Webhook;
-import org.javacord.api.entity.webhook.WebhookType;
 import org.javacord.api.interaction.SlashCommand;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.audio.AudioConnectionImpl;
@@ -1462,18 +1461,18 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     }
 
     @Override
+    public CompletableFuture<List<Webhook>> getAllIncomingWebhooks() {
+        return new RestRequest<List<Webhook>>(getApi(), RestMethod.GET, RestEndpoint.SERVER_WEBHOOK)
+                .setUrlParameters(getIdAsString())
+                .execute(result -> WebhookImpl.createAllIncomingWebhooksFromJsonArray(getApi(), result.getJsonBody()));
+    }
+
+    @Override
     public CompletableFuture<List<IncomingWebhook>> getIncomingWebhooks() {
         return new RestRequest<List<IncomingWebhook>>(getApi(), RestMethod.GET, RestEndpoint.SERVER_WEBHOOK)
                 .setUrlParameters(getIdAsString())
-                .execute(result -> {
-                    List<IncomingWebhook> webhooks = new ArrayList<>();
-                    for (JsonNode webhookJson : result.getJsonBody()) {
-                        if (WebhookType.fromValue(webhookJson.get("type").asInt()) == WebhookType.INCOMING) {
-                            webhooks.add(new IncomingWebhookImpl(getApi(), webhookJson));
-                        }
-                    }
-                    return Collections.unmodifiableList(webhooks);
-                });
+                .execute(result ->
+                        IncomingWebhookImpl.createIncomingWebhooksFromJsonArray(getApi(), result.getJsonBody()));
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/webhook/IncomingWebhookImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/webhook/IncomingWebhookImpl.java
@@ -8,6 +8,9 @@ import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
 import org.javacord.core.util.rest.RestRequest;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -29,24 +32,28 @@ public class IncomingWebhookImpl extends WebhookImpl implements IncomingWebhook 
         token = data.get("token").asText();
     }
 
+    /**
+     * Gets the incoming webhooks with a token from a json array.
+     *
+     * @param api The discord api instance.
+     * @param jsonArray The json array of the webhooks.
+     * @return A list of all the incoming webhooks from the array.
+     */
+    public static List<IncomingWebhook> createIncomingWebhooksFromJsonArray(DiscordApi api, JsonNode jsonArray) {
+        List<IncomingWebhook> webhooks = new ArrayList<>();
+        for (JsonNode webhookJson : jsonArray) {
+            if (WebhookType.fromValue(webhookJson.get("type").asInt()) == WebhookType.INCOMING
+                    && webhookJson.hasNonNull("token")) { // check if it has a token to create IncomingWebhook
+                webhooks.add(new IncomingWebhookImpl(api, webhookJson));
+            }
+        }
+        return Collections.unmodifiableList(webhooks);
+    }
+
     @Override
     public Optional<IncomingWebhook> asIncomingWebhook() {
+        // important, as this is only possible with incoming webhooks with token
         return Optional.of(this);
-    }
-
-    @Override
-    public WebhookType getType() {
-        return WebhookType.INCOMING;
-    }
-
-    @Override
-    public boolean isIncomingWebhook() {
-        return true;
-    }
-
-    @Override
-    public boolean isChannelFollowerWebhook() {
-        return false;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/webhook/WebhookImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/webhook/WebhookImpl.java
@@ -25,6 +25,9 @@ import org.javacord.core.util.rest.RestRequest;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -76,11 +79,28 @@ public class WebhookImpl implements Webhook, Specializable<WebhookImpl>, Interna
      * @return The new webhook.
      */
     public static WebhookImpl createWebhook(DiscordApi api, JsonNode data) {
-        if (WebhookType.fromValue(data.get("type").asInt()) == WebhookType.INCOMING) {
+        if (data.hasNonNull("token")) {
             return new IncomingWebhookImpl(api, data);
         } else {
             return new WebhookImpl(api, data);
         }
+    }
+
+    /**
+     * Gets all the incoming webhooks that may or may not have a token from a json array.
+     *
+     * @param api The discord api instance.
+     * @param jsonArray The json array of the webhooks.
+     * @return A list of all the incoming webhooks from the array.
+     */
+    public static List<Webhook> createAllIncomingWebhooksFromJsonArray(DiscordApi api, JsonNode jsonArray) {
+        List<Webhook> webhooks = new ArrayList<>();
+        for (JsonNode webhookJson : jsonArray) {
+            if (WebhookType.fromValue(webhookJson.get("type").asInt()) == WebhookType.INCOMING) {
+                webhooks.add(createWebhook(api, webhookJson));
+            }
+        }
+        return Collections.unmodifiableList(webhooks);
     }
 
     @Override
@@ -120,7 +140,8 @@ public class WebhookImpl implements Webhook, Specializable<WebhookImpl>, Interna
 
     @Override
     public Optional<IncomingWebhook> asIncomingWebhook() {
-        return isIncomingWebhook() ? Optional.of((IncomingWebhookImpl) this) : Optional.empty();
+        // this gets overridden in IncomingWebhookImpl to make it work
+        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
Not every incoming webhook comes with a token. IncomingWebhooks without a token are useless. So I think we should just ignore them. https://github.com/discord/discord-api-docs/issues/3056