### PR TITLE
Add SlashCommandOptionType NUMBER.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteractionOption.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteractionOption.java
@@ -31,7 +31,16 @@ public interface SlashCommandInteractionOption extends SlashCommandInteractionOp
     }
 
     /**
-     * Gets the string representation of this option value.
+     * Gets the string representation value of this option.
+     *
+     * <p>This will always be present unless the option is a subcommand or subcommand group.
+     *
+     * @return The string representation value of this option.
+     */
+    Optional<String> getStringRepresentationValue();
+
+    /**
+     * Gets the string value of this option.
      *
      * <p>If this option does not have a string value or the option itself is a subcommand or group,
      * the optional will be empty.
@@ -114,6 +123,19 @@ public interface SlashCommandInteractionOption extends SlashCommandInteractionOp
      * @return The mentionable value of this option.
      */
     Optional<Mentionable> getMentionableValue();
+
+    /**
+     * Gets the mentionable value of this option.
+     * Note: This method only respects cached users if the ID of the Mentionable belongs to a user. To fetch the user
+     *     from Discord if the user is not cached,
+     *     use {@link SlashCommandInteractionOption#requestMentionableValue()}.
+     *
+     * <p>If this option does not have a mentionable value or the option itself is a subcommand or group,
+     *     the optional will be empty.
+     *
+     * @return The mentionable value of this option.
+     */
+    Optional<Double> getNumberValue();
 
     /**
      * Gets the mentionable value of this option.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteractionOptionsProvider.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteractionOptionsProvider.java
@@ -36,6 +36,15 @@ public interface SlashCommandInteractionOptionsProvider {
      *
      * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
      */
+    default Optional<String> getFirstOptionStringRepresentationValue() {
+        return getFirstOption().flatMap(SlashCommandInteractionOption::getStringRepresentationValue);
+    }
+
+    /**
+     * Gets the string value of the first option (if present).
+     *
+     * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
+     */
     default Optional<String> getFirstOptionStringValue() {
         return getFirstOption().flatMap(SlashCommandInteractionOption::getStringValue);
     }
@@ -118,6 +127,15 @@ public interface SlashCommandInteractionOptionsProvider {
     }
 
     /**
+     * Gets the double value of the first option (if present).
+     *
+     * @return An Optional with the double value of such an option if it exists; an empty Optional otherwise
+     */
+    default Optional<Double> getFirstOptionNumberValue() {
+        return getFirstOption().flatMap(SlashCommandInteractionOption::getNumberValue);
+    }
+
+    /**
      * Get the second option, if present. Useful if you're working with a command that has two options.
      *
      * @return The option at index 0, if present; an empty Optional otherwise
@@ -128,6 +146,15 @@ public interface SlashCommandInteractionOptionsProvider {
 
     /**
      * Gets the string representation of the second option (if present).
+     *
+     * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
+     */
+    default Optional<String> getSecondOptionStringRepresentationValue() {
+        return getSecondOption().flatMap(SlashCommandInteractionOption::getStringRepresentationValue);
+    }
+
+    /**
+     * Gets the string value of the second option (if present).
      *
      * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
      */
@@ -213,6 +240,15 @@ public interface SlashCommandInteractionOptionsProvider {
     }
 
     /**
+     * Gets the double value of the second option (if present).
+     *
+     * @return An Optional with the double value of such an option if it exists; an empty Optional otherwise
+     */
+    default Optional<Double> getSecondOptionNumberValue() {
+        return getSecondOption().flatMap(SlashCommandInteractionOption::getNumberValue);
+    }
+
+    /**
      * Get the third option, if present. Useful if you're working with a command that has up to 3 options.
      *
      * @return The option at index 0, if present; an empty Optional otherwise
@@ -223,6 +259,15 @@ public interface SlashCommandInteractionOptionsProvider {
 
     /**
      * Gets the string representation of the third option (if present).
+     *
+     * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
+     */
+    default Optional<String> getThirdOptionStringRepresentationValue() {
+        return getThirdOption().flatMap(SlashCommandInteractionOption::getStringRepresentationValue);
+    }
+
+    /**
+     * Gets the string of the third option (if present).
      *
      * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
      */
@@ -308,6 +353,15 @@ public interface SlashCommandInteractionOptionsProvider {
     }
 
     /**
+     * Gets the double value of the third option (if present).
+     *
+     * @return An Optional with the double value of such an option if it exists; an empty Optional otherwise
+     */
+    default Optional<Double> getThirdOptionNumberValue() {
+        return getThirdOption().flatMap(SlashCommandInteractionOption::getNumberValue);
+    }
+
+    /**
      * Get an option having the specified name.
      *
      * @param name The name of the option to search for.
@@ -318,6 +372,16 @@ public interface SlashCommandInteractionOptionsProvider {
                 .stream()
                 .filter(option -> option.getName().equalsIgnoreCase(name))
                 .findAny();
+    }
+
+    /**
+     * Gets the string representation value of an option having the specified name.
+     *
+     * @param name The name of the option to search for.
+     * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
+     */
+    default Optional<String> getOptionStringRepresentationValueByName(String name) {
+        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getStringRepresentationValue);
     }
 
     /**
@@ -416,6 +480,16 @@ public interface SlashCommandInteractionOptionsProvider {
     }
 
     /**
+     * Gets the double value of an option having the specified name.
+     *
+     * @param name The name of the option to search for.
+     * @return An Optional with the double value of such an option if it exists; an empty Optional otherwise
+     */
+    default Optional<Double> getOptionNumberValueByName(String name) {
+        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getNumberValue);
+    }
+
+    /**
      * Gets the option at the specified index, if present.
      *
      * @param index The index of the option to search for.
@@ -426,6 +500,16 @@ public interface SlashCommandInteractionOptionsProvider {
                 .stream()
                 .skip(index)
                 .findFirst();
+    }
+
+    /**
+     * Gets the string representation value of an option at the specified index.
+     *
+     * @param index The index of the option to search for.
+     * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
+     */
+    default Optional<String> getOptionStringRepresentationValueByIndex(int index) {
+        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getStringRepresentationValue);
     }
 
     /**
@@ -521,5 +605,15 @@ public interface SlashCommandInteractionOptionsProvider {
      */
     default Optional<CompletableFuture<Mentionable>> requestOptionMentionableValueByIndex(int index) {
         return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::requestFirstOptionMentionableValue);
+    }
+
+    /**
+     * Gets the double value of an option at the specified index.
+     *
+     * @param index The index of the option to search for.
+     * @return An Optional with the double value of such an option if it exists; an empty Optional otherwise
+     */
+    default Optional<Double> getOptionNumberValueByIndex(int index) {
+        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getNumberValue);
     }
 }

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionType.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionType.java
@@ -11,6 +11,7 @@ public enum SlashCommandOptionType {
     CHANNEL(7),
     ROLE(8),
     MENTIONABLE(9),
+    NUMBER(10),
     UNKNOWN(-1);
 
     private final int value;


### PR DESCRIPTION
This PR is a breaking change in terms of the `getStringValue` now doesn't return a result anymore if the option type is not a string.
In place comes `getStringRepresentationValue` which also returns the boolean which was missing previously.

- Reworked SlashCommandInteractionOptionImpl to check for the "type" key value instead of the datatype of the value node to uniquely identify the option.
- Add getStringRepresentationValue to clearly differentiate between getStringValue which is now only present when the option "type" key is a string.