### PR TITLE
Add Message reference object to fix issues with message reference

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -768,12 +768,22 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     MessageAuthor getAuthor();
 
     /**
-     * Gets the id of the message referenced with a reply.
-     * Only present if this message is type {@code MessageType.REPLY}.
+     * Gets the message reference of the message.
+     *
+     * @return The message reference.
+     */
+    Optional<MessageReference> getMessageReference();
+
+    /**
+     * Gets the id of the referenced message.
      *
      * @return The id of the referenced message.
+     * @deprecated Use {@link #getMessageReference()} instead.
      */
-    Optional<Long> getReferencedMessageId();
+    @Deprecated
+    default Optional<Long> getReferencedMessageId() {
+        return getMessageReference().flatMap(MessageReference::getMessageId);
+    }
 
     /**
      * Gets the message referenced with a reply.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageReference.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageReference.java
@@ -1,0 +1,78 @@
+package org.javacord.api.entity.message;
+
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.channel.TextChannel;
+import org.javacord.api.entity.server.Server;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public interface MessageReference {
+
+    /**
+     * Gets the discord api instance.
+     *
+     * @return The discord api instance.
+     */
+    DiscordApi getApi();
+
+    /**
+     * Gets the server id of the message reference.
+     *
+     * @return The server if of the message reference.
+     */
+    Optional<Long> getServerId();
+
+    /**
+     * Gets the channel id of the message reference.
+     *
+     * @return The channel if of the message reference.
+     */
+    long getChannelId();
+
+    /**
+     * Gets the message id of the message reference.
+     *
+     * @return The message if of the message reference.
+     */
+    Optional<Long> getMessageId();
+
+    /**
+     * Gets the referenced message.
+     *
+     * @return The referenced Message.
+     */
+    Optional<Message> getMessage();
+
+    /**
+     * Gets the server of the message reference.
+     *
+     * @return The server of the message reference.
+     */
+    default Optional<Server> getServer() {
+        return getServerId().flatMap(id -> getApi().getServerById(id));
+    }
+
+    /**
+     * Gets the server of the message reference.
+     *
+     * @return The server of the message reference.
+     */
+    default Optional<TextChannel> getChannel() {
+        return getApi().getTextChannelById(getChannelId());
+    }
+
+    /**
+     * Requests the referenced message if it isn't present.
+     *
+     * @return The referenced Message.
+     */
+    default Optional<CompletableFuture<Message>> requestMessage() {
+        Optional<Message> optionalMessage = getMessage();
+        if (optionalMessage.isPresent()) {
+            return optionalMessage.map(CompletableFuture::completedFuture);
+        }
+
+        return getMessageId().flatMap(messageId -> getChannel().map(channel -> channel.getMessageById(messageId)));
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
@@ -10,6 +10,7 @@ import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.MessageActivity;
 import org.javacord.api.entity.message.MessageAttachment;
 import org.javacord.api.entity.message.MessageAuthor;
+import org.javacord.api.entity.message.MessageReference;
 import org.javacord.api.entity.message.MessageType;
 import org.javacord.api.entity.message.Reaction;
 import org.javacord.api.entity.message.component.HighLevelComponent;
@@ -108,13 +109,14 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
     private final String nonce;
 
     /**
-     * The id of the message referenced via message reply.
-     */
-    private final Long referencedMessageId;
-    /**
      * The message referenced via message reply.
      */
     private final Message referencedMessage;
+
+    /**
+     * The message reference.
+     */
+    private final MessageReference messageReference;
 
     /**
      * If the message should be cached forever or not.
@@ -232,16 +234,16 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
             nonce = null;
         }
 
-        if (data.hasNonNull("message_reference")) {
-            referencedMessageId = data.get("message_reference").get("message_id").asLong();
-        } else {
-            referencedMessageId = null;
-        }
-
         if (data.hasNonNull("referenced_message")) {
             referencedMessage = api.getOrCreateMessage(channel, data.get("referenced_message"));
         } else {
             referencedMessage = null;
+        }
+
+        if (data.hasNonNull("message_reference")) {
+            messageReference = new MessageReferenceImpl(api, referencedMessage, data.get("message_reference"));
+        } else {
+            messageReference = null;
         }
     }
 
@@ -420,8 +422,8 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
     }
 
     @Override
-    public Optional<Long> getReferencedMessageId() {
-        return Optional.ofNullable(referencedMessageId);
+    public Optional<MessageReference> getMessageReference() {
+        return Optional.ofNullable(messageReference);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageReferenceImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageReferenceImpl.java
@@ -1,0 +1,87 @@
+package org.javacord.core.entity.message;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.message.Message;
+import org.javacord.api.entity.message.MessageReference;
+import org.javacord.core.DiscordApiImpl;
+
+import java.util.Optional;
+
+public class MessageReferenceImpl implements MessageReference {
+
+    /**
+     * The discord api instance.
+     */
+    private final DiscordApiImpl api;
+
+    /**
+     * The server id of the message reference. Can be null.
+     */
+    private final Long serverId;
+
+    /**
+     * The channel id of the message reference.
+     */
+    private final long channelId;
+
+    /**
+     * The message id of the message reference. Can be null.
+     */
+    private final Long messageId;
+
+    /**
+     * The referenced message. Can be null.
+     */
+    private final Message message;
+
+    /**
+     * Creates a new message reference object.
+     *
+     * @param api The discord api instance.
+     * @param message The message that got referenced. Can be null.
+     * @param data The json data of the message reference.
+     */
+    public MessageReferenceImpl(DiscordApiImpl api, Message message, JsonNode data) {
+        this.api = api;
+        if (data.hasNonNull("guild_id")) {
+            this.serverId = data.get("guild_id").asLong();
+        } else {
+            this.serverId = null;
+        }
+        this.channelId = data.get("channel_id").asLong();
+
+        if (data.hasNonNull("message_id")) {
+            this.messageId = data.get("message_id").asLong();
+        } else {
+            this.messageId = null;
+        }
+
+        this.message = message;
+    }
+
+    @Override
+    public DiscordApi getApi() {
+        return api;
+    }
+
+    @Override
+    public Optional<Long> getServerId() {
+        return Optional.ofNullable(serverId);
+    }
+
+    @Override
+    public long getChannelId() {
+        return channelId;
+    }
+
+    @Override
+    public Optional<Long> getMessageId() {
+        return Optional.ofNullable(messageId);
+    }
+
+    @Override
+    public Optional<Message> getMessage() {
+        return Optional.ofNullable(message);
+    }
+}


### PR DESCRIPTION
See: https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure

As there now can be message references without a message id, we need to implement it properly.