### PR TITLE
Expose method to get unknown custom emoji

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -1223,6 +1223,20 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
     }
 
     /**
+     * Creates or gets a custom emoji to be used in other Javacord APIs. Use this if the custom emoji you're looking
+     * for is hosted on a different shard, and can't be accessed through {@code getCustomEmojiById()}.
+     * If the custom emoji is known, the method will return the known custom emoji instead of creating a new one.
+     * The method will always return a non-null value, even if the emoji does not exist which will lead to a non
+     * functional custom emoji for further usage.
+     *
+     * @param id the ID of the custom emoji
+     * @param name the name of the custom emoji
+     * @param animated true if the emoji is animated; false otherwise
+     * @return the new (unknown) custom emoji instance
+     */
+    CustomEmoji getKnownCustomEmojiOrCreateCustomEmoji(long id, String name, boolean animated);
+
+    /**
      * Gets a collection with all roles the bot knows.
      *
      * @return A collection with all roles the bot knows.

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -1084,6 +1084,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * @param animated Whether the emoji is animated or not.
      * @return The emoji for the given json object.
      */
+    @Override
     public CustomEmoji getKnownCustomEmojiOrCreateCustomEmoji(long id, String name, boolean animated) {
         CustomEmoji emoji = customEmojis.get(id);
         return emoji == null ? new CustomEmojiImpl(this, id, name, animated) : emoji;


### PR DESCRIPTION
This will expose ``getKnownCustomEmojiOrCreateCustomEmoji`` to the public API of ``DiscordApi`` so one can get custom emoji objects that are not known to the current shard for use elsewhere in the Javacord API.