### PR TITLE
MessageBuilder and Component fixes

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderBaseDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderBaseDelegateImpl.java
@@ -27,7 +27,7 @@ import org.javacord.api.entity.message.mention.AllowedMentions;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.webhook.IncomingWebhook;
 import org.javacord.core.DiscordApiImpl;
-import org.javacord.core.entity.message.component.ActionRowImpl;
+import org.javacord.core.entity.message.component.ComponentImpl;
 import org.javacord.core.entity.message.embed.EmbedBuilderDelegateImpl;
 import org.javacord.core.entity.message.mention.AllowedMentionsImpl;
 import org.javacord.core.entity.user.Member;
@@ -712,10 +712,8 @@ public class MessageBuilderBaseDelegateImpl implements MessageBuilderBaseDelegat
     protected void prepareComponents(ObjectNode body, boolean evenIfEmpty) {
         if (evenIfEmpty || !components.isEmpty()) {
             ArrayNode componentsNode = JsonNodeFactory.instance.objectNode().arrayNode();
-            for (int i = 0; i < components.size() && i < 5; i++) {
-                ActionRowImpl component = (ActionRowImpl) components.get(i);
-                componentsNode.add(component.toJsonNode());
-            }
+            components.forEach(
+                    highLevelComponent -> componentsNode.add(((ComponentImpl) highLevelComponent).toJsonNode()));
             body.set("components", componentsNode);
         }
     }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/component/ActionRowImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/component/ActionRowImpl.java
@@ -51,11 +51,7 @@ public class ActionRowImpl extends ComponentImpl implements ActionRow {
         }
     }
 
-    /**
-     * Gets the ActionRow as a {@link ObjectNode}. This is what is sent to Discord.
-     *
-     * @return The button as a ObjectNode.
-     */
+    @Override
     public ObjectNode toJsonNode() {
         ObjectNode object = JsonNodeFactory.instance.objectNode();
         return toJsonNode(object);
@@ -71,7 +67,7 @@ public class ActionRowImpl extends ComponentImpl implements ActionRow {
     public ObjectNode toJsonNode(ObjectNode object) throws IllegalStateException {
         object.put("type", ComponentType.ACTION_ROW.value());
 
-        if (components.size() == 0) {
+        if (components.isEmpty()) {
             object.putArray("components");
             return object;
         }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/component/ButtonImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/component/ButtonImpl.java
@@ -108,11 +108,7 @@ public class ButtonImpl extends ComponentImpl implements Button {
         return Optional.ofNullable(emoji);
     }
 
-    /**
-     * Gets the button as a {@link ObjectNode}. This is what is sent to Discord.
-     *
-     * @return The button as a ObjectNode.
-     */
+    @Override
     public ObjectNode toJsonNode() {
         ObjectNode object = JsonNodeFactory.instance.objectNode();
         return toJsonNode(object);

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/component/ComponentImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/component/ComponentImpl.java
@@ -26,5 +26,10 @@ public abstract class ComponentImpl implements Component {
         return type;
     }
 
-    abstract ObjectNode toJsonNode();
+    /**
+     * Gets the Component as a {@link ObjectNode}. This is what is sent to Discord.
+     *
+     * @return The component as a ObjectNode.
+     */
+    public abstract ObjectNode toJsonNode();
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/component/SelectMenuImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/component/SelectMenuImpl.java
@@ -91,12 +91,8 @@ public class SelectMenuImpl extends ComponentImpl implements SelectMenu {
         return isDisabled;
     }
 
-    /**
-     * Gets the select menu as a {@link ObjectNode}. This is what is sent to Discord.
-     *
-     * @return The select menu as a ObjectNode.
-     */
-    ObjectNode toJsonNode() {
+    @Override
+    public ObjectNode toJsonNode() {
         ObjectNode object = JsonNodeFactory.instance.objectNode();
         return toJsonNode(object);
     }


### PR DESCRIPTION
- Fixed MessageBuilder logic that wasn't correctly adjusted for messages with multiple embeds
- Fixed hard coded actionrow size limit and `prepareComponents` in the MessageBuilder can now also add other HighLevelComponents(for the future)