### PR TITLE
Fix incoming interaction in unknown DM channels

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/handler/interaction/InteractionCreateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/interaction/InteractionCreateHandler.java
@@ -11,7 +11,10 @@ import org.javacord.api.event.interaction.MessageComponentCreateEvent;
 import org.javacord.api.event.interaction.SelectMenuChooseEvent;
 import org.javacord.api.event.interaction.SlashCommandCreateEvent;
 import org.javacord.api.interaction.InteractionType;
+import org.javacord.core.entity.channel.PrivateChannelImpl;
 import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.event.interaction.ButtonClickEventImpl;
 import org.javacord.core.event.interaction.InteractionCreateEventImpl;
 import org.javacord.core.event.interaction.MessageComponentCreateEventImpl;
@@ -44,7 +47,15 @@ public class InteractionCreateHandler extends PacketHandler {
     public void handle(JsonNode packet) {
         TextChannel channel = null;
         if (packet.hasNonNull("channel_id")) {
-            channel = api.getTextChannelById(packet.get("channel_id").asLong()).orElse(null);
+            long channelId = packet.get("channel_id").asLong();
+
+            // Check if this interaction comes from a guild or a DM
+            if (packet.hasNonNull("guild_id")) {
+                channel = api.getTextChannelById(channelId).orElse(null);
+            } else {
+                UserImpl user = new UserImpl(api, packet.get("user"), (MemberImpl) null, null);
+                channel = PrivateChannelImpl.getOrCreatePrivateChannel(api, channelId, user.getId(), user);
+            }
         }
 
         int typeId = packet.get("type").asInt();


### PR DESCRIPTION
Similar to past issues with DMs ( #524, #707, #732, #708 ), interaction don't work if they are spawned in an uncached DM channel.

Currently, this spawns this exception:
```
java.lang.NullPointerException: Cannot invoke "org.javacord.api.entity.channel.TextChannel.getMessageCache()" because "channel" is null
    at org.javacord.core.entity.message.MessageImpl.<init>(MessageImpl.java:178) ~[javacord-3.4.0-SNAPSHOT-shaded.jar:na]
    at org.javacord.core.interaction.MessageComponentInteractionImpl.<init>(MessageComponentInteractionImpl.java:46) ~[javacord-3.4.0-SNAPSHOT-shaded.jar:na]
    at org.javacord.core.interaction.ButtonInteractionImpl.<init>(ButtonInteractionImpl.java:18) ~[javacord-3.4.0-SNAPSHOT-shaded.jar:na]
```

Steps to reproduce:
- Start test bot
- Send yourself a DM from the bot with a button component
- Restart bot
- Click button
--> The interaction cannot be processed

This PR contains the fix for this issue similar to how we fixed the other related issues.