### PR TITLE
Add addIntents and setNonPrivilegedIntentsAnd method to DiscordApiBuilder

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
@@ -429,6 +429,29 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
     }
 
     /**
+     * Sets all non privileged intents and the given intents.
+     *
+     * @param intentsToInclude One or more {@code Intent}s which should be included.
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder setAllNonPrivilegedIntentsAnd(Intent... intentsToInclude) {
+        setAllIntentsWhere(intent -> !intent.isPrivileged());
+        addIntents(intentsToInclude);
+        return this;
+    }
+
+    /**
+     * Adds the given intents to the already set.
+     *
+     * @param intents The intents to add.
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder addIntents(Intent... intents) {
+        delegate.addIntents(intents);
+        return this;
+    }
+
+    /**
      * Sets the intents where the given predicate matches.
      *
      * @param condition Whether the intent should be added or not.

--- a/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
@@ -172,6 +172,13 @@ public interface DiscordApiBuilderDelegate {
     boolean isShutdownHookRegistrationEnabled();
 
     /**
+     * Adds the given intents to the already set.
+     *
+     * @param intents The intents to add.
+     */
+    void addIntents(Intent... intents);
+
+    /**
      * Sets the intents where the given predicate matches.
      *
      * @param condition Whether the intent should be added or not.

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiBuilderDelegateImpl.java
@@ -391,6 +391,11 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
     }
 
     @Override
+    public void addIntents(Intent... intents) {
+        this.intents.addAll(Arrays.asList(intents));
+    }
+
+    @Override
     public void setAllIntentsWhere(Predicate<Intent> condition) {
         intents = new HashSet<>();
         for (Intent value : Intent.values()) {


### PR DESCRIPTION
## Description
This adds the two methods: `addIntents(...)` which adds the specified intents to the current list (or default) and also `setNonPrivilegedIntentsAnd(...)` which is basically setting the default intents together with the intents specified, though it's probably better to use `addIntents(...)` instead since it does the same thing (as long as you don't set anything else).

## Type of Change
- ✔️ New Feature

## Necessary Checks
- ✔️ Tested both methods with a test Discord bot
- ✔️ Codestyle