### PR TITLE
Throw an exception when calling a method that requires a populated cache

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -285,7 +285,7 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
      */
     public ServerImpl(DiscordApiImpl api, JsonNode data) {
         this.api = api;
-        ready = !api.hasUserCacheEnabled() || !api.isWaitingForUsersOnStartup();
+        ready = !api.isUserCacheEnabled() || !api.isWaitingForUsersOnStartup();
 
         id = Long.parseLong(data.get("id").asText());
         name = data.get("name").asText();
@@ -400,7 +400,7 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
         if (
                 (isLarge() || !api.getIntents().contains(Intent.GUILD_PRESENCES))
                 && getMembers().size() < getMemberCount()
-                && api.hasUserCacheEnabled()
+                && api.isUserCacheEnabled()
         ) {
             api.getWebSocketAdapter().queueRequestGuildMembers(this);
         }
@@ -1270,7 +1270,7 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
 
     @Override
     public Set<User> getMembers() {
-        return api.getEntityCache().get().getMemberCache()
+        return api.getMemberCache()
                 .getMembersByServer(getId())
                 .stream()
                 .map(Member::getUser)
@@ -1283,13 +1283,13 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
      * @return The real members.
      */
     public Set<Member> getRealMembers() {
-        return api.getEntityCache().get().getMemberCache()
+        return api.getMemberCache()
                 .getMembersByServer(getId());
     }
 
     @Override
     public Optional<User> getMemberById(long id) {
-        return api.getEntityCache().get().getMemberCache()
+        return api.getMemberCache()
                 .getMemberByIdAndServer(id, getId())
                 .map(Member::getUser);
     }
@@ -1301,13 +1301,13 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
      * @return The real member.
      */
     public Optional<Member> getRealMemberById(long userId) {
-        return api.getEntityCache().get().getMemberCache()
+        return api.getMemberCache()
                 .getMemberByIdAndServer(userId, getId());
     }
 
     @Override
     public boolean isMember(User user) {
-        return api.getEntityCache().get().getMemberCache()
+        return api.getMemberCache()
                 .getMemberByIdAndServer(user.getId(), getId())
                 .isPresent();
     }

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
@@ -237,14 +237,14 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
     @Override
     public Set<Server> getMutualServers() {
         if (api.isUserCacheEnabled()) {
-            return api.getEntityCache().get().getMemberCache().getServers(getId());
+            return api.getMemberCache().getServers(getId());
         }
         return member == null ? Collections.emptySet() : Collections.singleton(member.getServer());
     }
 
     @Override
     public String getDisplayName(Server server) {
-        if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
+        if (api.isUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
             return server.getNickname(this).orElseGet(this::getName);
         } else {
             return member.getNickname().orElse(getName());
@@ -253,7 +253,7 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
 
     @Override
     public Optional<String> getNickname(Server server) {
-        if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
+        if (api.isUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
             return server.getNickname(this);
         } else {
             return member.getNickname();
@@ -262,7 +262,7 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
 
     @Override
     public boolean isPending(Server server) {
-        if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
+        if (api.isUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
             return server.isPending(getId());
         } else {
             return member.isPending();
@@ -271,7 +271,7 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
 
     @Override
     public boolean isSelfMuted(Server server) {
-        if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
+        if (api.isUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
             return server.isSelfMuted(getId());
         } else {
             return member.isSelfMuted();
@@ -280,7 +280,7 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
 
     @Override
     public boolean isSelfDeafened(Server server) {
-        if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
+        if (api.isUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
             return server.isSelfDeafened(getId());
         } else {
             return member.isSelfDeafened();
@@ -289,7 +289,7 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
 
     @Override
     public Optional<Instant> getJoinedAtTimestamp(Server server) {
-        if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
+        if (api.isUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
             return server.getJoinedAtTimestamp(this);
         } else {
             return Optional.of(member.getJoinedAtTimestamp());
@@ -298,7 +298,7 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
 
     @Override
     public List<Role> getRoles(Server server) {
-        if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
+        if (api.isUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
             return server.getRoles(this);
         } else {
             return member.getRoles();
@@ -307,7 +307,7 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
 
     @Override
     public Optional<Color> getRoleColor(Server server) {
-        if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
+        if (api.isUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
             return server.getRoleColor(this);
         } else {
             return member.getRoleColor();

--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
@@ -589,7 +589,7 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                             }
                             allServersLoaded = api.getUnavailableServers().isEmpty();
                             if (allServersLoaded) {
-                                allUsersLoaded = !api.hasUserCacheEnabled()
+                                allUsersLoaded = !api.isUserCacheEnabled()
                                         || !api.isWaitingForUsersOnStartup()
                                         || api.getAllServers().stream()
                                         .map(ServerImpl.class::cast)

--- a/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
+++ b/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
@@ -5,6 +5,7 @@ import okhttp3.Credentials
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.test.appender.ListAppender
 import org.javacord.api.AccountType
+import org.javacord.api.entity.intent.Intent
 import org.javacord.api.entity.server.Server
 import org.javacord.api.exception.NotFoundException
 import org.javacord.test.MockProxyManager
@@ -22,7 +23,9 @@ import java.util.concurrent.CompletionException
 class DiscordApiImplTest extends Specification {
 
     @Subject
-    def api = new DiscordApiImpl(null, null, null, null, null, null, false)
+    def api = new DiscordApiImpl(AccountType.BOT, null, 0, 1,
+            Collections.unmodifiableSet(new HashSet<Intent>(Collections.singleton(Intent.GUILD_MEMBERS))), true, false,
+            true, null, null, null, null, null, false, null, null, Collections.emptyMap(), Collections.emptyList(), true)
 
     def 'getAllServers returns all servers'() {
         given:


### PR DESCRIPTION
- In addition, an internal used duplicated method hasUserCacheEnabled has been removed in favor of an already existing isUserCacheEnabled method.