### PR TITLE
Change message methods that take embed as argument only to needing an array of embeds

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -241,15 +241,12 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param embed     The new embed of the message.
-     * @param embeds    One or more additional new embeds of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, EmbedBuilder embed,
-                                           EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embedBuilders, true);
+    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, EmbedBuilder... embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false,
+                Arrays.asList(embeds), true);
     }
 
     /**
@@ -271,15 +268,11 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param embed     The new embed of the message.
-     * @param embeds    One or more additional new embeds of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId,
-                                           EmbedBuilder embed, EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embedBuilders, true);
+    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, EmbedBuilder... embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, Arrays.asList(embeds), true);
     }
 
     /**
@@ -303,16 +296,12 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param content   The new content of the message.
-     * @param embed     The new embed of the message.
-     * @param embeds    One or more additional new embeds of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(
-            DiscordApi api, long channelId, long messageId, String content, EmbedBuilder embed,
-            EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, embedBuilders, true);
+            DiscordApi api, long channelId, long messageId, String content, EmbedBuilder... embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Arrays.asList(embeds), true);
     }
 
     /**
@@ -337,16 +326,12 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param content   The new content of the message.
-     * @param embed     The new embed of the message.
-     * @param embeds    One or more additional new embeds of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(
-            DiscordApi api, String channelId, String messageId, String content, EmbedBuilder embed,
-            EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, embedBuilders, true);
+            DiscordApi api, String channelId, String messageId, String content, EmbedBuilder... embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Arrays.asList(embeds), true);
     }
 
     /**
@@ -412,14 +397,11 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Updates the embed of the message.
      *
-     * @param embed  The new embed of the message.
-     * @param embeds One or more additional new embeds of the message.
+     * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> edit(EmbedBuilder embed, EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return new MessageUpdater(this).addEmbeds(embedBuilders).applyChanges();
+    default CompletableFuture<Message> edit(EmbedBuilder... embeds) {
+        return new MessageUpdater(this).addEmbeds(Arrays.asList(embeds)).applyChanges();
     }
 
     /**
@@ -436,14 +418,11 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * Updates the content and the embed of the message.
      *
      * @param content The new content of the message.
-     * @param embed   The new embed of the message.
-     * @param embeds  One or more additional new embeds of the message.
+     * @param embeds  An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> edit(String content, EmbedBuilder embed, EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return new MessageUpdater(this).setContent(content).addEmbeds(embedBuilders).applyChanges();
+    default CompletableFuture<Message> edit(String content, EmbedBuilder... embeds) {
+        return new MessageUpdater(this).setContent(content).addEmbeds(embeds).applyChanges();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Messageable.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Messageable.java
@@ -2,10 +2,8 @@ package org.javacord.api.entity.message;
 
 import org.javacord.api.entity.message.component.HighLevelComponent;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
-
 import java.io.File;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -115,14 +113,12 @@ public interface Messageable {
      * Sends a message.
      *
      * @param content The content of the message.
-     * @param embed   The embed which should be displayed.
-     * @param embeds  One or more additional embeds which should be displayed.
+     * @param embeds  An array of the new embeds of the message.
      * @return The sent message.
      */
-    default CompletableFuture<Message> sendMessage(String content, EmbedBuilder embed, EmbedBuilder... embeds) {
+    default CompletableFuture<Message> sendMessage(String content, EmbedBuilder... embeds) {
         return new MessageBuilder()
                 .append(content == null ? "" : content)
-                .setEmbed(embed)
                 .addEmbeds(embeds)
                 .send(this);
     }
@@ -181,14 +177,11 @@ public interface Messageable {
     /**
      * Sends a message.
      *
-     * @param embed  The embed which should be displayed.
-     * @param embeds One or more additional embeds new embed of the message.
+     * @param embeds An array of the new embeds of the message.
      * @return The sent message.
      */
-    default CompletableFuture<Message> sendMessage(EmbedBuilder embed, EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return sendMessage(embedBuilders);
+    default CompletableFuture<Message> sendMessage(EmbedBuilder... embeds) {
+        return sendMessage(Arrays.asList(embeds));
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
@@ -4,8 +4,6 @@ import org.javacord.api.entity.emoji.Emoji;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.listener.message.UncachedMessageAttachableListenerManager;
-
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -145,15 +143,11 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param embed     The new embed of the message.
-     * @param embeds    One or more new embeds of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> edit(long channelId, long messageId, EmbedBuilder embed,
-                                            EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return edit(channelId, messageId, embedBuilders);
+    default CompletableFuture<Message> edit(long channelId, long messageId, EmbedBuilder... embeds) {
+        return edit(channelId, messageId, Arrays.asList(embeds));
     }
 
     /**
@@ -171,15 +165,11 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      *
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
-     * @param embed     The new embed of the message.
-     * @param embeds    One or more new embeds of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> edit(String channelId, String messageId, EmbedBuilder embed,
-                                            EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return edit(channelId, messageId, embedBuilders);
+    default CompletableFuture<Message> edit(String channelId, String messageId, EmbedBuilder... embeds) {
+        return edit(channelId, messageId, Arrays.asList(embeds));
     }
 
     /**
@@ -198,15 +188,11 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param content   The new content of the message.
-     * @param embed     The new embed of the message.
-     * @param embeds    One or more new embeds of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> edit(long channelId, long messageId, String content, EmbedBuilder embed,
-                                            EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return edit(channelId, messageId, content, embedBuilders);
+    default CompletableFuture<Message> edit(long channelId, long messageId, String content, EmbedBuilder... embeds) {
+        return edit(channelId, messageId, content, embeds);
     }
 
     /**
@@ -226,15 +212,12 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param content   The new content of the message.
-     * @param embed     The new embed of the message.
-     * @param embeds    One or more new embeds of the message.
+     * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> edit(String channelId, String messageId, String content, EmbedBuilder embed,
+    default CompletableFuture<Message> edit(String channelId, String messageId, String content,
                                             EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return edit(channelId, messageId, content, embedBuilders);
+        return edit(channelId, messageId, content, embeds);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/event/message/MessageEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/message/MessageEvent.java
@@ -7,7 +7,6 @@ import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.channel.TextChannelEvent;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -58,14 +57,11 @@ public interface MessageEvent extends TextChannelEvent {
     /**
      * Updates the embeds of the message involved in the event.
      *
-     * @param embed  The embed of the new embeds of the message.
-     * @param embeds One or more additional embeds for the message.
+     * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> editMessage(EmbedBuilder embed, EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return editMessage(embedBuilders);
+    default CompletableFuture<Message> editMessage(EmbedBuilder... embeds) {
+        return editMessage(Arrays.asList(embeds));
     }
 
     /**
@@ -80,14 +76,11 @@ public interface MessageEvent extends TextChannelEvent {
      * Updates the content and the embeds of the message involved in the event.
      *
      * @param content The new content of the message.
-     * @param embed   The embed of the new embeds of the message.
-     * @param embeds  One or more additional embeds for the message.
+     * @param embeds  An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> editMessage(String content, EmbedBuilder embed, EmbedBuilder... embeds) {
-        List<EmbedBuilder> embedBuilders = new ArrayList<>(Arrays.asList(embeds));
-        embedBuilders.add(embed);
-        return editMessage(content, embedBuilders);
+    default CompletableFuture<Message> editMessage(String content, EmbedBuilder... embeds) {
+        return editMessage(content, Arrays.asList(embeds));
     }
 
     /**


### PR DESCRIPTION
In #848 I introduced the new methods with needing at least 1 argument and and inifite amount of more embeds. This was changed to only needing an array of embeds due to method overloading which also take an inifnite amount of argument of a type, so it is not possible to pass 0 embeds, unless you pass an empty array