### PR TITLE
FIX: Separate Heartbeat Scheduler

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/util/concurrent/ThreadPool.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/concurrent/ThreadPool.java
@@ -24,6 +24,14 @@ public interface ThreadPool {
     ScheduledExecutorService getScheduler();
 
     /**
+     * Gets the used heart scheduler. 
+     * This scheduler is used to keep the bot connected to the gateway.
+     *
+     * @return The used heart scheduler.
+     */
+    ScheduledExecutorService getHeartScheduler();
+
+    /**
      * Gets the used daemon scheduler.
      *
      * @return The used daemon scheduler.

--- a/javacord-core/src/main/java/org/javacord/core/util/concurrent/ThreadPoolImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/concurrent/ThreadPoolImpl.java
@@ -29,6 +29,8 @@ public class ThreadPoolImpl implements ThreadPool {
             CORE_POOL_SIZE, new ThreadFactory("Javacord - Central Scheduler - %d", false));
     private final ScheduledExecutorService daemonScheduler = Executors.newScheduledThreadPool(
             CORE_POOL_SIZE, new ThreadFactory("Javacord - Central Daemon Scheduler - %d", true));
+    private final ScheduledExecutorService heartScheduler = Executors.newScheduledThreadPool(
+            CORE_POOL_SIZE, new ThreadFactory("Javacord - Heart Scheduler - %d", false));
     private final ConcurrentHashMap<String, ExecutorService> executorServiceSingleThreads = new ConcurrentHashMap<>();
 
     /**
@@ -39,6 +41,7 @@ public class ThreadPoolImpl implements ThreadPool {
         executorService.shutdown();
         scheduler.shutdown();
         daemonScheduler.shutdown();
+        heartScheduler.shutdown();
         executorServiceSingleThreads.values().forEach(ExecutorService::shutdown);
     }
 
@@ -55,6 +58,11 @@ public class ThreadPoolImpl implements ThreadPool {
     @Override
     public ScheduledExecutorService getDaemonScheduler() {
         return daemonScheduler;
+    }
+
+    @Override
+    public ScheduledExecutorService getHeartScheduler() {
+        return heartScheduler;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/Heart.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/Heart.java
@@ -92,7 +92,7 @@ public class Heart {
                 // If there was an old heart beating, crush it
                 future.cancel(false);
             }
-            return api.getThreadPool().getScheduler().scheduleWithFixedDelay(() -> {
+            return api.getThreadPool().getHeartScheduler().scheduleWithFixedDelay(() -> {
                 try {
                     if (heartbeatAckReceived.getAndSet(false)) {
                         beat();


### PR DESCRIPTION
Fixes #833 

This has been a bit of an ongoing discussion, as Beemo has been missing heartbeats during times of high-stress (such as login, queueing a bunch of REST calls, etc). While there may be a counterargument here that the Javacord schedulers should not be used for computations, it has definitely been a regular suggestion in the Javacord Discord to use the Javacord threadpools, and it doesn't say anywhere in the code that it is doing essential things like heartbeats (or else I doubt anyone would touch them).

This PR is an example of how I imagine a heartbeat scheduler would look in the current Javacord. While it is accessible to the wrapper user, it is properly labelled as the `Heart Scheduler` (notably, not `Heartbeat Scheduler`, because the class in Javacord for heartbeats is cutely named `Heart`!), so I highly doubt that anyone would make the mistake of using it for heavy computations, if even at all.

Note: While I don't think a heartbeat scheduler should be accessible to users, because of the way Javacord is currently designed around `ThreadPool.java` being accessible I don't think it would be a quick and easy PR to make otherwise.