### PR TITLE
Add the ability to modify the application command permissions

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -32,6 +32,8 @@ import org.javacord.api.entity.webhook.Webhook;
 import org.javacord.api.interaction.ApplicationCommand;
 import org.javacord.api.interaction.ApplicationCommandBuilder;
 import org.javacord.api.interaction.ApplicationCommandUpdater;
+import org.javacord.api.interaction.ServerApplicationCommandPermissions;
+import org.javacord.api.interaction.ServerApplicationCommandPermissionsBuilder;
 import org.javacord.api.listener.GloballyAttachableListenerManager;
 import org.javacord.api.util.DiscordRegexPattern;
 import org.javacord.api.util.concurrent.ThreadPool;
@@ -124,7 +126,36 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
      * @param commandId The id of the server application command.
      * @return The server application command with the given id.
      */
-    CompletableFuture<ApplicationCommand> getServerApplicationCommandById(Server server,long commandId);
+    CompletableFuture<ApplicationCommand> getServerApplicationCommandById(Server server, long commandId);
+
+    /**
+     * Gets a list of all server application command permissions from the given server.
+     *
+     * @param server The server.
+     * @return A list containing the server application command permissions.
+     */
+    CompletableFuture<List<ServerApplicationCommandPermissions>> getServerApplicationCommandPermissions(Server server);
+
+    /**
+     * Gets a server application command permissions by it ID from the given server.
+     *
+     * @param server The server.
+     * @param commandId The command ID.
+     * @return The server application command permissions for the given ID.
+     */
+    CompletableFuture<ServerApplicationCommandPermissions> getServerApplicationCommandPermissionsById(
+            Server server, long commandId);
+
+    /**
+     * Updates multiple server application command permissions at once.
+     *
+     * @param server The server where the application command permissions should be updated on.
+     * @param applicationCommandPermissionsBuilders The application command permissions builders,
+     *     which should be updated.
+     * @return A list of the updated server application command permissions.
+     */
+    CompletableFuture<List<ServerApplicationCommandPermissions>> batchUpdateApplicationCommandPermissions(
+            Server server, List<ServerApplicationCommandPermissionsBuilder> applicationCommandPermissionsBuilders);
 
     /**
      * Bulk overwrites the global Application Commands.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
@@ -47,6 +47,13 @@ public interface ApplicationCommand extends DiscordEntity {
     List<ApplicationCommandOption> getOptions();
 
     /**
+     * Gets the default permission of this command.
+     *
+     * @return The default permission of this command.
+     */
+    boolean getDefaultPermission();
+
+    /**
      * Deletes this application command.
      *
      * @return A future to check if the deletion was successful.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandBuilder.java
@@ -66,6 +66,18 @@ public class ApplicationCommandBuilder {
     }
 
     /**
+     * Sets the default permission for the application command
+     * whether the command is enabled by default when the app is added to a server.
+     *
+     * @param defaultPermission The default permission.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandBuilder setDefaultPermission(Boolean defaultPermission) {
+        delegate.setDefaultPermission(defaultPermission);
+        return this;
+    }
+
+    /**
      * Creates a global application command.
      * When used to update multiple global application commands at once
      * {@link DiscordApi#bulkOverwriteGlobalApplicationCommands(List)} should be used instead.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandPermissionType.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandPermissionType.java
@@ -1,0 +1,39 @@
+package org.javacord.api.interaction;
+
+public enum ApplicationCommandPermissionType {
+
+    ROLE(1),
+    USER(2),
+    UNKNOWN(-1);
+
+    private final int value;
+
+    ApplicationCommandPermissionType(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets integer value that represents this type.
+     *
+     * @return The integer value that represents this type.
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Gets an {@code ApplicationCommandPermissionType} by its value.
+     *
+     * @param value The value of the application command permission type.
+     * @return The application command permission type for the given value,
+     *     or {@link ApplicationCommandPermissionType#UNKNOWN} if there's none with the given value.
+     */
+    public static ApplicationCommandPermissionType fromValue(int value) {
+        for (ApplicationCommandPermissionType type : values()) {
+            if (type.getValue() == value) {
+                return type;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandPermissions.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandPermissions.java
@@ -1,0 +1,46 @@
+package org.javacord.api.interaction;
+
+import org.javacord.api.entity.permission.Role;
+import org.javacord.api.entity.user.User;
+
+public interface ApplicationCommandPermissions {
+
+    /**
+     * Gets the ID of the affected {@link ApplicationCommandPermissionType}.
+     *
+     * @return The ID..
+     */
+    long getId();
+
+    /**
+     * Gets the type of this application commands permissions which may be a {@link User} or a {@link Role}.
+     *
+     * @return The type of this application command permissions.
+     */
+    ApplicationCommandPermissionType getType();
+
+    /**
+     * Whether this permission is enabled or disabled for the this application command permissions.
+     *
+     * @return True if the command is enabled for this user or role. Otherwise false.
+     */
+    boolean getPermission();
+
+    /**
+     * Creates and application command permissions which can be used by {@link ApplicationCommandPermissionsUpdater}
+     * to update the permission.
+     *
+     * @param id The id of the role or user which should be updated.
+     * @param type The type this ID belong to.
+     * @param permission True if the command should be enabled.
+     * @return The built ApplicationCommandPermissions.
+     */
+    static ApplicationCommandPermissions with(
+            long id, ApplicationCommandPermissionType type, boolean permission) {
+        return new ApplicationCommandPermissionsBuilder()
+                .setId(id)
+                .setType(type)
+                .setPermission(permission)
+                .build();
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandPermissionsBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandPermissionsBuilder.java
@@ -1,0 +1,53 @@
+package org.javacord.api.interaction;
+
+import org.javacord.api.interaction.internal.ApplicationCommandPermissionsBuilderDelegate;
+import org.javacord.api.util.internal.DelegateFactory;
+
+public class ApplicationCommandPermissionsBuilder {
+
+    private final ApplicationCommandPermissionsBuilderDelegate delegate =
+            DelegateFactory.createApplicationCommandPermissionsBuilderDelegate();
+
+    /**
+     * Sets the ID of the application command permissions.
+     *
+     * @param id The id.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandPermissionsBuilder setId(long id) {
+        delegate.setId(id);
+        return this;
+    }
+
+    /**
+     * Sets the type of the application command permissions.
+     *
+     * @param type The type.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandPermissionsBuilder setType(ApplicationCommandPermissionType type) {
+        delegate.setType(type);
+        return this;
+    }
+
+    /**
+     * Sets the permissions of the application command option whether the command should be enabled or disabled.
+     *
+     * @param permission The permission.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandPermissionsBuilder setPermission(boolean permission) {
+        delegate.setPermission(permission);
+        return this;
+    }
+
+    /**
+     * Builds the application command permissions.
+     *
+     * @return A new instance of the ApplicationCommandPermissions.
+     */
+    public ApplicationCommandPermissions build() {
+        return delegate.build();
+    }
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandPermissionsUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandPermissionsUpdater.java
@@ -1,0 +1,82 @@
+package org.javacord.api.interaction;
+
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.interaction.internal.ApplicationCommandPermissionsUpdaterDelegate;
+import org.javacord.api.util.internal.DelegateFactory;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class ApplicationCommandPermissionsUpdater {
+
+    private final ApplicationCommandPermissionsUpdaterDelegate delegate;
+
+    /**
+     * Creates a new ApplicationCommandPermissionsUpdater for the given Server.
+     *
+     * @param server The server where the application command permissions should be applied on.
+     */
+    public ApplicationCommandPermissionsUpdater(Server server) {
+        delegate = DelegateFactory.createApplicationCommandPermissionsUpdaterDelegate(server);
+    }
+
+    /**
+     * Sets the permissions of the application command updater.
+     *
+     * @param permissions The permissions.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandPermissionsUpdater setPermissions(List<ApplicationCommandPermissions> permissions) {
+        delegate.setPermissions(permissions);
+        return this;
+    }
+
+    /**
+     * Add the permission to the application command updater.
+     *
+     * @param permission The permission.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandPermissionsUpdater addPermission(ApplicationCommandPermissions permission) {
+        delegate.addPermission(permission);
+        return this;
+    }
+
+    /**
+     * Add the permission to the application command updater.
+     *
+     * @param id The ID of the entity which should be updated.
+     * @param type The type of the ID which may be a user or a role.
+     * @param permission True if allowed, otherwise false.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandPermissionsUpdater addPermission(
+            long id, ApplicationCommandPermissionType type, boolean permission) {
+        delegate.addPermission(ApplicationCommandPermissions.with(id, type, permission));
+        return this;
+    }
+
+    /**
+     * Adds the permissions to the application command updater.
+     *
+     * @param permissions The permissions.
+     * @return The current instance in order to chain call methods.
+     */
+    public ApplicationCommandPermissionsUpdater addPermissions(List<ApplicationCommandPermissions> permissions) {
+        delegate.addPermissions(permissions);
+        return this;
+    }
+
+    /**
+     * Updates the command with the set permissions. When updating multiple application command permissions at once,
+     * prefer using {@link org.javacord.api.DiscordApi#batchUpdateApplicationCommandPermissions(Server, List)} as this
+     * requires only 1 request.
+     *
+     * @param commandId The ID of the command which should be updated.
+     * @return The updated server application command permissions.
+     */
+    public CompletableFuture<ServerApplicationCommandPermissions> update(long commandId) {
+        return delegate.update(commandId);
+    }
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ServerApplicationCommandPermissions.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ServerApplicationCommandPermissions.java
@@ -1,0 +1,33 @@
+package org.javacord.api.interaction;
+
+import java.util.List;
+
+public interface ServerApplicationCommandPermissions {
+    /**
+     * Gets the ID of this server application command permissions.
+     *
+     * @return The id.
+     */
+    long getId();
+
+    /**
+     * Gets the application ID from this server application command permissions.
+     *
+     * @return The application id.
+     */
+    long getApplicationId();
+
+    /**
+     * Gets the server ID of this server application command permissions.
+     *
+     * @return The server ID.
+     */
+    long getServerId();
+
+    /**
+     * Gets the permissions of this server application command permissions.
+     *
+     * @return A list containing the application command permissions.
+     */
+    List<ApplicationCommandPermissions> getPermissions();
+}

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ServerApplicationCommandPermissionsBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ServerApplicationCommandPermissionsBuilder.java
@@ -1,0 +1,40 @@
+package org.javacord.api.interaction;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ServerApplicationCommandPermissionsBuilder {
+
+    private final long commandId;
+    private final List<ApplicationCommandPermissions> permissions;
+
+    /**
+     * Creates an instance of this server application command permissions builder.
+     *
+     * @param commandId The command ID which should be updated.
+     * @param permissions The permissions for the command which should be updated.
+     */
+    public ServerApplicationCommandPermissionsBuilder(long commandId, List<ApplicationCommandPermissions> permissions) {
+        this.commandId = commandId;
+        this.permissions = new ArrayList<>(permissions);
+    }
+
+    /**
+     * Gets the command ID.
+     *
+     * @return The command ID.
+     */
+    public long getCommandId() {
+        return commandId;
+    }
+
+    /**
+     * Gets a list of the application command permissions.
+     *
+     * @return A list containing the application command permissions.
+     */
+    public List<ApplicationCommandPermissions> getPermissions() {
+        return Collections.unmodifiableList(permissions);
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandBuilderDelegate.java
@@ -43,6 +43,14 @@ public interface ApplicationCommandBuilderDelegate {
     void setOptions(List<ApplicationCommandOption> options);
 
     /**
+     * Sets the default permission for the application command
+     * whether the command is enabled by default when the app is added to a server.
+     *
+     * @param defaultPermission The default permission.
+     */
+    void setDefaultPermission(Boolean defaultPermission);
+
+    /**
      * Creates a global application command.
      *
      * @param api The discord api instance.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandPermissionsBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandPermissionsBuilderDelegate.java
@@ -1,0 +1,35 @@
+package org.javacord.api.interaction.internal;
+
+import org.javacord.api.interaction.ApplicationCommandPermissionType;
+import org.javacord.api.interaction.ApplicationCommandPermissions;
+
+public interface ApplicationCommandPermissionsBuilderDelegate {
+
+    /**
+     * Sets the ID of the application command permissions.
+     *
+     * @param id The id.
+     */
+    void setId(long id);
+
+    /**
+     * Sets the type of the application command permissions.
+     *
+     * @param type The type.
+     */
+    void setType(ApplicationCommandPermissionType type);
+
+    /**
+     * Sets the permissions of the application command option whether the command should be enabled or disabled.
+     *
+     * @param permission The permission.
+     */
+    void setPermission(boolean permission);
+
+    /**
+     * Builds the application command permissions.
+     *
+     * @return A new instance of the ApplicationCommandPermissions.
+     */
+    ApplicationCommandPermissions build();
+}

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandPermissionsUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandPermissionsUpdaterDelegate.java
@@ -1,0 +1,39 @@
+package org.javacord.api.interaction.internal;
+
+import org.javacord.api.interaction.ApplicationCommandPermissions;
+import org.javacord.api.interaction.ServerApplicationCommandPermissions;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public interface ApplicationCommandPermissionsUpdaterDelegate {
+
+    /**
+     * Sets the permissions of the application command updater.
+     *
+     * @param permissions The permissions.
+     */
+    void setPermissions(List<ApplicationCommandPermissions> permissions);
+
+    /**
+     * Add the permissions to the application command updater.
+     *
+     * @param permissions The permissions.
+     */
+    void addPermissions(List<ApplicationCommandPermissions> permissions);
+
+    /**
+     * Adds the permission to the application command updater.
+     *
+     * @param permission The permission.
+     */
+    void addPermission(ApplicationCommandPermissions permission);
+
+    /**
+     * Updates the command with the set permissions.
+     *
+     * @param commandId The ID of the command which should be updated.
+     * @return The updated server application command permissions.
+     */
+    CompletableFuture<ServerApplicationCommandPermissions> update(long commandId);
+}

--- a/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactory.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactory.java
@@ -38,6 +38,8 @@ import org.javacord.api.entity.webhook.internal.WebhookUpdaterDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionChoiceBuilderDelegate;
+import org.javacord.api.interaction.internal.ApplicationCommandPermissionsBuilderDelegate;
+import org.javacord.api.interaction.internal.ApplicationCommandPermissionsUpdaterDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandUpdaterDelegate;
 import org.javacord.api.internal.AccountUpdaterDelegate;
 import org.javacord.api.internal.DiscordApiBuilderDelegate;
@@ -387,6 +389,26 @@ public class DelegateFactory {
      */
     public static ApplicationCommandOptionBuilderDelegate createApplicationCommandOptionBuilderDelegate() {
         return delegateFactoryDelegate.createApplicationCommandOptionBuilderDelegate();
+    }
+
+    /**
+     * Creates a new application command permissions updater delegate.
+     *
+     * @param server The server.
+     * @return The application command permissions updater delegate.
+     */
+    public static ApplicationCommandPermissionsUpdaterDelegate createApplicationCommandPermissionsUpdaterDelegate(
+            Server server) {
+        return delegateFactoryDelegate.createApplicationCommandPermissionsUpdaterDelegate(server);
+    }
+
+    /**
+     * Creates a new application command permissions builder delegate.
+     *
+     * @return The application command permissions builder delegate.
+     */
+    public static ApplicationCommandPermissionsBuilderDelegate createApplicationCommandPermissionsBuilderDelegate() {
+        return delegateFactoryDelegate.createApplicationCommandPermissionsBuilderDelegate();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactoryDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/internal/DelegateFactoryDelegate.java
@@ -38,6 +38,8 @@ import org.javacord.api.entity.webhook.internal.WebhookUpdaterDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionChoiceBuilderDelegate;
+import org.javacord.api.interaction.internal.ApplicationCommandPermissionsBuilderDelegate;
+import org.javacord.api.interaction.internal.ApplicationCommandPermissionsUpdaterDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandUpdaterDelegate;
 import org.javacord.api.internal.AccountUpdaterDelegate;
 import org.javacord.api.internal.DiscordApiBuilderDelegate;
@@ -286,6 +288,21 @@ public interface DelegateFactoryDelegate {
      * @return The application command option builder delegate.
      */
     ApplicationCommandOptionBuilderDelegate createApplicationCommandOptionBuilderDelegate();
+
+    /**
+     * Creates a new application command permissions updater delegate.
+     *
+     * @param server The server where the update should be performed on.
+     * @return The application command permissions updater delegate.
+     */
+    ApplicationCommandPermissionsUpdaterDelegate createApplicationCommandPermissionsUpdaterDelegate(Server server);
+
+    /**
+     * Creates a new application command permissions builder delegate.
+     *
+     * @return The application command permissions builder delegate.
+     */
+    ApplicationCommandPermissionsBuilderDelegate createApplicationCommandPermissionsBuilderDelegate();
 
     /**
      * Creates a new application command option choice builder delegate.

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
@@ -22,6 +22,7 @@ public class ApplicationCommandImpl implements ApplicationCommand {
     private final String name;
     private final String description;
     private final List<ApplicationCommandOption> options;
+    private final boolean defaultPermission;
 
     /**
      * Class constructor.
@@ -41,6 +42,7 @@ public class ApplicationCommandImpl implements ApplicationCommand {
                 options.add(new ApplicationCommandOptionImpl(optionJson));
             }
         }
+        defaultPermission = !data.hasNonNull("default_permission") || data.get("default_permission").asBoolean();
     }
 
     @Override
@@ -71,6 +73,11 @@ public class ApplicationCommandImpl implements ApplicationCommand {
     @Override
     public List<ApplicationCommandOption> getOptions() {
         return Collections.unmodifiableList(options);
+    }
+
+    @Override
+    public boolean getDefaultPermission() {
+        return defaultPermission;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandPermissionsBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandPermissionsBuilderDelegateImpl.java
@@ -1,0 +1,48 @@
+package org.javacord.core.interaction;
+
+import org.javacord.api.interaction.ApplicationCommandPermissionType;
+import org.javacord.api.interaction.ApplicationCommandPermissions;
+import org.javacord.api.interaction.internal.ApplicationCommandPermissionsBuilderDelegate;
+
+import java.util.Objects;
+
+public class ApplicationCommandPermissionsBuilderDelegateImpl implements ApplicationCommandPermissionsBuilderDelegate {
+
+    private Long id;
+    private ApplicationCommandPermissionType type;
+    private Boolean permission;
+
+    /**
+     * Class constructor.
+     */
+    public ApplicationCommandPermissionsBuilderDelegateImpl() {
+    }
+
+    @Override
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    @Override
+    public void setType(ApplicationCommandPermissionType type) {
+        Objects.requireNonNull(type,"The type can not be null!");
+        this.type = type;
+    }
+
+    @Override
+    public void setPermission(boolean permission) {
+        this.permission = permission;
+    }
+
+    @Override
+    public ApplicationCommandPermissions build() {
+        if (null == type) {
+            throw new IllegalStateException("Type can not be null!");
+        } else if (null == permission) {
+            throw new IllegalStateException("Permission can not be null!");
+        } else if (null == id) {
+            throw new IllegalStateException("ID can not be null!");
+        }
+        return new ApplicationCommandPermissionsImpl(id, type, permission);
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandPermissionsImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandPermissionsImpl.java
@@ -1,0 +1,68 @@
+package org.javacord.core.interaction;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.interaction.ApplicationCommandPermissionType;
+import org.javacord.api.interaction.ApplicationCommandPermissions;
+
+public class ApplicationCommandPermissionsImpl implements ApplicationCommandPermissions {
+
+    private final long id;
+    private final ApplicationCommandPermissionType type;
+    private final boolean permission;
+
+    /**
+     * Class constructor.
+     *
+     * @param data The json data of the application command permissions.
+     */
+    public ApplicationCommandPermissionsImpl(JsonNode data) {
+        id = data.get("id").asLong();
+        type = ApplicationCommandPermissionType.fromValue(data.get("type").asInt());
+        permission = data.get("permission").asBoolean();
+    }
+
+    /**
+     * Class constructor.
+     *
+     * @param id The id.
+     * @param type The type.
+     * @param permission The permission.
+     *
+     */
+    public ApplicationCommandPermissionsImpl(long id, ApplicationCommandPermissionType type, boolean permission) {
+        this.id = id;
+        this.type = type;
+        this.permission = permission;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public ApplicationCommandPermissionType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean getPermission() {
+        return permission;
+    }
+
+    /**
+     * Adds the json data to the given object node.
+     *
+     * @return The provided object with the data of the embed.
+     */
+    public ObjectNode toJsonNode() {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put("id", id);
+        node.put("type", type.getValue());
+        node.put("permission", permission);
+
+        return node;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandPermissionsUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandPermissionsUpdaterDelegateImpl.java
@@ -1,0 +1,63 @@
+package org.javacord.core.interaction;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.interaction.ApplicationCommandPermissions;
+import org.javacord.api.interaction.ServerApplicationCommandPermissions;
+import org.javacord.api.interaction.internal.ApplicationCommandPermissionsUpdaterDelegate;
+import org.javacord.core.util.rest.RestEndpoint;
+import org.javacord.core.util.rest.RestMethod;
+import org.javacord.core.util.rest.RestRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class ApplicationCommandPermissionsUpdaterDelegateImpl implements ApplicationCommandPermissionsUpdaterDelegate {
+
+    private final Server server;
+    private List<ApplicationCommandPermissions> permissions;
+
+    /**
+     * Creates an instance of this class.
+     *
+     * @param server The server where the update should be performed on.
+     */
+    public ApplicationCommandPermissionsUpdaterDelegateImpl(Server server) {
+        this.server = server;
+        this.permissions = new ArrayList<>();
+    }
+
+    @Override
+    public void setPermissions(List<ApplicationCommandPermissions> permission) {
+        this.permissions = permission;
+    }
+
+    @Override
+    public void addPermissions(List<ApplicationCommandPermissions> permissions) {
+        this.permissions.addAll(permissions);
+    }
+
+    @Override
+    public void addPermission(ApplicationCommandPermissions permission) {
+        this.permissions.add(permission);
+    }
+
+    @Override
+    public CompletableFuture<ServerApplicationCommandPermissions> update(long commandId) {
+        ObjectNode body = JsonNodeFactory.instance.objectNode();
+        ArrayNode array = body.putArray("permissions");
+        for (ApplicationCommandPermissions permission : permissions) {
+            array.add(((ApplicationCommandPermissionsImpl) permission).toJsonNode());
+        }
+
+        return new RestRequest<ServerApplicationCommandPermissions>(server.getApi(), RestMethod.PUT,
+                RestEndpoint.APPLICATION_COMMAND_PERMISSIONS)
+                .setUrlParameters(String.valueOf(server.getApi().getClientId()),
+                        server.getIdAsString(), String.valueOf(commandId))
+                .setBody(body)
+                .execute(result -> new ServerApplicationCommandPermissionsImpl(result.getJsonBody()));
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ServerApplicationCommandPermissionsImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ServerApplicationCommandPermissionsImpl.java
@@ -1,0 +1,52 @@
+package org.javacord.core.interaction;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.interaction.ApplicationCommandPermissions;
+import org.javacord.api.interaction.ServerApplicationCommandPermissions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ServerApplicationCommandPermissionsImpl implements ServerApplicationCommandPermissions {
+
+    private final long id;
+    private final long applicationId;
+    private final long serverId;
+    private final List<ApplicationCommandPermissions> permissions;
+
+    /**
+     * Class constructor.
+     *
+     * @param data The json data of the application command permissions.
+     */
+    public ServerApplicationCommandPermissionsImpl(JsonNode data) {
+        id = data.get("id").asLong();
+        applicationId = data.get("application_id").asLong();
+        serverId = data.get("guild_id").asLong();
+
+        permissions = new ArrayList<>();
+        for (JsonNode jsonNode : data.get("permissions")) {
+            permissions.add(new ApplicationCommandPermissionsImpl(jsonNode));
+        }
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public long getApplicationId() {
+        return applicationId;
+    }
+
+    @Override
+    public long getServerId() {
+        return serverId;
+    }
+
+    @Override
+    public List<ApplicationCommandPermissions> getPermissions() {
+        return permissions;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/DelegateFactoryDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/DelegateFactoryDelegateImpl.java
@@ -38,6 +38,8 @@ import org.javacord.api.entity.webhook.internal.WebhookUpdaterDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionBuilderDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandOptionChoiceBuilderDelegate;
+import org.javacord.api.interaction.internal.ApplicationCommandPermissionsBuilderDelegate;
+import org.javacord.api.interaction.internal.ApplicationCommandPermissionsUpdaterDelegate;
 import org.javacord.api.interaction.internal.ApplicationCommandUpdaterDelegate;
 import org.javacord.api.internal.AccountUpdaterDelegate;
 import org.javacord.api.internal.DiscordApiBuilderDelegate;
@@ -76,6 +78,8 @@ import org.javacord.core.entity.webhook.WebhookUpdaterDelegateImpl;
 import org.javacord.core.interaction.ApplicationCommandBuilderDelegateImpl;
 import org.javacord.core.interaction.ApplicationCommandOptionBuilderDelegateImpl;
 import org.javacord.core.interaction.ApplicationCommandOptionChoiceBuilderDelegateImpl;
+import org.javacord.core.interaction.ApplicationCommandPermissionsBuilderDelegateImpl;
+import org.javacord.core.interaction.ApplicationCommandPermissionsUpdaterDelegateImpl;
 import org.javacord.core.interaction.ApplicationCommandUpdaterDelegateImpl;
 import org.javacord.core.util.exception.DiscordExceptionValidatorImpl;
 import org.javacord.core.util.logging.ExceptionLoggerDelegateImpl;
@@ -228,6 +232,17 @@ public class DelegateFactoryDelegateImpl implements DelegateFactoryDelegate {
     @Override
     public ApplicationCommandOptionBuilderDelegate createApplicationCommandOptionBuilderDelegate() {
         return new ApplicationCommandOptionBuilderDelegateImpl();
+    }
+
+    @Override
+    public ApplicationCommandPermissionsUpdaterDelegate createApplicationCommandPermissionsUpdaterDelegate(
+            Server server) {
+        return new ApplicationCommandPermissionsUpdaterDelegateImpl(server);
+    }
+
+    @Override
+    public ApplicationCommandPermissionsBuilderDelegate createApplicationCommandPermissionsBuilderDelegate() {
+        return new ApplicationCommandPermissionsBuilderDelegateImpl();
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
@@ -49,7 +49,9 @@ public enum RestEndpoint {
     INTERACTION_RESPONSE("/interactions/%s/%s/callback", 0),
     ORIGINAL_INTERACTION_RESPONSE("/webhooks/%s/%s/messages/@original",0),
     APPLICATION_COMMANDS("/applications/%s/commands", 0),
-    SERVER_APPLICATION_COMMANDS("/applications/%s/guilds/%s/commands",1);
+    SERVER_APPLICATION_COMMANDS("/applications/%s/guilds/%s/commands",0),
+    SERVER_APPLICATION_COMMAND_PERMISSIONS("/applications/%s/guilds/%s/commands/permissions",0),
+    APPLICATION_COMMAND_PERMISSIONS("/applications/%s/guilds/%s/commands/%s/permissions",0);
 
     /**
      * The endpoint url (only including the base, not the https://discord.com/api/vXYZ/ "prefix".


### PR DESCRIPTION
# Example usage:

```java
//Update a single comand for a user
new ApplicationCommandPermissionsUpdater(server)
                .addPermission(ApplicationCommandPermissions.createApplicationCommandPermissions(USER_ID, ApplicationCommandPermissionType.USER, false))
                .update(APPLICATION_COMMAND_ID);

//Update multiple permissions at once
api.batchUpdateApplicationCommandPermissions(
    server,
    Arrays.asList(new ServerApplicationCommandPermissionsBuilder(APPLICATION_COMMAND_ID, Collections.singletonList(ApplicationCommandPermissions.createApplicationCommandPermissions(USER_ID, ApplicationCommandPermissionType.USER, false))),
                  new ServerApplicationCommandPermissionsBuilder(APPLICATION_COMMAND_ID, Collections.singletonList(ApplicationCommandPermissions.createApplicationCommandPermissions(ROLE_ID, ApplicationCommandPermissionType.ROLE, false)))));
```
