### PR TITLE
Move from deprecated "embed" field to "embeds" in UncachedMessageUtil.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -44,9 +44,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Returns a {@code MessageBuilder} according to this {@code Message}.
      *
-     * @see MessageBuilder#fromMessage(Message)
-     *
      * @return The {@code MessageBuilder}.
+     * @see MessageBuilder#fromMessage(Message)
      */
     default MessageBuilder toMessageBuilder() {
         return MessageBuilder.fromMessage(this);
@@ -55,18 +54,17 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Returns a {@code WebhookMessageBuilder} according to this {@code Message}.
      *
-     * @see WebhookMessageBuilder#fromMessage(Message)
-     *
      * @return The {@code WebhookMessageBuilder}.
+     * @see WebhookMessageBuilder#fromMessage(Message)
      */
     default WebhookMessageBuilder toWebhookMessageBuilder() {
         return WebhookMessageBuilder.fromMessage(this);
     }
 
     /**
-     * Cross posts the message if it is in a announcement channel.
+     * Cross posts the message if it is in an announcement channel.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return The new message object.
@@ -76,7 +74,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Cross posts the message if it is in a announcement channel.
+     * Cross posts the message if it is in an announcement channel.
      *
      * @return The new message object.
      */
@@ -87,7 +85,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Deletes the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to tell us if the deletion was successful.
@@ -99,7 +97,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Deletes the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to tell us if the deletion was successful.
@@ -111,10 +109,10 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Deletes the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param reason The audit log reason for the deletion.
+     * @param reason    The audit log reason for the deletion.
      * @return A future to tell us if the deletion was successful.
      */
     static CompletableFuture<Void> delete(DiscordApi api, long channelId, long messageId, String reason) {
@@ -124,10 +122,10 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Deletes the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param reason The audit log reason for the deletion.
+     * @param reason    The audit log reason for the deletion.
      * @return A future to tell us if the deletion was successful.
      */
     static CompletableFuture<Void> delete(DiscordApi api, String channelId, String messageId, String reason) {
@@ -159,8 +157,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * Messages younger than two weeks are sent in batches of 100 messages to the bulk delete API,
      * older messages are deleted with individual delete requests.
      *
-     * @param api The discord api instance.
-     * @param channelId The id of the message's channel.
+     * @param api        The discord api instance.
+     * @param channelId  The id of the message's channel.
      * @param messageIds The ids of the messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
@@ -174,8 +172,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * Messages younger than two weeks are sent in batches of 100 messages to the bulk delete API,
      * older messages are deleted with individual delete requests.
      *
-     * @param api The discord api instance.
-     * @param channelId The id of the message's channel.
+     * @param api        The discord api instance.
+     * @param channelId  The id of the message's channel.
      * @param messageIds The ids of the messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
@@ -189,7 +187,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * Messages younger than two weeks are sent in batches of 100 messages to the bulk delete API,
      * older messages are deleted with individual delete requests.
      *
-     * @param api The discord api instance.
+     * @param api      The discord api instance.
      * @param messages The messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
@@ -203,7 +201,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * Messages younger than two weeks are sent in batches of 100 messages to the bulk delete API,
      * older messages are deleted with individual delete requests.
      *
-     * @param api The discord api instance.
+     * @param api      The discord api instance.
      * @param messages The messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
@@ -214,117 +212,191 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Updates the content of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param content The new content of the message.
+     * @param content   The new content of the message.
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, String content) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, null, false);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content);
     }
 
     /**
      * Updates the content of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param content The new content of the message.
+     * @param content   The new content of the message.
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, String content) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, null, false);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), false);
     }
 
     /**
      * Updates the embed of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param embed The new embed of the message.
+     * @param embed     The new embed of the message.
+     * @param embeds    One or more additional new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, EmbedBuilder embed) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embed, true);
+    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, EmbedBuilder embed,
+                                           EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embedBuilders, true);
     }
 
     /**
      * Updates the embed of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param embed The new embed of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, EmbedBuilder embed) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embed, true);
+    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, List<EmbedBuilder> embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
+    }
+
+    /**
+     * Updates the embed of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embed     The new embed of the message.
+     * @param embeds    One or more additional new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId,
+                                           EmbedBuilder embed, EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embedBuilders, true);
+    }
+
+    /**
+     * Updates the embed of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId,
+                                           List<EmbedBuilder> embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
     }
 
     /**
      * Updates the content and the embed of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param content The new content of the message.
-     * @param embed The new embed of the message.
+     * @param content   The new content of the message.
+     * @param embed     The new embed of the message.
+     * @param embeds    One or more additional new embeds of the message.
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(
-            DiscordApi api, long channelId, long messageId, String content, EmbedBuilder embed) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, embed, true);
+            DiscordApi api, long channelId, long messageId, String content, EmbedBuilder embed,
+            EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, embedBuilders, true);
     }
 
     /**
      * Updates the content and the embed of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param content The new content of the message.
-     * @param embed The new embed of the message.
+     * @param content   The new content of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(
-            DiscordApi api, String channelId, String messageId, String content, EmbedBuilder embed) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, embed, true);
+            DiscordApi api, long channelId, long messageId, String content, List<EmbedBuilder> embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, embeds, true);
     }
 
     /**
      * Updates the content and the embed of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param content The new content of the message.
+     * @param content   The new content of the message.
+     * @param embed     The new embed of the message.
+     * @param embeds    One or more additional new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(
+            DiscordApi api, String channelId, String messageId, String content, EmbedBuilder embed,
+            EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, embedBuilders, true);
+    }
+
+    /**
+     * Updates the content and the embed of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param content   The new content of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(
+            DiscordApi api, String channelId, String messageId, String content, List<EmbedBuilder> embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, embeds, true);
+    }
+
+    /**
+     * Updates the content and the embed of the message.
+     *
+     * @param api           The discord api instance.
+     * @param channelId     The id of the message's channel.
+     * @param messageId     The id of the message.
+     * @param content       The new content of the message.
      * @param updateContent Whether to update or remove the content.
-     * @param embed The new embed of the message.
-     * @param updateEmbed Whether to update or remove the embed.
+     * @param embeds        An array of the new embeds of the message.
+     * @param updateEmbed   Whether to update or remove the embed.
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, String content,
-                                        boolean updateContent, EmbedBuilder embed, boolean updateEmbed) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, updateContent, embed, updateEmbed);
+                                           boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, updateContent, embeds, updateEmbed);
     }
+
 
     /**
      * Updates the content and the embed of the message.
      *
-     * @param api The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param content The new content of the message.
+     * @param api           The discord api instance.
+     * @param channelId     The id of the message's channel.
+     * @param messageId     The id of the message.
+     * @param content       The new content of the message.
      * @param updateContent Whether to update or remove the content.
-     * @param embed The new embed of the message.
-     * @param updateEmbed Whether to update or remove the embed.
+     * @param embeds        An array of the new embeds of the message.
+     * @param updateEmbed   Whether to update or remove the embed.
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, String content,
-                                        boolean updateContent, EmbedBuilder embed, boolean updateEmbed) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, updateContent, embed, updateEmbed);
+                                           boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, updateContent, embeds, updateEmbed);
     }
 
     /**
@@ -334,28 +406,55 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to check if the update was successful.
      */
     default CompletableFuture<Message> edit(String content) {
-        return Message.edit(getApi(), getChannel().getId(), getId(), content, true, null, false);
+        return new MessageUpdater(this).setContent(content).applyChanges();
     }
 
     /**
      * Updates the embed of the message.
      *
-     * @param embed The new embed of the message.
+     * @param embed  The new embed of the message.
+     * @param embeds One or more additional new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> edit(EmbedBuilder embed) {
-        return Message.edit(getApi(), getChannel().getId(), getId(), null, false, embed, true);
+    default CompletableFuture<Message> edit(EmbedBuilder embed, EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return new MessageUpdater(this).addEmbeds(embedBuilders).applyChanges();
+    }
+
+    /**
+     * Updates the embed of the message.
+     *
+     * @param embeds An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(List<EmbedBuilder> embeds) {
+        return new MessageUpdater(this).addEmbeds(embeds).applyChanges();
     }
 
     /**
      * Updates the content and the embed of the message.
      *
      * @param content The new content of the message.
-     * @param embed The new embed of the message.
+     * @param embed   The new embed of the message.
+     * @param embeds  One or more additional new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> edit(String content, EmbedBuilder embed) {
-        return Message.edit(getApi(), getChannel().getId(), getId(), content, true, embed, true);
+    default CompletableFuture<Message> edit(String content, EmbedBuilder embed, EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return new MessageUpdater(this).setContent(content).addEmbeds(embedBuilders).applyChanges();
+    }
+
+    /**
+     * Updates the content and the embed of the message.
+     *
+     * @param content The new content of the message.
+     * @param embeds  An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(String content, List<EmbedBuilder> embeds) {
+        return new MessageUpdater(this).setContent(content).addEmbeds(embeds).applyChanges();
     }
 
     /**
@@ -371,25 +470,25 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Removes the content of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to check if the removal was successful.
      */
     static CompletableFuture<Message> removeContent(DiscordApi api, long channelId, long messageId) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, null, false);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, "");
     }
 
     /**
      * Removes the content of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to check if the removal was successful.
      */
     static CompletableFuture<Message> removeContent(DiscordApi api, String channelId, String messageId) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, null, false);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, Collections.emptyList(), false);
     }
 
     /**
@@ -398,32 +497,31 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to check if the removal was successful.
      */
     default CompletableFuture<Message> removeContent() {
-        return Message.edit(getApi(), getChannel().getId(), getId(), null, true, null, false);
+        return new MessageUpdater(this).setContent("").applyChanges();
     }
-
 
     /**
      * Removes the embed of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to check if the removal was successful.
      */
     static CompletableFuture<Message> removeEmbed(DiscordApi api, long channelId, long messageId) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, null, true);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, Collections.emptyList(), true);
     }
 
     /**
      * Removes the embed of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to check if the removal was successful.
      */
     static CompletableFuture<Message> removeEmbed(DiscordApi api, String channelId, String messageId) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, null, true);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, Collections.emptyList(), true);
     }
 
     /**
@@ -432,31 +530,31 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to check if the removal was successful.
      */
     default CompletableFuture<Message> removeEmbed() {
-        return Message.edit(getApi(), getChannel().getId(), getId(), null, false, null, true);
+        return new MessageUpdater(this).addEmbeds(Collections.emptyList()).applyChanges();
     }
 
     /**
      * Removes the content and embed of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to check if the removal was successful.
      */
     static CompletableFuture<Message> removeContentAndEmbed(DiscordApi api, long channelId, long messageId) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, null, true);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, Collections.emptyList(), true);
     }
 
     /**
      * Removes the content and embed of the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to check if the removal was successful.
      */
     static CompletableFuture<Message> removeContentAndEmbed(DiscordApi api, String channelId, String messageId) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, null, true);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, Collections.emptyList(), true);
     }
 
     /**
@@ -465,16 +563,16 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to check if the removal was successful.
      */
     default CompletableFuture<Message> removeContentAndEmbed() {
-        return Message.edit(getApi(), getChannel().getId(), getId(), null, true, null, true);
+        return new MessageUpdater(this).setContent("").addEmbeds(Collections.emptyList()).applyChanges();
     }
 
 
     /**
      * Adds a unicode reaction to the message.
      *
-     * @param api The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
+     * @param api          The discord api instance.
+     * @param channelId    The id of the message's channel.
+     * @param messageId    The id of the message.
      * @param unicodeEmoji The unicode emoji string.
      * @return A future to tell us if the action was successful.
      */
@@ -485,9 +583,9 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Adds a unicode reaction to the message.
      *
-     * @param api The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
+     * @param api          The discord api instance.
+     * @param channelId    The id of the message's channel.
+     * @param messageId    The id of the message.
      * @param unicodeEmoji The unicode emoji string.
      * @return A future to tell us if the action was successful.
      */
@@ -511,10 +609,10 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Adds a reaction to the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param emoji The emoji.
+     * @param emoji     The emoji.
      * @return A future to tell us if the action was successful.
      */
     static CompletableFuture<Void> addReaction(DiscordApi api, long channelId, long messageId, Emoji emoji) {
@@ -535,10 +633,10 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Adds a reaction to the message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param emoji The emoji.
+     * @param emoji     The emoji.
      * @return A future to tell us if the action was successful.
      */
     static CompletableFuture<Void> addReaction(DiscordApi api, String channelId, String messageId, Emoji emoji) {
@@ -548,7 +646,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Deletes all reactions on this message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to tell us if the deletion was successful.
@@ -560,7 +658,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Deletes all reactions on this message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to tell us if the deletion was successful.
@@ -581,7 +679,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Pins this message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to tell us if the pin was successful.
@@ -593,7 +691,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Pins this message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to tell us if the pin was successful.
@@ -614,7 +712,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Unpins this message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to tell us if the action was successful.
@@ -626,7 +724,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Unpins this message.
      *
-     * @param api The discord api instance.
+     * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @return A future to tell us if the action was successful.
@@ -687,7 +785,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     *  Gets the link leading to this message.
+     * Gets the link leading to this message.
      *
      * @return The message link.
      * @throws AssertionError If the link is malformed.
@@ -813,8 +911,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      */
     default Optional<CompletableFuture<Message>> requestReferencedMessage() {
         return getReferencedMessageId().map(id ->
-                        getReferencedMessage().map(CompletableFuture::completedFuture)
-                .orElseGet(() -> getApi().getMessageById(id, getChannel())));
+                getReferencedMessage().map(CompletableFuture::completedFuture)
+                        .orElseGet(() -> getApi().getMessageById(id, getChannel())));
     }
 
 
@@ -826,9 +924,9 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     boolean isCachedForever();
 
     /**
-     * Sets if the the message is kept in cache forever.
+     * Sets if the message is kept in cache forever.
      *
-     * @param cachedForever  Whether the message should be kept in cache forever or not.
+     * @param cachedForever Whether the message should be kept in cache forever or not.
      */
     void setCachedForever(boolean cachedForever);
 
@@ -887,7 +985,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Checks if the message was sent in a {@link ChannelType#PRIVATE_CHANNEL private channel}.
      *
-     * @return Whether or not the message was sent in a private channel.
+     * @return Whether the message was sent in a private channel.
      * @deprecated Use {@link Message#isPrivateMessage()} instead.
      */
     @Deprecated // Deprecated to be consistent with #isServerMessage() and #isGroupMessage()
@@ -898,7 +996,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Checks if the message was sent in a {@link ChannelType#PRIVATE_CHANNEL private channel}.
      *
-     * @return Whether or not the message was sent in a private channel.
+     * @return Whether the message was sent in a private channel.
      */
     default boolean isPrivateMessage() {
         return getChannel().getType() == ChannelType.PRIVATE_CHANNEL;
@@ -907,7 +1005,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Checks if the message was sent in a {@link ChannelType#SERVER_TEXT_CHANNEL server channel}.
      *
-     * @return Whether or not the message was sent in a server channel.
+     * @return Whether the message was sent in a server channel.
      */
     default boolean isServerMessage() {
         return getChannel().getType() == ChannelType.SERVER_TEXT_CHANNEL;
@@ -916,7 +1014,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Checks if the message was sent in a {@link ChannelType#GROUP_CHANNEL group channel}.
      *
-     * @return Whether or not the message was sent in a group channel.
+     * @return Whether the message was sent in a group channel.
      */
     default boolean isGroupMessage() {
         return getChannel().getType() == ChannelType.GROUP_CHANNEL;
@@ -968,7 +1066,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Removes a user from the list of reactors of a given emoji reaction.
      *
-     * @param user The user to remove.
+     * @param user  The user to remove.
      * @param emoji The emoji of the reaction.
      * @return A future to tell us if the deletion was successful.
      */
@@ -979,7 +1077,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Removes a user from the list of reactors of a given unicode emoji reaction.
      *
-     * @param user The user to remove.
+     * @param user         The user to remove.
      * @param unicodeEmoji The unicode emoji of the reaction.
      * @return A future to tell us if the deletion was successful.
      */
@@ -1009,7 +1107,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Removes a user from the list of reactors of the given emoji reactions.
      *
-     * @param user The user to remove.
+     * @param user   The user to remove.
      * @param emojis The emojis of the reactions.
      * @return A future to tell us if the deletion was successful.
      */
@@ -1024,7 +1122,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * Removes a user from the list of reactors of the given unicode emoji reactions.
      *
      * @param unicodeEmojis The unicode emojis of the reactions.
-     * @param user The user to remove.
+     * @param user          The user to remove.
      * @return A future to tell us if the deletion was successful.
      */
     CompletableFuture<Void> removeReactionsByEmoji(User user, String... unicodeEmojis);
@@ -1300,7 +1398,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Gets all messages between this messages and the given message, excluding the boundaries.
+     * Gets all messages between this message and the given message, excluding the boundaries.
      *
      * @param other The id of the other boundary messages.
      * @return The messages.
@@ -1312,7 +1410,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Gets all messages between this messages and the given message, excluding the boundaries.
+     * Gets all messages between this message and the given message, excluding the boundaries.
      *
      * @param other The other boundary messages.
      * @return The messages.
@@ -1328,7 +1426,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * given condition is found.
      * If no message matches the condition, an empty set is returned.
      *
-     * @param other The id of the other boundary messages.
+     * @param other     The id of the other boundary messages.
      * @param condition The abort condition for when to stop retrieving messages.
      * @return The messages.
      * @see TextChannel#getMessagesBetweenUntil(Predicate, long, long)
@@ -1343,7 +1441,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * given condition is found.
      * If no message matches the condition, an empty set is returned.
      *
-     * @param other The other boundary messages.
+     * @param other     The other boundary messages.
      * @param condition The abort condition for when to stop retrieving messages.
      * @return The messages.
      * @see TextChannel#getMessagesBetweenUntil(Predicate, long, long)
@@ -1358,7 +1456,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * given condition.
      * If the first message does not match the condition, an empty set is returned.
      *
-     * @param other The id of the other boundary messages.
+     * @param other     The id of the other boundary messages.
      * @param condition The condition that has to be met.
      * @return The messages.
      * @see TextChannel#getMessagesBetweenWhile(Predicate, long, long)
@@ -1373,7 +1471,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * given condition.
      * If the first message does not match the condition, an empty set is returned.
      *
-     * @param other The other boundary messages.
+     * @param other     The other boundary messages.
      * @param condition The condition that has to be met.
      * @return The messages.
      * @see TextChannel#getMessagesBetweenWhile(Predicate, long, long)

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageBuilderBase.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageBuilderBase.java
@@ -13,6 +13,8 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
 
 abstract class MessageBuilderBase<T> {
     private final Class<T> myClass;
@@ -151,6 +153,18 @@ abstract class MessageBuilderBase<T> {
      */
     public T setEmbeds(EmbedBuilder... embeds) {
         delegate.removeAllEmbeds();
+        delegate.addEmbeds(Arrays.asList(embeds));
+        return myClass.cast(this);
+    }
+
+    /**
+     * Sets multiple embeds of the message (overrides all existing embeds).
+     *
+     * @param embeds The embed to set.
+     * @return The current instance in order to chain call methods.
+     */
+    public T setEmbeds(List<EmbedBuilder> embeds) {
+        delegate.removeAllEmbeds();
         delegate.addEmbeds(embeds);
         return myClass.cast(this);
     }
@@ -159,7 +173,7 @@ abstract class MessageBuilderBase<T> {
      * Adds an embed to the message.
      *
      * @param embed The embed to add.
-     * @return The current isntance in order to chain call methods.
+     * @return The current instance in order to chain call methods.
      */
     public T addEmbed(EmbedBuilder embed) {
         delegate.addEmbed(embed);
@@ -482,6 +496,17 @@ abstract class MessageBuilderBase<T> {
      * @return The current instance in order to chain call methods.
      */
     public T addEmbeds(EmbedBuilder... embeds) {
+        delegate.addEmbeds(Arrays.asList(embeds));
+        return myClass.cast(this);
+    }
+
+    /**
+     * Adds the embeds to the message.
+     *
+     * @param embeds The embeds to add.
+     * @return The current instance in order to chain call methods.
+     */
+    public T addEmbeds(List<EmbedBuilder> embeds) {
         delegate.addEmbeds(embeds);
         return myClass.cast(this);
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Messageable.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Messageable.java
@@ -5,6 +5,10 @@ import org.javacord.api.entity.message.embed.EmbedBuilder;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -15,11 +19,11 @@ public interface Messageable {
     /**
      * Sends a message.
      *
-     * @param content The content of the message.
-     * @param embed The embed which should be displayed.
-     * @param tts Whether the message should be "text to speech" or not.
-     * @param nonce The nonce of the message.
-     * @param stream The stream for the file to send.
+     * @param content  The content of the message.
+     * @param embed    The embed which should be displayed.
+     * @param tts      Whether the message should be "text to speech" or not.
+     * @param nonce    The nonce of the message.
+     * @param stream   The stream for the file to send.
      * @param fileName The name of the file.
      * @return The sent message.
      */
@@ -38,10 +42,10 @@ public interface Messageable {
      * Sends a message.
      *
      * @param content The content of the message.
-     * @param embed The embed which should be displayed.
-     * @param tts Whether the message should be "text to speech" or not.
-     * @param nonce The nonce of the message.
-     * @param files The file(s) to send.
+     * @param embed   The embed which should be displayed.
+     * @param tts     Whether the message should be "text to speech" or not.
+     * @param nonce   The nonce of the message.
+     * @param files   The file(s) to send.
      * @return The sent message.
      */
     default CompletableFuture<Message> sendMessage(
@@ -61,9 +65,9 @@ public interface Messageable {
      * Sends a message.
      *
      * @param content The content of the message.
-     * @param embed The embed which should be displayed.
-     * @param tts Whether the message should be "text to speech" or not.
-     * @param nonce The nonce of the message.
+     * @param embed   The embed which should be displayed.
+     * @param tts     Whether the message should be "text to speech" or not.
+     * @param nonce   The nonce of the message.
      * @return The sent message.
      */
     default CompletableFuture<Message> sendMessage(String content, EmbedBuilder embed, boolean tts, String nonce) {
@@ -78,17 +82,31 @@ public interface Messageable {
     /**
      * Sends a message.
      *
-     * @param content The content of the message.
-     * @param embed The embed which should be displayed.
+     * @param content    The content of the message.
+     * @param embed      The embed which should be displayed.
      * @param components High level components to add to the message, most probably of type ActionRow.
      * @return The sent message.
      */
     default CompletableFuture<Message> sendMessage(String content,
                                                    EmbedBuilder embed,
                                                    HighLevelComponent... components) {
+        return sendMessage(content, Collections.singletonList(embed), components);
+    }
+
+    /**
+     * Sends a message.
+     *
+     * @param content    The content of the message.
+     * @param embeds     A list of embeds which should be displayed.
+     * @param components High level components to add to the message, most probably of type ActionRow.
+     * @return The sent message.
+     */
+    default CompletableFuture<Message> sendMessage(String content,
+                                                   List<EmbedBuilder> embeds,
+                                                   HighLevelComponent... components) {
         return new MessageBuilder()
                 .append(content == null ? "" : content)
-                .setEmbed(embed)
+                .setEmbeds(embeds)
                 .addComponents(components)
                 .send(this);
     }
@@ -97,20 +115,22 @@ public interface Messageable {
      * Sends a message.
      *
      * @param content The content of the message.
-     * @param embed The embed which should be displayed.
+     * @param embed   The embed which should be displayed.
+     * @param embeds  One or more additional embeds which should be displayed.
      * @return The sent message.
      */
-    default CompletableFuture<Message> sendMessage(String content, EmbedBuilder embed) {
+    default CompletableFuture<Message> sendMessage(String content, EmbedBuilder embed, EmbedBuilder... embeds) {
         return new MessageBuilder()
                 .append(content == null ? "" : content)
                 .setEmbed(embed)
+                .addEmbeds(embeds)
                 .send(this);
     }
 
     /**
      * Sends a message.
      *
-     * @param content The content of the message.
+     * @param content    The content of the message.
      * @param components High level components to add to the message, most probably of type ActionRow.
      * @return The sent message.
      */
@@ -136,13 +156,24 @@ public interface Messageable {
     /**
      * Sends a message.
      *
-     * @param embed The embed which should be displayed.
+     * @param embed      The embed which should be displayed.
      * @param components High level components to add to the message, most probably of type ActionRow.
      * @return The sent message.
      */
     default CompletableFuture<Message> sendMessage(EmbedBuilder embed, HighLevelComponent... components) {
+        return sendMessage(Collections.singletonList(embed), components);
+    }
+
+    /**
+     * Sends a message.
+     *
+     * @param embeds     A list of embeds which should be displayed.
+     * @param components High level components to add to the message, most probably of type ActionRow.
+     * @return The sent message.
+     */
+    default CompletableFuture<Message> sendMessage(List<EmbedBuilder> embeds, HighLevelComponent... components) {
         return new MessageBuilder()
-                .setEmbed(embed)
+                .setEmbeds(embeds)
                 .addComponents(components)
                 .send(this);
     }
@@ -150,12 +181,25 @@ public interface Messageable {
     /**
      * Sends a message.
      *
-     * @param embed The embed which should be displayed.
+     * @param embed  The embed which should be displayed.
+     * @param embeds One or more additional embeds new embed of the message.
      * @return The sent message.
      */
-    default CompletableFuture<Message> sendMessage(EmbedBuilder embed) {
+    default CompletableFuture<Message> sendMessage(EmbedBuilder embed, EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return sendMessage(embedBuilders);
+    }
+
+    /**
+     * Sends a message.
+     *
+     * @param embeds A list of embeds which should be displayed.
+     * @return The sent message.
+     */
+    default CompletableFuture<Message> sendMessage(List<EmbedBuilder> embeds) {
         return new MessageBuilder()
-                .setEmbed(embed)
+                .setEmbeds(embeds)
                 .send(this);
     }
 
@@ -176,7 +220,7 @@ public interface Messageable {
     /**
      * Sends a message.
      *
-     * @param stream The stream for the file to send.
+     * @param stream   The stream for the file to send.
      * @param fileName The name of the file.
      * @return The sent message.
      */
@@ -190,7 +234,7 @@ public interface Messageable {
      * Sends a message.
      *
      * @param content The content of the message.
-     * @param files The file(s) to send.
+     * @param files   The file(s) to send.
      * @return The sent message.
      */
     default CompletableFuture<Message> sendMessage(String content, File... files) {
@@ -205,8 +249,8 @@ public interface Messageable {
     /**
      * Sends a message.
      *
-     * @param content The content of the message.
-     * @param stream The stream for the file to send.
+     * @param content  The content of the message.
+     * @param stream   The stream for the file to send.
      * @param fileName The name of the file.
      * @return The sent message.
      */
@@ -225,8 +269,19 @@ public interface Messageable {
      * @return The sent message.
      */
     default CompletableFuture<Message> sendMessage(EmbedBuilder embed, File... files) {
+        return sendMessage(Collections.singletonList(embed), files);
+    }
+
+    /**
+     * Sends a message.
+     *
+     * @param embeds A list of embeds which should be displayed.
+     * @param files  The file(s) to send.
+     * @return The sent message.
+     */
+    default CompletableFuture<Message> sendMessage(List<EmbedBuilder> embeds, File... files) {
         MessageBuilder messageBuilder = new MessageBuilder()
-                .setEmbed(embed);
+                .setEmbeds(embeds);
         for (File file : files) {
             messageBuilder.addAttachment(file);
         }
@@ -236,14 +291,26 @@ public interface Messageable {
     /**
      * Sends a message.
      *
-     * @param embed The embed which should be displayed.
-     * @param stream The stream for the file to send.
+     * @param embed    The embed which should be displayed.
+     * @param stream   The stream for the file to send.
      * @param fileName The name of the file.
      * @return The sent message.
      */
     default CompletableFuture<Message> sendMessage(EmbedBuilder embed, InputStream stream, String fileName) {
+        return sendMessage(Collections.singletonList(embed), stream, fileName);
+    }
+
+    /**
+     * Sends a message.
+     *
+     * @param embeds   A list of embeds which should be displayed.
+     * @param stream   The stream for the file to send.
+     * @param fileName The name of the file.
+     * @return The sent message.
+     */
+    default CompletableFuture<Message> sendMessage(List<EmbedBuilder> embeds, InputStream stream, String fileName) {
         return new MessageBuilder()
-                .setEmbed(embed)
+                .setEmbeds(embeds)
                 .addAttachment(stream, fileName)
                 .send(this);
     }
@@ -252,14 +319,26 @@ public interface Messageable {
      * Sends a message.
      *
      * @param content The content of the message.
-     * @param embed The embed which should be displayed.
-     * @param files The file(s) to send.
+     * @param embed   The embed which should be displayed.
+     * @param files   The file(s) to send.
      * @return The sent message.
      */
     default CompletableFuture<Message> sendMessage(String content, EmbedBuilder embed, File... files) {
+        return sendMessage(content, Collections.singletonList(embed), files);
+    }
+
+    /**
+     * Sends a message.
+     *
+     * @param content The content of the message.
+     * @param embeds  A list of embeds which should be displayed.
+     * @param files   The file(s) to send.
+     * @return The sent message.
+     */
+    default CompletableFuture<Message> sendMessage(String content, List<EmbedBuilder> embeds, File... files) {
         MessageBuilder messageBuilder = new MessageBuilder()
                 .append(content == null ? "" : content)
-                .setEmbed(embed);
+                .setEmbeds(embeds);
         for (File file : files) {
             messageBuilder.addAttachment(file);
         }
@@ -269,9 +348,9 @@ public interface Messageable {
     /**
      * Sends a message.
      *
-     * @param content The content of the message.
-     * @param embed The embed which should be displayed.
-     * @param stream The stream for the file to send.
+     * @param content  The content of the message.
+     * @param embed    The embed which should be displayed.
+     * @param stream   The stream for the file to send.
      * @param fileName The name of the file.
      * @return The sent message.
      */
@@ -280,6 +359,24 @@ public interface Messageable {
         return new MessageBuilder()
                 .append(content == null ? "" : content)
                 .setEmbed(embed)
+                .addAttachment(stream, fileName)
+                .send(this);
+    }
+
+    /**
+     * Sends a message.
+     *
+     * @param content  The content of the message.
+     * @param embeds   A list of embeds which should be displayed.
+     * @param stream   The stream for the file to send.
+     * @param fileName The name of the file.
+     * @return The sent message.
+     */
+    default CompletableFuture<Message> sendMessage(String content, List<EmbedBuilder> embeds, InputStream stream,
+                                                   String fileName) {
+        return new MessageBuilder()
+                .append(content == null ? "" : content)
+                .setEmbeds(embeds)
                 .addAttachment(stream, fileName)
                 .send(this);
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
@@ -5,6 +5,9 @@ import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.listener.message.UncachedMessageAttachableListenerManager;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -14,7 +17,7 @@ import java.util.concurrent.CompletableFuture;
 public interface UncachedMessageUtil extends UncachedMessageAttachableListenerManager {
 
     /**
-     * Cross posts the message if it is in a announcement channel.
+     * Cross posts the message if it is in an announcement channel.
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
@@ -25,7 +28,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
     }
 
     /**
-     * Cross posts the message if it is in a announcement channel.
+     * Cross posts the message if it is in an announcement channel.
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
@@ -56,7 +59,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param reason The audit log reason for the deletion.
+     * @param reason    The audit log reason for the deletion.
      * @return A future to tell us if the deletion was successful.
      */
     CompletableFuture<Void> delete(long channelId, long messageId, String reason);
@@ -66,7 +69,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param reason The audit log reason for the deletion.
+     * @param reason    The audit log reason for the deletion.
      * @return A future to tell us if the deletion was successful.
      */
     CompletableFuture<Void> delete(String channelId, String messageId, String reason);
@@ -77,7 +80,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      * Messages younger than two weeks are sent in batches of 100 messages to the bulk delete API,
      * older messages are deleted with individual delete requests.
      *
-     * @param channelId The id of the message's channel.
+     * @param channelId  The id of the message's channel.
      * @param messageIds The ids of the messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
@@ -89,7 +92,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      * Messages younger than two weeks are sent in batches of 100 messages to the bulk delete API,
      * older messages are deleted with individual delete requests.
      *
-     * @param channelId The id of the message's channel.
+     * @param channelId  The id of the message's channel.
      * @param messageIds The ids of the messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
@@ -122,7 +125,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param content The new content of the message.
+     * @param content   The new content of the message.
      * @return A future to check if the update was successful.
      */
     CompletableFuture<Message> edit(long channelId, long messageId, String content);
@@ -132,7 +135,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param content The new content of the message.
+     * @param content   The new content of the message.
      * @return A future to check if the update was successful.
      */
     CompletableFuture<Message> edit(String channelId, String messageId, String content);
@@ -142,70 +145,168 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param embed The new embed of the message.
+     * @param embed     The new embed of the message.
+     * @param embeds    One or more new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    CompletableFuture<Message> edit(long channelId, long messageId, EmbedBuilder embed);
+    default CompletableFuture<Message> edit(long channelId, long messageId, EmbedBuilder embed,
+                                            EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return edit(channelId, messageId, embedBuilders);
+    }
 
     /**
      * Updates the embed of the message.
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param embed The new embed of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    CompletableFuture<Message> edit(String channelId, String messageId, EmbedBuilder embed);
+    CompletableFuture<Message> edit(long channelId, long messageId, List<EmbedBuilder> embeds);
+
+    /**
+     * Updates the embed of the message.
+     *
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embed     The new embed of the message.
+     * @param embeds    One or more new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(String channelId, String messageId, EmbedBuilder embed,
+                                            EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return edit(channelId, messageId, embedBuilders);
+    }
+
+    /**
+     * Updates the embed of the message.
+     *
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    CompletableFuture<Message> edit(String channelId, String messageId, List<EmbedBuilder> embeds);
 
     /**
      * Updates the content and the embed of the message.
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param content The new content of the message.
-     * @param embed The new embed of the message.
+     * @param content   The new content of the message.
+     * @param embed     The new embed of the message.
+     * @param embeds    One or more new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    CompletableFuture<Message> edit(long channelId, long messageId, String content, EmbedBuilder embed);
+    default CompletableFuture<Message> edit(long channelId, long messageId, String content, EmbedBuilder embed,
+                                            EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return edit(channelId, messageId, content, embedBuilders);
+    }
 
     /**
      * Updates the content and the embed of the message.
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param content The new content of the message.
-     * @param embed The new embed of the message.
+     * @param content   The new content of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    CompletableFuture<Message> edit(String channelId, String messageId, String content, EmbedBuilder embed);
+    CompletableFuture<Message> edit(long channelId, long messageId, String content, List<EmbedBuilder> embeds);
 
     /**
      * Updates the content and the embed of the message.
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param content The new content of the message.
+     * @param content   The new content of the message.
+     * @param embed     The new embed of the message.
+     * @param embeds    One or more new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(String channelId, String messageId, String content, EmbedBuilder embed,
+                                            EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return edit(channelId, messageId, content, embedBuilders);
+    }
+
+    /**
+     * Updates the content and the embed of the message.
+     *
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param content   The new content of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    CompletableFuture<Message> edit(String channelId, String messageId, String content, List<EmbedBuilder> embeds);
+
+    /**
+     * Updates the content and the embed of the message.
+     *
+     * @param channelId     The id of the message's channel.
+     * @param messageId     The id of the message.
+     * @param content       The new content of the message.
      * @param updateContent Whether to update or remove the content.
-     * @param embed The new embed of the message.
-     * @param updateEmbed Whether to update or remove the embed.
+     * @param embed         The new embed of the message.
+     * @param updateEmbed   Whether to update or remove the embed.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(long channelId, long messageId, String content, boolean updateContent,
+                                            EmbedBuilder embed, boolean updateEmbed) {
+        return edit(channelId, messageId, content, updateContent, Collections.singletonList(embed), updateEmbed);
+    }
+
+    /**
+     * Updates the content and the embed of the message.
+     *
+     * @param channelId     The id of the message's channel.
+     * @param messageId     The id of the message.
+     * @param content       The new content of the message.
+     * @param updateContent Whether to update or remove the content.
+     * @param embeds        An array of the new embeds of the message.
+     * @param updateEmbed   Whether to update or remove the embed.
      * @return A future to check if the update was successful.
      */
     CompletableFuture<Message> edit(long channelId, long messageId, String content, boolean updateContent,
-                                 EmbedBuilder embed, boolean updateEmbed);
+                                    List<EmbedBuilder> embeds, boolean updateEmbed);
 
     /**
      * Updates the content and the embed of the message.
      *
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param content The new content of the message.
+     * @param channelId     The id of the message's channel.
+     * @param messageId     The id of the message.
+     * @param content       The new content of the message.
      * @param updateContent Whether to update or remove the content.
-     * @param embed The new embed of the message.
-     * @param updateEmbed Whether to update or remove the embed.
+     * @param embed         The new embed of the message.
+     * @param updateEmbed   Whether to update or remove the embed.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(String channelId, String messageId, String content, boolean updateContent,
+                                            EmbedBuilder embed, boolean updateEmbed) {
+        return edit(channelId, messageId, content, updateContent, Collections.singletonList(embed), updateEmbed);
+    }
+
+    /**
+     * Updates the content and the embed of the message.
+     *
+     * @param channelId     The id of the message's channel.
+     * @param messageId     The id of the message.
+     * @param content       The new content of the message.
+     * @param updateContent Whether to update or remove the content.
+     * @param embeds        An array of the new embeds of the message.
+     * @param updateEmbed   Whether to update or remove the embed.
      * @return A future to check if the update was successful.
      */
     CompletableFuture<Message> edit(String channelId, String messageId, String content, boolean updateContent,
-                                 EmbedBuilder embed, boolean updateEmbed);
+                                    List<EmbedBuilder> embeds, boolean updateEmbed);
 
     /**
      * Removes the content of the message.
@@ -264,8 +365,8 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
     /**
      * Adds a unicode reaction to the message.
      *
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
+     * @param channelId    The id of the message's channel.
+     * @param messageId    The id of the message.
      * @param unicodeEmoji The unicode emoji string.
      * @return A future to tell us if the action was successful.
      */
@@ -274,8 +375,8 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
     /**
      * Adds a unicode reaction to the message.
      *
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
+     * @param channelId    The id of the message's channel.
+     * @param messageId    The id of the message.
      * @param unicodeEmoji The unicode emoji string.
      * @return A future to tell us if the action was successful.
      */
@@ -286,7 +387,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param emoji The emoji.
+     * @param emoji     The emoji.
      * @return A future to tell us if the action was successful.
      */
     CompletableFuture<Void> addReaction(long channelId, long messageId, Emoji emoji);
@@ -296,7 +397,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param emoji The emoji.
+     * @param emoji     The emoji.
      * @return A future to tell us if the action was successful.
      */
     CompletableFuture<Void> addReaction(String channelId, String messageId, Emoji emoji);
@@ -360,7 +461,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param emoji The emoji of the reaction.
+     * @param emoji     The emoji of the reaction.
      * @return A list with all users who reacted with the given emoji
      */
     CompletableFuture<List<User>> getUsersWhoReactedWithEmoji(long channelId, long messageId, Emoji emoji);
@@ -370,7 +471,7 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param emoji The emoji of the reaction.
+     * @param emoji     The emoji of the reaction.
      * @return A list with all users who reacted with the given emoji
      */
     CompletableFuture<List<User>> getUsersWhoReactedWithEmoji(String channelId, String messageId, Emoji emoji);
@@ -380,8 +481,8 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param emoji The emoji of the reaction.
-     * @param userId The id of the user to remove.
+     * @param emoji     The emoji of the reaction.
+     * @param userId    The id of the user to remove.
      * @return A future to tell us if the action was successful.
      */
     CompletableFuture<Void> removeUserReactionByEmoji(long channelId, long messageId, Emoji emoji, long userId);
@@ -391,8 +492,8 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param emoji The emoji of the reaction.
-     * @param userId The id of the user to remove.
+     * @param emoji     The emoji of the reaction.
+     * @param userId    The id of the user to remove.
      * @return A future to tell us if the action was successful.
      */
     CompletableFuture<Void> removeUserReactionByEmoji(String channelId, String messageId, Emoji emoji, String userId);

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/WebhookMessageBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/WebhookMessageBuilder.java
@@ -16,6 +16,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 
@@ -181,7 +182,7 @@ public class WebhookMessageBuilder {
      * @return The current instance in order to chain call methods.
      */
     public WebhookMessageBuilder addEmbeds(EmbedBuilder... embeds) {
-        delegate.addEmbeds(embeds);
+        delegate.addEmbeds(Arrays.asList(embeds));
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/internal/MessageBuilderBaseDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/internal/MessageBuilderBaseDelegate.java
@@ -19,6 +19,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -110,7 +111,7 @@ public interface MessageBuilderBaseDelegate {
      *
      * @param embeds The embeds to add.
      */
-    void addEmbeds(EmbedBuilder... embeds);
+    void addEmbeds(List<EmbedBuilder> embeds);
 
     /**
      * Removes the embed from the message.

--- a/javacord-api/src/main/java/org/javacord/api/event/message/MessageEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/message/MessageEvent.java
@@ -7,6 +7,9 @@ import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.channel.TextChannelEvent;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -53,21 +56,48 @@ public interface MessageEvent extends TextChannelEvent {
     CompletableFuture<Message> editMessage(String content);
 
     /**
-     * Updates the embed of the message involved in the event.
+     * Updates the embeds of the message involved in the event.
      *
-     * @param embed The new embed of the message.
+     * @param embed  The embed of the new embeds of the message.
+     * @param embeds One or more additional embeds for the message.
      * @return A future to check if the update was successful.
      */
-    CompletableFuture<Message> editMessage(EmbedBuilder embed);
+    default CompletableFuture<Message> editMessage(EmbedBuilder embed, EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return editMessage(embedBuilders);
+    }
 
     /**
-     * Updates the content and the embed of the message involved in the event.
+     * Updates the embeds of the message involved in the event.
      *
-     * @param content The new content of the message.
-     * @param embed The new embed of the message.
+     * @param embeds A list of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    CompletableFuture<Message> editMessage(String content, EmbedBuilder embed);
+    CompletableFuture<Message> editMessage(List<EmbedBuilder> embeds);
+
+    /**
+     * Updates the content and the embeds of the message involved in the event.
+     *
+     * @param content The new content of the message.
+     * @param embed   The embed of the new embeds of the message.
+     * @param embeds  One or more additional embeds for the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> editMessage(String content, EmbedBuilder embed, EmbedBuilder... embeds) {
+        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
+        embedBuilders.add(embed);
+        return editMessage(content, embedBuilders);
+    }
+
+    /**
+     * Updates the content and the embeds of the message involved in the event.
+     *
+     * @param content The new content of the message.
+     * @param embeds  An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    CompletableFuture<Message> editMessage(String content, List<EmbedBuilder> embeds);
 
     /**
      * Adds a unicode reaction to the message involved in the event.
@@ -111,7 +141,7 @@ public interface MessageEvent extends TextChannelEvent {
     /**
      * Removes a user from the list of reactors of a given emoji reaction from the message.
      *
-     * @param user The user to remove.
+     * @param user  The user to remove.
      * @param emoji The emoji of the reaction.
      * @return A future to tell us if the deletion was successful.
      */
@@ -120,7 +150,7 @@ public interface MessageEvent extends TextChannelEvent {
     /**
      * Removes a user from the list of reactors of a given unicode emoji reaction from the message.
      *
-     * @param user The user to remove.
+     * @param user         The user to remove.
      * @param unicodeEmoji The unicode emoji of the reaction.
      * @return A future to tell us if the deletion was successful.
      */
@@ -145,7 +175,7 @@ public interface MessageEvent extends TextChannelEvent {
     /**
      * Removes a user from the list of reactors of the given emoji reactions from the message.
      *
-     * @param user The user to remove.
+     * @param user   The user to remove.
      * @param emojis The emojis of the reactions.
      * @return A future to tell us if the deletion was successful.
      */
@@ -155,7 +185,7 @@ public interface MessageEvent extends TextChannelEvent {
      * Removes a user from the list of reactors of the given unicode emoji reactions from the message.
      *
      * @param unicodeEmojis The unicode emojis of the reactions.
-     * @param user The user to remove.
+     * @param user          The user to remove.
      * @return A future to tell us if the deletion was successful.
      */
     CompletableFuture<Void> removeReactionsByEmojiFromMessage(User user, String... unicodeEmojis);

--- a/javacord-api/src/main/java/org/javacord/api/interaction/callback/InteractionMessageBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/callback/InteractionMessageBuilder.java
@@ -18,11 +18,12 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * This class is intended to be used by advanced users that desire full control over interaction responses.
- * We strongly recommend to use the offered methods on your received interactions instead of this class.
+ * We strongly recommend using the offered methods on your received interactions instead of this class.
  */
 public class InteractionMessageBuilder implements ExtendedInteractionMessageBuilderBase<InteractionMessageBuilder> {
 
@@ -33,8 +34,8 @@ public class InteractionMessageBuilder implements ExtendedInteractionMessageBuil
      * Sends the first response message.
      * This can only be done once after you want to respond to an interaction the FIRST time.
      * Responding directly to an interaction limits you to not being able to upload anything.
-     * Therefore i.e. {@link EmbedBuilder#setFooter(String, File)} will not work and you have to use the String methods
-     * for attachments like {@link EmbedBuilder#setFooter(String, String)} if available.
+     * Therefore, i.e. {@link EmbedBuilder#setFooter(String, File)} will not work, and you have to use the
+     * String methods for attachments like {@link EmbedBuilder#setFooter(String, String)} if available.
      * If you want to upload attachments use {@link #editOriginalResponse(InteractionBase)} instead.
      *
      * @param interaction The interaction.
@@ -42,11 +43,8 @@ public class InteractionMessageBuilder implements ExtendedInteractionMessageBuil
      */
     public CompletableFuture<InteractionMessageBuilder> sendInitialResponse(InteractionBase interaction) {
         CompletableFuture<InteractionMessageBuilder> future = new CompletableFuture<>();
-
-        CompletableFuture<Void> job = delegate.sendInitialResponse(interaction)
-                .thenRun(() -> {
-                    future.complete(this);
-                })
+        delegate.sendInitialResponse(interaction)
+                .thenRun(() -> future.complete(this))
                 .exceptionally(e -> {
                     future.completeExceptionally(e);
                     return null;
@@ -176,6 +174,12 @@ public class InteractionMessageBuilder implements ExtendedInteractionMessageBuil
 
     @Override
     public InteractionMessageBuilder addEmbeds(EmbedBuilder... embeds) {
+        delegate.addEmbeds(Arrays.asList(embeds));
+        return this;
+    }
+
+    @Override
+    public InteractionMessageBuilder addEmbeds(List<EmbedBuilder> embeds) {
         delegate.addEmbeds(embeds);
         return this;
     }

--- a/javacord-api/src/main/java/org/javacord/api/interaction/callback/InteractionMessageBuilderBase.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/callback/InteractionMessageBuilderBase.java
@@ -8,6 +8,7 @@ import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.message.mention.AllowedMentions;
 
 import java.util.EnumSet;
+import java.util.List;
 
 public interface InteractionMessageBuilderBase<T> {
     /**
@@ -77,6 +78,14 @@ public interface InteractionMessageBuilderBase<T> {
      * @return The current instance in order to chain call methods.
      */
     T addEmbeds(EmbedBuilder... embeds);
+
+    /**
+     * Adds the embeds to the message.
+     *
+     * @param embeds A list of embeds to add.
+     * @return The current instance in order to chain call methods.
+     */
+    T addEmbeds(List<EmbedBuilder> embeds);
 
     /**
      * Adds multiple components to the message.

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderBaseDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderBaseDelegateImpl.java
@@ -225,8 +225,8 @@ public class MessageBuilderBaseDelegateImpl implements MessageBuilderBaseDelegat
     }
 
     @Override
-    public void addEmbeds(EmbedBuilder... embeds) {
-        this.embeds.addAll(Arrays.asList(embeds));
+    public void addEmbeds(List<EmbedBuilder> embeds) {
+        this.embeds.addAll(embeds);
         embedsChanged = true;
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
@@ -159,66 +159,64 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
 
     @Override
     public CompletableFuture<Message> edit(long channelId, long messageId, String content) {
-        return edit(channelId, messageId, content, true, null, false);
+        return edit(channelId, messageId, content, true, Collections.emptyList(), false);
     }
 
     @Override
     public CompletableFuture<Message> edit(String channelId, String messageId, String content) {
-        return edit(channelId, messageId, content, true, null, false);
+        return edit(channelId, messageId, content, true, Collections.emptyList(), false);
     }
 
     @Override
-    public CompletableFuture<Message> edit(long channelId, long messageId, EmbedBuilder embed) {
-        return edit(channelId, messageId, null, false, embed, true);
+    public CompletableFuture<Message> edit(long channelId, long messageId, List<EmbedBuilder> embeds) {
+        return edit(channelId, messageId, null, false, embeds, true);
     }
 
     @Override
-    public CompletableFuture<Message> edit(String channelId, String messageId, EmbedBuilder embed) {
-        return edit(channelId, messageId, null, false, embed, true);
-    }
-
-    @Override
-    public CompletableFuture<Message> edit(
-            long channelId, long messageId, String content, EmbedBuilder embed) {
-        return edit(channelId, messageId, content, true, embed, true);
+    public CompletableFuture<Message> edit(String channelId, String messageId, List<EmbedBuilder> embeds) {
+        return edit(channelId, messageId, null, false, embeds, true);
     }
 
     @Override
     public CompletableFuture<Message> edit(
-            String channelId, String messageId, String content, EmbedBuilder embed) {
-        return edit(channelId, messageId, content, true, embed, true);
+            long channelId, long messageId, String content, List<EmbedBuilder> embeds) {
+        return edit(channelId, messageId, content, true, embeds, true);
+    }
+
+    @Override
+    public CompletableFuture<Message> edit(
+            String channelId, String messageId, String content, List<EmbedBuilder> embeds) {
+        return edit(channelId, messageId, content, true, embeds, true);
     }
 
     @Override
     public CompletableFuture<Message> edit(long channelId, long messageId, String content,
-                                        boolean updateContent, EmbedBuilder embed, boolean updateEmbed) {
+                                           boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
         ObjectNode body = JsonNodeFactory.instance.objectNode();
         if (updateContent) {
-            if (content == null) {
+            if (content == null || content.isEmpty()) {
                 body.putNull("content");
             } else {
                 body.put("content", content);
             }
         }
         if (updateEmbed) {
-            if (embed == null) {
-                body.putNull("embed");
-            } else {
-                ((EmbedBuilderDelegateImpl) embed.getDelegate()).toJsonNode(body.putObject("embed"));
-            }
+            ArrayNode embedArray = body.putArray("embeds");
+            embeds.stream().map(embedBuilder -> ((EmbedBuilderDelegateImpl) embedBuilder.getDelegate()).toJsonNode())
+                    .forEach(embedArray::add);
         }
         return new RestRequest<Message>(api, RestMethod.PATCH, RestEndpoint.MESSAGE)
                 .setUrlParameters(Long.toUnsignedString(channelId), Long.toUnsignedString(messageId))
                 .setBody(body)
                 .execute(result -> new MessageImpl(api, api.getTextChannelById(channelId).orElseThrow(() ->
-                                new IllegalStateException("TextChannel is missing.")), result.getJsonBody()));
+                        new IllegalStateException("TextChannel is missing.")), result.getJsonBody()));
     }
 
     @Override
     public CompletableFuture<Message> edit(String channelId, String messageId, String content,
-                                        boolean updateContent, EmbedBuilder embed, boolean updateEmbed) {
+                                           boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
         try {
-            return edit(Long.parseLong(channelId), Long.parseLong(messageId), content, true, embed, true);
+            return edit(Long.parseLong(channelId), Long.parseLong(messageId), content, true, embeds, true);
         } catch (NumberFormatException e) {
             CompletableFuture<Message> future = new CompletableFuture<>();
             future.completeExceptionally(e);
@@ -228,32 +226,32 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
 
     @Override
     public CompletableFuture<Message> removeContent(long channelId, long messageId) {
-        return edit(channelId, messageId, null, true, null, false);
+        return edit(channelId, messageId, "");
     }
 
     @Override
     public CompletableFuture<Message> removeContent(String channelId, String messageId) {
-        return edit(channelId, messageId, null, true, null, false);
+        return edit(channelId, messageId, null, true, Collections.emptyList(), false);
     }
 
     @Override
     public CompletableFuture<Message> removeEmbed(long channelId, long messageId) {
-        return edit(channelId, messageId, null, false, null, true);
+        return edit(channelId, messageId, null, false, Collections.emptyList(), true);
     }
 
     @Override
     public CompletableFuture<Message> removeEmbed(String channelId, String messageId) {
-        return edit(channelId, messageId, null, false, null, true);
+        return edit(channelId, messageId, null, false, Collections.emptyList(), true);
     }
 
     @Override
     public CompletableFuture<Message> removeContentAndEmbed(long channelId, long messageId) {
-        return edit(channelId, messageId, null, true, null, true);
+        return edit(channelId, messageId, null, true, Collections.emptyList(), true);
     }
 
     @Override
     public CompletableFuture<Message> removeContentAndEmbed(String channelId, String messageId) {
-        return edit(channelId, messageId, null, true, null, true);
+        return edit(channelId, messageId, null, true, Collections.emptyList(), true);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/event/message/MessageEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/message/MessageEventImpl.java
@@ -14,6 +14,7 @@ import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
 import org.javacord.core.event.EventImpl;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -81,17 +82,17 @@ public abstract class MessageEventImpl extends EventImpl implements MessageEvent
 
     @Override
     public CompletableFuture<Message> editMessage(String content) {
-        return Message.edit(getApi(), getChannel().getId(), getMessageId(), content, null);
+        return Message.edit(getApi(), getChannel().getId(), getMessageId(), content);
     }
 
     @Override
-    public CompletableFuture<Message> editMessage(EmbedBuilder embed) {
-        return Message.edit(getApi(), getChannel().getId(), getMessageId(), null, embed);
+    public CompletableFuture<Message> editMessage(List<EmbedBuilder> embeds) {
+        return Message.edit(getApi(), getChannel().getId(), getMessageId(), null, embeds);
     }
 
     @Override
-    public CompletableFuture<Message> editMessage(String content, EmbedBuilder embed) {
-        return Message.edit(getApi(), getChannel().getId(), getMessageId(), content, embed);
+    public CompletableFuture<Message> editMessage(String content, List<EmbedBuilder> embeds) {
+        return Message.edit(getApi(), getChannel().getId(), getMessageId(), content, embeds);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/interaction/InteractionMessageBuilderBaseImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/InteractionMessageBuilderBaseImpl.java
@@ -12,6 +12,7 @@ import org.javacord.api.util.internal.DelegateFactory;
 
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
 
 public abstract class InteractionMessageBuilderBaseImpl<T> implements InteractionMessageBuilderBase<T> {
     protected final InteractionMessageBuilderDelegate delegate;
@@ -80,6 +81,12 @@ public abstract class InteractionMessageBuilderBaseImpl<T> implements Interactio
 
     @Override
     public T addEmbeds(EmbedBuilder... embeds) {
+        delegate.addEmbeds(Arrays.asList(embeds));
+        return myClass.cast(this);
+    }
+
+    @Override
+    public T addEmbeds(List<EmbedBuilder> embeds) {
         delegate.addEmbeds(embeds);
         return myClass.cast(this);
     }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/InteractionOriginalResponseUpdaterImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/InteractionOriginalResponseUpdaterImpl.java
@@ -102,7 +102,7 @@ public class InteractionOriginalResponseUpdaterImpl
 
     @Override
     public InteractionOriginalResponseUpdater addEmbeds(EmbedBuilder... embeds) {
-        delegate.addEmbeds(embeds);
+        delegate.addEmbeds(Arrays.asList(embeds));
         return this;
     }
 


### PR DESCRIPTION
- Added MessageBuilderBase#addEmbeds(List<EmbedBuilder>)
- Switched the edit methods in Message from using the static edit methods to using the MessageUpdater.
- Message#edit, MessageEvent#editMessage and UncachedMessageUtil#edit methods now take in addition a list of embeds instead of a single embed and single embeds were enhanced to take at least 1 embeds.
- A few edit methods couldn't be enhanced due to the embed parameter being in the middle of params, so they introduce a breaking change as they have been refactored to take a list of embeds
- Messageable was enhanced with being able to take multiple embeds