### PR TITLE
Removed deprecated methods.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -370,7 +370,6 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
         return api.getUncachedMessageUtil().edit(channelId, messageId, content, updateContent, embeds, updateEmbed);
     }
 
-
     /**
      * Updates the content and the embed of the message.
      *
@@ -866,17 +865,6 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     Optional<MessageReference> getMessageReference();
 
     /**
-     * Gets the id of the referenced message.
-     *
-     * @return The id of the referenced message.
-     * @deprecated Use {@link #getMessageReference()} instead.
-     */
-    @Deprecated
-    default Optional<Long> getReferencedMessageId() {
-        return getMessageReference().flatMap(MessageReference::getMessageId);
-    }
-
-    /**
      * Gets the message referenced with a reply.
      * Only present if this message is type {@code MessageType.REPLY},
      * discord decided to send it and the message hasn't been deleted.
@@ -893,11 +881,10 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return The referenced message.
      */
     default Optional<CompletableFuture<Message>> requestReferencedMessage() {
-        return getReferencedMessageId().map(id ->
+        return getReferencedMessage().map(message ->
                 getReferencedMessage().map(CompletableFuture::completedFuture)
-                        .orElseGet(() -> getApi().getMessageById(id, getChannel())));
+                        .orElseGet(() -> getApi().getMessageById(message.getId(), getChannel())));
     }
-
 
     /**
      * Checks if the message is kept in cache forever.
@@ -970,17 +957,6 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
                     .ifPresent(mentionedChannels::add);
         }
         return Collections.unmodifiableList(mentionedChannels);
-    }
-
-    /**
-     * Checks if the message was sent in a {@link ChannelType#PRIVATE_CHANNEL private channel}.
-     *
-     * @return Whether the message was sent in a private channel.
-     * @deprecated Use {@link Message#isPrivateMessage()} instead.
-     */
-    @Deprecated // Deprecated to be consistent with #isServerMessage() and #isGroupMessage()
-    default boolean isPrivate() {
-        return getChannel().getType() == ChannelType.PRIVATE_CHANNEL;
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/util/ratelimit/LocalRatelimiter.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/ratelimit/LocalRatelimiter.java
@@ -45,19 +45,6 @@ public class LocalRatelimiter implements Ratelimiter {
      * Creates a new local ratelimiter.
      *
      * @param amount The amount available per reset interval.
-     * @param seconds The time to wait until the available quota resets.
-     * @deprecated Use {@link #LocalRatelimiter(int, Duration)} instead.
-     */
-    @Deprecated
-    public LocalRatelimiter(int amount, int seconds) {
-        this.amount = amount;
-        bucketDuration = Duration.ofSeconds(seconds);
-    }
-
-    /**
-     * Creates a new local ratelimiter.
-     *
-     * @param amount The amount available per reset interval.
      * @param bucketDuration The time to wait until the available quota resets.
      */
     public LocalRatelimiter(int amount, Duration bucketDuration) {
@@ -81,17 +68,6 @@ public class LocalRatelimiter implements Ratelimiter {
      */
     public Duration getBucketDuration() {
         return bucketDuration;
-    }
-
-    /**
-     * Gets the time to wait until the available quota resets in seconds.
-     *
-     * @return The time to wait until the available quota resets.
-     * @deprecated Use {@link #getBucketDuration()} instead.
-     */
-    @Deprecated
-    public int getSeconds() {
-        return (int) bucketDuration.getSeconds();
     }
 
     /**


### PR DESCRIPTION
- Message#isPrivate has been removed in favor of Message#isPrivateMessage.
- Message#getReferencedMessageId has been removed in favor of Message#getReferencedMessage.
- LocalRatelimiter(int, int) constructor has been removed in favor of LocalRatelimiter(int, Duration).
- LocalRatelimiter#getSeconds has been removed in favor of LocalRatelimiter#getBucketDuration.