### PR TITLE
Allow the bot to bypass disabled user cache.

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -943,9 +943,10 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * @param member The member to add.
      */
     public void addMemberToCacheOrReplaceExisting(Member member) {
-        if (!isUserCacheEnabled()) {
+        if (!isUserCacheEnabled() && member.getId() != you.getId()) {
             return;
         }
+        
         entityCache.getAndUpdate(cache -> {
             Member oldMember = cache.getMemberCache()
                     .getMemberByIdAndServer(member.getId(), member.getServer().getId())


### PR DESCRIPTION
Personally, I don't know whether this is really needed but for many bots, the disabled user cache breaks methods like `canYouManageServer` or other similar methods for the bot. I personally needed those methods to function which is why I monkey-patched this, some bots may also need the bot to be on the cache, so I decided to make a PR.

If you think that this PR or the intention of the PR doesn't really fit well with Javacord, feel free to close this PR.

Checks:
- ✔️ Codestyle.

Tests:
- ✔️ Actual production deployment on a bot.