### PR TITLE
Add Membership Screening Pending getter and event.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -178,6 +178,20 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     Optional<String> getNickname(User user);
 
     /**
+     * Gets the pending state of the user.
+     *
+     * <p>Membership screening pending state is only available for servers that have
+     * verification gate enabled, this will default to false if it isn't.
+     * You can check if a server has membership verification gate enabled
+     * using the {@link #getFeatures()} method if it has
+     * {@link org.javacord.api.entity.server.ServerFeature#MEMBER_VERIFICATION_GATE_ENABLED}.
+     *
+     * @param userId The id of the user to check.
+     * @return Whether the user has passed membership screening
+     */
+    boolean isPending(long userId);
+
+    /**
      * Gets your self-muted state.
      *
      * @return Whether you are self-muted.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -307,6 +307,18 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
     Optional<String> getNickname(Server server);
 
     /**
+     * Gets the pending state of the user in the given server.
+     *
+     * <p>This will always return false if the server doesn't have membership screening enable.
+     * You can check through {@link Server#getFeatures()} if it has
+     * {@link org.javacord.api.entity.server.ServerFeature#MEMBER_VERIFICATION_GATE_ENABLED}.
+     *
+     * @param server The server to check.
+     * @return Whether the user has passed the Membership screening.
+     */
+    boolean isPending(Server server);
+
+    /**
      * Moves this user to the given channel.
      *
      * @param channel The channel to move the user to.

--- a/javacord-api/src/main/java/org/javacord/api/event/user/UserChangePendingEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/user/UserChangePendingEvent.java
@@ -1,0 +1,24 @@
+package org.javacord.api.event.user;
+
+import org.javacord.api.event.server.member.ServerMemberEvent;
+
+/**
+ * A user pending state (membership screening) change event.
+ */
+public interface UserChangePendingEvent extends ServerMemberEvent {
+
+    /**
+     * Gets the old pending state of the member.
+     *
+     * @return The old pending state of the member.
+     */
+    boolean getOldPending();
+
+    /**
+     * Gets the new pending state of the member.
+     *
+     * @return The new pending state of the member.
+     */
+    boolean getNewPending();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangePendingListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangePendingListener.java
@@ -1,0 +1,21 @@
+package org.javacord.api.listener.user;
+
+import org.javacord.api.event.user.UserChangePendingEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.server.ServerAttachableListener;
+
+/**
+ * This listener listens to user pending state changes (member screening pass).
+ */
+public interface UserChangePendingListener extends ServerAttachableListener, UserAttachableListener,
+        GloballyAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called every time a user's pending state changes.
+     *
+     * @param event The event.
+     */
+    void onServerMemberChangePending(UserChangePendingEvent event);
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1108,6 +1108,13 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     }
 
     @Override
+    public boolean isPending(long userId) {
+        return getRealMemberById(userId)
+                .map(Member::isPending)
+                .orElse(false);
+    }
+
+    @Override
     public boolean isSelfMuted(long userId) {
         return getRealMemberById(userId)
                 .map(Member::isSelfMuted)

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/Member.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/Member.java
@@ -103,4 +103,11 @@ public interface Member extends DiscordEntity, Messageable, Mentionable, Permiss
      */
     boolean isSelfDeafened();
 
+    /**
+     * Gets the pending state of this member.
+     *
+     * @return Whether this user has passed the membership screening.
+     */
+    boolean isPending();
+
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/MemberImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/MemberImpl.java
@@ -27,6 +27,7 @@ public final class MemberImpl implements Member {
     private final DiscordApiImpl api;
     private final ServerImpl server;
     private final UserImpl user;
+    private final boolean pending;
     private final String nickname;
     private final List<Long> roleIds;
     private final String joinedAt;
@@ -72,6 +73,12 @@ public final class MemberImpl implements Member {
             serverBoostingSince = null;
         }
 
+        if (data.hasNonNull("pending")) {
+            pending = data.get("pending").asBoolean();
+        } else {
+            pending = false;
+        }
+
         if (data.hasNonNull("deaf")) {
             selfDeafened = data.get("deaf").asBoolean();
         } else {
@@ -85,7 +92,8 @@ public final class MemberImpl implements Member {
     }
 
     private MemberImpl(DiscordApiImpl api, ServerImpl server, UserImpl user, String nickname, List<Long> roleIds,
-                       String joinedAt, String serverBoostingSince, boolean selfDeafened, boolean selfMuted) {
+                       String joinedAt, String serverBoostingSince, boolean selfDeafened,
+                       boolean selfMuted, boolean pending) {
         this.api = api;
         this.server = server;
         this.user = user;
@@ -95,6 +103,7 @@ public final class MemberImpl implements Member {
         this.serverBoostingSince = serverBoostingSince;
         this.selfDeafened = selfDeafened;
         this.selfMuted = selfMuted;
+        this.pending = pending;
     }
 
     /**
@@ -105,7 +114,7 @@ public final class MemberImpl implements Member {
      */
     public MemberImpl setUser(UserImpl user) {
         return new MemberImpl(
-                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted);
+                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted, pending);
     }
 
     /**
@@ -116,7 +125,7 @@ public final class MemberImpl implements Member {
      */
     public MemberImpl setPartialUser(JsonNode partialUserJson) {
         return new MemberImpl(api, server, user.replacePartialUserData(partialUserJson), nickname, roleIds, joinedAt,
-                serverBoostingSince, selfDeafened, selfMuted);
+                serverBoostingSince, selfDeafened, selfMuted, pending);
     }
 
     /**
@@ -128,7 +137,7 @@ public final class MemberImpl implements Member {
     public MemberImpl setRoleIds(List<Long> roleIds) {
         roleIds.add(server.getEveryoneRole().getId());
         return new MemberImpl(
-                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted);
+                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted, pending);
     }
 
     /**
@@ -148,7 +157,7 @@ public final class MemberImpl implements Member {
      */
     public MemberImpl setNickname(String nickname) {
         return new MemberImpl(
-                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted);
+                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted, pending);
     }
 
     /**
@@ -159,7 +168,7 @@ public final class MemberImpl implements Member {
      */
     public MemberImpl setServerBoostingSince(String serverBoostingSince) {
         return new MemberImpl(
-                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted);
+                api, server, user, nickname, roleIds, joinedAt, serverBoostingSince, selfDeafened, selfMuted, pending);
     }
 
     /**
@@ -239,6 +248,11 @@ public final class MemberImpl implements Member {
     @Override
     public boolean isSelfDeafened() {
         return selfDeafened;
+    }
+
+    @Override
+    public boolean isPending() {
+        return pending;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
@@ -271,6 +271,15 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
     }
 
     @Override
+    public boolean isPending(Server server) {
+        if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
+            return server.isPending(getId());
+        } else {
+            return member.isPending();
+        }
+    }
+
+    @Override
     public boolean isSelfMuted(Server server) {
         if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
             return server.isSelfMuted(getId());

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangePendingEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangePendingEventImpl.java
@@ -1,0 +1,44 @@
+package org.javacord.core.event.user;
+
+import org.javacord.api.event.user.UserChangePendingEvent;
+import org.javacord.core.entity.user.Member;
+import org.javacord.core.event.user.ServerUserEventImpl;
+
+/**
+ * The implementation of {@link UserChangePendingEvent}.
+ */
+public class UserChangePendingEventImpl extends ServerUserEventImpl
+        implements UserChangePendingEvent {
+
+    /**
+     * The old pending state of the user.
+     */
+    private final boolean oldPending;
+
+    /**
+     * The new pending state of the user.
+     */
+    private final boolean newPending;
+
+    /**
+     * Creates a new server member pending change event.
+     *
+     * @param oldMember The old member.
+     * @param newMember The new member.
+     */
+    public UserChangePendingEventImpl(Member oldMember, Member newMember) {
+        super(newMember.getUser(), newMember.getServer());
+        this.oldPending = oldMember.isPending();
+        this.newPending = newMember.isPending();
+    }
+
+    @Override
+    public boolean getOldPending() {
+        return oldPending;
+    }
+
+    @Override
+    public boolean getNewPending() {
+        return newPending;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildMemberUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildMemberUpdateHandler.java
@@ -12,6 +12,7 @@ import org.javacord.api.event.user.UserChangeAvatarEvent;
 import org.javacord.api.event.user.UserChangeDiscriminatorEvent;
 import org.javacord.api.event.user.UserChangeNameEvent;
 import org.javacord.api.event.user.UserChangeNicknameEvent;
+import org.javacord.api.event.user.UserChangePendingEvent;
 import org.javacord.core.entity.server.ServerImpl;
 import org.javacord.core.entity.user.Member;
 import org.javacord.core.entity.user.MemberImpl;
@@ -22,6 +23,7 @@ import org.javacord.core.event.user.UserChangeAvatarEventImpl;
 import org.javacord.core.event.user.UserChangeDiscriminatorEventImpl;
 import org.javacord.core.event.user.UserChangeNameEventImpl;
 import org.javacord.core.event.user.UserChangeNicknameEventImpl;
+import org.javacord.core.event.user.UserChangePendingEventImpl;
 import org.javacord.core.util.event.DispatchQueueSelector;
 import org.javacord.core.util.gateway.PacketHandler;
 import org.javacord.core.util.logging.LoggerUtil;
@@ -70,6 +72,14 @@ public class GuildMemberUpdateHandler extends PacketHandler {
                                 new UserChangeNicknameEventImpl(newMember, oldMember);
 
                         api.getEventDispatcher().dispatchUserChangeNicknameEvent(
+                                server, server, newMember.getUser(), event);
+                    }
+
+                    if (newMember.isPending() != oldMember.isPending()) {
+                        UserChangePendingEvent event =
+                                new UserChangePendingEventImpl(oldMember, newMember);
+
+                        api.getEventDispatcher().dispatchUserChangePendingEvent(
                                 server, server, newMember.getUser(), event);
                     }
 
@@ -160,6 +170,7 @@ public class GuildMemberUpdateHandler extends PacketHandler {
                                 userChanged = true;
                             }
                         }
+
                         if (userChanged) {
                             api.updateUserOfAllMembers(updatedUser);
                         }


### PR DESCRIPTION
As the title implies, it adds the `pending` field of [Guild Member](https://github.com/discord/discord-api-docs/blob/eeba53e05a5bb929e7fbf9487a02dceb34811586/docs/resources/Guild.md#guild-member-object) which is a field that moderation bots or auto-role bots may require since it is needed to check whether the user has passed membership screening.

This PR has been tested (both the listener and get method: `User#isPending`, `Server#isPending` and `UserChangePendingListener`) though I feel like the JavaDocs and the name for the event may not fit well, feel free to leave your opinions.

Fixes #690 