### PR TITLE
Elevate getAvatarHash to User

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -204,6 +204,13 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
     EnumSet<UserFlag> getUserFlags();
 
     /**
+     * Gets the avatar hash of the user.
+     *
+     * @return The avatar hash.
+     */
+    Optional<String> getAvatarHash();
+
+    /**
      * Gets the avatar of the user.
      *
      * @return The avatar of the user.

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
@@ -166,13 +166,9 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
         return Optional.ofNullable(member);
     }
 
-    /**
-     * Gets the avatar hash of the user.
-     *
-     * @return The avatar hash.
-     */
-    public String getAvatarHash() {
-        return avatarHash;
+    @Override
+    public Optional<String> getAvatarHash() {
+        return Optional.ofNullable(avatarHash);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildMemberUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildMemberUpdateHandler.java
@@ -164,7 +164,7 @@ public class GuildMemberUpdateHandler extends PacketHandler {
                         }
                         if (packet.get("user").has("avatar")) {
                             String newAvatarHash = packet.get("user").get("avatar").asText(null);
-                            String oldAvatarHash = oldUser.getAvatarHash();
+                            String oldAvatarHash = oldUser.getAvatarHash().orElse(null);
                             if (!Objects.deepEquals(newAvatarHash, oldAvatarHash)) {
                                 dispatchUserChangeAvatarEvent(updatedUser, newAvatarHash, oldAvatarHash);
                                 userChanged = true;


### PR DESCRIPTION
This PR is to make the `UserImpl#getAvatarHash` from the `javacord-core` accessible via the `User` class.

This is important, at least for me (and anyone else who wants to manage their own cache), so that the raw hash can be easily accessible / stored on the Javacord user's end. I am actually currently running on a patch myself (https://github.com/AyuAi/Javacord/commit/55e8ecb8d70d9469ff26329a5afff32b028be4a0) that elevated this method because I needed access to it to implement my own member/user cache on top of Javacord.