### PR TITLE
Fix message updater

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -359,6 +359,16 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
+     * Creates a new {@link MessageUpdater} for this message that can be used similarly to a builder to edit this
+     * message.
+     *
+     * @return the new message updater
+     */
+    default MessageUpdater createUpdater() {
+        return new MessageUpdater(this);
+    }
+
+    /**
      * Removes the content of the message.
      *
      * @param api The discord api instance.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageUpdater.java
@@ -15,7 +15,6 @@ public class MessageUpdater extends MessageBuilderBase<MessageUpdater> {
      */
     public MessageUpdater(Message m) {
         super(MessageUpdater.class);
-        delegate.copy(m);
         this.message = m;
     }
 
@@ -27,7 +26,7 @@ public class MessageUpdater extends MessageBuilderBase<MessageUpdater> {
      * @return The edited message.
      */
     public CompletableFuture<Message> applyChanges() {
-        return delegate.edit(message, true);
+        return delegate.edit(message, false);
     }
 
     /**
@@ -37,6 +36,6 @@ public class MessageUpdater extends MessageBuilderBase<MessageUpdater> {
      * @return The edited message.
      */
     public CompletableFuture<Message> replaceMessage() {
-        return delegate.edit(message, false);
+        return delegate.edit(message, true);
     }
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/internal/MessageBuilderBaseDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/internal/MessageBuilderBaseDelegate.java
@@ -354,10 +354,11 @@ public interface MessageBuilderBaseDelegate {
      * Edits the message.
      *
      * @param message The message to edit.
-     * @param onlyChangedFields True if only changed fields should be updated
+     * @param allFields True if all fields should be included in the patch request, even if not changed; False if
+     *                  only changed fields should be patched
      * @return The edited message.
      */
-    CompletableFuture<Message> edit(Message message, boolean onlyChangedFields);
+    CompletableFuture<Message> edit(Message message, boolean allFields);
 
     /**
      * Sends the message.

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderBaseDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderBaseDelegateImpl.java
@@ -641,8 +641,8 @@ public class MessageBuilderBaseDelegateImpl implements MessageBuilderBaseDelegat
                                                                         ObjectNode body,
                                                                         RestRequest<Message> request) {
         request.setBody(body);
-        return request.execute(result -> ((DiscordApiImpl) channel.getApi())
-                .getOrCreateMessage(channel, result.getJsonBody()));
+        return request.execute(result -> new MessageImpl((DiscordApiImpl) channel.getApi(), channel,
+                result.getJsonBody()));
     }
 
     private void prepareAllowedMentions(ObjectNode body) {


### PR DESCRIPTION
Fixing two bugs in the message updater:
- Inverted behavior of "applyChanges" and "replaceMessage"
- Returned message was outdated / taken from cache; now uses data from the Discord response

Adds ``Message#createUpdater()`` as convenience method.