### PR TITLE
Allow ephemeral deferred interaction responses

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/InteractionBase.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/InteractionBase.java
@@ -48,6 +48,18 @@ public interface InteractionBase extends DiscordEntity {
     CompletableFuture<InteractionOriginalResponseUpdater> respondLater();
 
     /**
+     * Sends an acknowledgement of the interaction to Discord and displays an (ephemeral) loading state to the user,
+     * indicating that you'll respond with a delay.
+     * Please note that you can only actually update this loading state message within 15 minutes after receiving the
+     * interaction.
+     *
+     * @param ephemeral wether or not the response should be ephemeral
+     * @return A CompletableFuture that completes as soon as the acknowledgement has been sent; it yields an updater
+     *     that should be used to update the message later on.
+     */
+    CompletableFuture<InteractionOriginalResponseUpdater> respondLater(boolean ephemeral);
+
+    /**
      * Create a message builder to send follow up messages for this interaction.
      * You can send, edit and delete follow up messages up to 15 minutes after you received the interaction.
      *

--- a/javacord-core/src/main/java/org/javacord/core/interaction/InteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/InteractionImpl.java
@@ -6,6 +6,7 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.Channel;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.TextChannel;
+import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.interaction.Interaction;
@@ -32,6 +33,10 @@ public abstract class InteractionImpl implements Interaction {
 
     private static final String RESPOND_LATER_BODY =
             "{\"type\": " + InteractionCallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE.getId() + "}";
+
+    private static final String RESPOND_LATER_EPHEMERAL_BODY =
+            "{\"type\": " + InteractionCallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE.getId()
+                    + ", \"data\": {\"flags\": " + MessageFlag.EPHEMERAL.getId() + "}}";
 
     private final DiscordApiImpl api;
     private final TextChannel channel;
@@ -98,10 +103,15 @@ public abstract class InteractionImpl implements Interaction {
 
     @Override
     public CompletableFuture<InteractionOriginalResponseUpdater> respondLater() {
+        return respondLater(false);
+    }
+
+    @Override
+    public CompletableFuture<InteractionOriginalResponseUpdater> respondLater(boolean ephemeral) {
         return new RestRequest<InteractionOriginalResponseUpdater>(this.api,
                 RestMethod.POST, RestEndpoint.INTERACTION_RESPONSE)
                 .setUrlParameters(getIdAsString(), token)
-                .setBody(RESPOND_LATER_BODY)
+                .setBody(ephemeral ? RESPOND_LATER_EPHEMERAL_BODY : RESPOND_LATER_BODY)
                 .execute(result -> new InteractionOriginalResponseUpdaterImpl(this));
     }
 


### PR DESCRIPTION
Deferred responses to interactions (type 5) can be ephemeral as well. This PR adds the ability to make the "XYZBot is thinking ... " loading state ephemeral.

I've chosen to overload the method to make this change not breaking.