### PR TITLE
Discord now provides the message for interactions on ephemeral messages

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/MessageComponentInteractionBase.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/MessageComponentInteractionBase.java
@@ -3,7 +3,6 @@ package org.javacord.api.interaction;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.component.ComponentType;
 import org.javacord.api.interaction.callback.ComponentInteractionOriginalMessageUpdater;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public interface MessageComponentInteractionBase extends InteractionBase {
@@ -13,14 +12,7 @@ public interface MessageComponentInteractionBase extends InteractionBase {
      *
      * @return The message.
      */
-    Optional<Message> getMessage();
-
-    /**
-     * Gets the message ID that this interaction is related to.
-     *
-     * @return The message ID.
-     */
-    long getMessageId();
+    Message getMessage();
 
     /**
      * Get the identifier of the clicked component.

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionMessageBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionMessageBuilderDelegateImpl.java
@@ -112,7 +112,7 @@ public class InteractionMessageBuilderDelegateImpl extends MessageBuilderBaseDel
     @Override
     public void copy(InteractionBase interaction) {
         ((InteractionImpl) interaction).asMessageComponentInteraction()
-                .flatMap(MessageComponentInteraction::getMessage)
+                .map(MessageComponentInteraction::getMessage)
                 .ifPresent(this::copy);
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/interaction/MessageComponentInteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/MessageComponentInteractionImpl.java
@@ -3,7 +3,6 @@ package org.javacord.core.interaction;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.Message;
-import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.entity.message.component.ComponentType;
 import org.javacord.api.interaction.InteractionType;
 import org.javacord.api.interaction.MessageComponentInteraction;
@@ -14,7 +13,6 @@ import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
 import org.javacord.core.util.rest.RestRequest;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class MessageComponentInteractionImpl extends InteractionImpl implements MessageComponentInteraction {
@@ -24,27 +22,18 @@ public abstract class MessageComponentInteractionImpl extends InteractionImpl im
 
     private final Message message;
     private final String customId;
-    private final long messageId;
 
     /**
      * Class constructor.
      *
-     * @param api The api instance.
-     * @param channel The channel in which the interaction happened. Can be {@code null}.
+     * @param api      The api instance.
+     * @param channel  The channel in which the interaction happened. Can be {@code null}.
      * @param jsonData The json data of the interaction.
      */
     public MessageComponentInteractionImpl(DiscordApiImpl api, TextChannel channel, JsonNode jsonData) {
         super(api, channel, jsonData);
 
-        JsonNode messageNode = jsonData.get("message");
-        messageId = messageNode.get("id").asLong();
-
-        //Check is needed due to the message not being completely provided if it's ephemeral.
-        if (messageNode.has("flags") && (messageNode.get("flags").asInt() & MessageFlag.EPHEMERAL.getId()) != 0) {
-            message = null;
-        } else {
-            message = new MessageImpl(api, channel, jsonData.get("message"));
-        }
+        message = new MessageImpl(api, channel, jsonData.get("message"));
 
         JsonNode data = jsonData.get("data");
         this.customId = data.get("custom_id").asText();
@@ -70,13 +59,8 @@ public abstract class MessageComponentInteractionImpl extends InteractionImpl im
     }
 
     @Override
-    public Optional<Message> getMessage() {
-        return Optional.ofNullable(message);
-    }
-
-    @Override
-    public long getMessageId() {
-        return messageId;
+    public Message getMessage() {
+        return message;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/interaction/InteractionCreateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/interaction/InteractionCreateHandler.java
@@ -119,7 +119,7 @@ public class InteractionCreateHandler extends PacketHandler {
             case MESSAGE_COMPONENT:
                 MessageComponentCreateEvent messageComponentCreateEvent =
                         new MessageComponentCreateEventImpl(interaction);
-                long messageId = messageComponentCreateEvent.getMessageComponentInteraction().getMessageId();
+                long messageId = messageComponentCreateEvent.getMessageComponentInteraction().getMessage().getId();
                 api.getEventDispatcher().dispatchMessageComponentCreateEvent(
                         server == null ? api : server,
                         messageId,


### PR DESCRIPTION
This includes 2 breaking changes:
Removed `MessageComponentInteractionBase#getMessageId`
Changed method signature: `MessageComponentInteractionBase#getMessage` from returning `Optional<Message>` to `Message`