### PR TITLE
Replaced MessageFlag with InteractionCallbackDataFlag for interaction response types

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageFlag.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageFlag.java
@@ -6,10 +6,44 @@ package org.javacord.api.entity.message;
 public enum MessageFlag {
 
     /**
+     * This message has been published to subscribed channels (via Channel Following).
+     */
+    CROSSPOSTED(1),
+
+    /**
+     * This message originated from a message in another channel (via Channel Following).
+     */
+    IS_CROSSPOST(2),
+
+    /**
+     * Do not include any embeds when serializing this message.
+     */
+    SUPPRESS_EMBEDS(4),
+
+    /**
+     * The source message for this crosspost has been deleted (via Channel Following).
+     */
+    SOURCE_MESSAGE_DELETED(8),
+
+    /**
+     * This message came from the urgent message system.
+     */
+    URGENT(16),
+
+    /**
+     * This message has an associated thread, with the same id as the message.
+     */
+    HAS_THREAD(32),
+
+    /**
      * An ephemeral message (only visible for the user).
      */
     EPHEMERAL(64),
 
+    /**
+     * This message is an Interaction Response and the bot is "thinking".
+     */
+    LOADING(128),
     /**
      * An unknown flag.
      */
@@ -25,7 +59,7 @@ public enum MessageFlag {
      *
      * @param id The id of the type.
      */
-    MessageFlag(int id) {
+    MessageFlag(final int id) {
         this.id = id;
     }
 
@@ -44,12 +78,12 @@ public enum MessageFlag {
      * @param id The id of the message flag type.
      * @return The message flag type with the given id or {@link MessageFlag#UNKNOWN} if unknown id.
      */
-    public static MessageFlag getFlagTypeById(int id) {
-        switch (id) {
-            case 64:
-                return EPHEMERAL;
-            default:
-                return UNKNOWN;
+    public static MessageFlag getFlagTypeById(final int id) {
+        for (final MessageFlag value : values()) {
+            if (value.getId() == id) {
+                return value;
+            }
         }
+        return UNKNOWN;
     }
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/internal/InteractionMessageBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/internal/InteractionMessageBuilderDelegate.java
@@ -1,20 +1,19 @@
 package org.javacord.api.entity.message.internal;
 
 import org.javacord.api.entity.message.Message;
-import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.interaction.InteractionBase;
-
+import org.javacord.api.interaction.callback.InteractionCallbackDataFlag;
 import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
 
 public interface InteractionMessageBuilderDelegate extends MessageBuilderBaseDelegate {
 
     /**
-     * Sets the message flags of the message.
+     * Sets the interaction callback data flags of the message.
      *
-     * @param messageFlags The message flag of the message.
+     * @param interactionCallbackDataFlags The interaction callback data flags of the message.
      */
-    void setFlags(EnumSet<MessageFlag> messageFlags);
+    void setFlags(EnumSet<InteractionCallbackDataFlag> interactionCallbackDataFlags);
 
     /**
      * Sends the message.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/callback/InteractionCallbackDataFlag.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/callback/InteractionCallbackDataFlag.java
@@ -1,0 +1,56 @@
+package org.javacord.api.interaction.callback;
+
+/**
+ * Represents an interaction callback data flag type.
+ */
+public enum InteractionCallbackDataFlag {
+
+    /**
+     * An ephemeral message (only visible for the user).
+     */
+    EPHEMERAL(64),
+
+    /**
+     * An unknown flag.
+     */
+    UNKNOWN(-1);
+
+    /**
+     * The id of the flag.
+     */
+    private final int id;
+
+    /**
+     * Creates a new interaction callback data flag type.
+     *
+     * @param id The id of the type.
+     */
+    InteractionCallbackDataFlag(final int id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the id of the interaction callback data flag type.
+     *
+     * @return The id of the interaction callback data flag type.
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Gets the interaction callback data flag type by its id.
+     *
+     * @param id The id of the interaction callback data flag type.
+     * @return The interaction callback data flag type with the given id
+     *         or {@link InteractionCallbackDataFlag#UNKNOWN} if unknown id.
+     */
+    public static InteractionCallbackDataFlag getFlagTypeById(final int id) {
+        for (final InteractionCallbackDataFlag value : values()) {
+            if (value.getId() == id) {
+                return value;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/interaction/callback/InteractionMessageBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/callback/InteractionMessageBuilder.java
@@ -4,14 +4,12 @@ import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.Mentionable;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.MessageDecoration;
-import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.entity.message.component.HighLevelComponent;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.message.internal.InteractionMessageBuilderDelegate;
 import org.javacord.api.entity.message.mention.AllowedMentions;
 import org.javacord.api.interaction.InteractionBase;
 import org.javacord.api.util.internal.DelegateFactory;
-
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.InputStream;
@@ -239,14 +237,14 @@ public class InteractionMessageBuilder implements ExtendedInteractionMessageBuil
     }
 
     @Override
-    public InteractionMessageBuilder setFlags(MessageFlag... messageFlags) {
-        setFlags(EnumSet.copyOf(Arrays.asList(messageFlags)));
+    public InteractionMessageBuilder setFlags(InteractionCallbackDataFlag... interactionCallbackDataFlags) {
+        setFlags(EnumSet.copyOf(Arrays.asList(interactionCallbackDataFlags)));
         return this;
     }
 
     @Override
-    public InteractionMessageBuilder setFlags(EnumSet<MessageFlag> messageFlags) {
-        delegate.setFlags(messageFlags);
+    public InteractionMessageBuilder setFlags(EnumSet<InteractionCallbackDataFlag> interactionCallbackDataFlags) {
+        delegate.setFlags(interactionCallbackDataFlags);
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/interaction/callback/InteractionMessageBuilderBase.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/callback/InteractionMessageBuilderBase.java
@@ -2,11 +2,9 @@ package org.javacord.api.interaction.callback;
 
 import org.javacord.api.entity.Mentionable;
 import org.javacord.api.entity.message.MessageDecoration;
-import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.entity.message.component.HighLevelComponent;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.message.mention.AllowedMentions;
-
 import java.util.EnumSet;
 import java.util.List;
 
@@ -158,20 +156,20 @@ public interface InteractionMessageBuilderBase<T> {
     T setAllowedMentions(AllowedMentions allowedMentions);
 
     /**
-     * Sets the message flags of the message.
+     * Sets the interaction callback data flags of the message.
      *
-     * @param messageFlags The message flags enum type.
+     * @param interactionCallbackDataFlags The interaction callback data flags enum type.
      * @return The current instance in order to chain call methods.
      */
-    T setFlags(MessageFlag... messageFlags);
+    T setFlags(InteractionCallbackDataFlag... interactionCallbackDataFlags);
 
     /**
-     * Sets the message flags of the message.
+     * Sets the interaction callback data flags of the message.
      *
-     * @param messageFlags An EnumSet of message flag enum type.
+     * @param interactionCallbackDataFlags An EnumSet of interaction callback data flag enum type.
      * @return The current instance in order to chain call methods.
      */
-    T setFlags(EnumSet<MessageFlag> messageFlags);
+    T setFlags(EnumSet<InteractionCallbackDataFlag> interactionCallbackDataFlags);
 
     /**
      * Gets the {@link StringBuilder} which is used to build the message.

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionMessageBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionMessageBuilderDelegateImpl.java
@@ -3,18 +3,17 @@ package org.javacord.core.entity.message;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.entity.message.Message;
-import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.message.internal.InteractionMessageBuilderDelegate;
 import org.javacord.api.interaction.InteractionBase;
 import org.javacord.api.interaction.MessageComponentInteraction;
+import org.javacord.api.interaction.callback.InteractionCallbackDataFlag;
 import org.javacord.core.entity.message.embed.EmbedBuilderDelegateImpl;
 import org.javacord.core.interaction.InteractionImpl;
 import org.javacord.core.util.FileContainer;
 import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
 import org.javacord.core.util.rest.RestRequest;
-
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -25,13 +24,13 @@ public class InteractionMessageBuilderDelegateImpl extends MessageBuilderBaseDel
         implements InteractionMessageBuilderDelegate {
 
     /**
-     * The message flags of the message.
+     * The interaction callback data flags of the message.
      */
-    private EnumSet<MessageFlag> messageFlags = null;
+    private EnumSet<InteractionCallbackDataFlag> interactionCallbackDataFlags = null;
 
     @Override
-    public void setFlags(EnumSet<MessageFlag> messageFlags) {
-        this.messageFlags = messageFlags;
+    public void setFlags(EnumSet<InteractionCallbackDataFlag> interactionCallbackDataFlags) {
+        this.interactionCallbackDataFlags = interactionCallbackDataFlags;
     }
 
     @Override
@@ -126,8 +125,9 @@ public class InteractionMessageBuilderDelegateImpl extends MessageBuilderBaseDel
     private void prepareInteractionWebhookBodyParts(ObjectNode body) {
         prepareCommonWebhookMessageBodyParts(body);
         prepareComponents(body, true);
-        if (null != messageFlags) {
-            body.put("flags", messageFlags.stream().mapToInt(MessageFlag::getId).sum());
+        if (null != interactionCallbackDataFlags) {
+            body.put("flags", interactionCallbackDataFlags.stream()
+                    .mapToInt(InteractionCallbackDataFlag::getId).sum());
         }
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/interaction/InteractionMessageBuilderBaseImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/InteractionMessageBuilderBaseImpl.java
@@ -2,14 +2,13 @@ package org.javacord.core.interaction;
 
 import org.javacord.api.entity.Mentionable;
 import org.javacord.api.entity.message.MessageDecoration;
-import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.entity.message.component.HighLevelComponent;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.message.internal.InteractionMessageBuilderDelegate;
 import org.javacord.api.entity.message.mention.AllowedMentions;
+import org.javacord.api.interaction.callback.InteractionCallbackDataFlag;
 import org.javacord.api.interaction.callback.InteractionMessageBuilderBase;
 import org.javacord.api.util.internal.DelegateFactory;
-
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
@@ -146,14 +145,14 @@ public abstract class InteractionMessageBuilderBaseImpl<T> implements Interactio
     }
 
     @Override
-    public T setFlags(MessageFlag... messageFlags) {
-        setFlags(EnumSet.copyOf(Arrays.asList(messageFlags)));
+    public T setFlags(InteractionCallbackDataFlag... interactionCallbackDataFlags) {
+        setFlags(EnumSet.copyOf(Arrays.asList(interactionCallbackDataFlags)));
         return myClass.cast(this);
     }
 
     @Override
-    public T setFlags(EnumSet<MessageFlag> messageFlags) {
-        delegate.setFlags(messageFlags);
+    public T setFlags(EnumSet<InteractionCallbackDataFlag> interactionCallbackDataFlags) {
+        delegate.setFlags(interactionCallbackDataFlags);
         return myClass.cast(this);
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/interaction/InteractionOriginalResponseUpdaterImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/InteractionOriginalResponseUpdaterImpl.java
@@ -4,14 +4,13 @@ import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.Mentionable;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.MessageDecoration;
-import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.entity.message.component.HighLevelComponent;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.message.internal.InteractionMessageBuilderDelegate;
 import org.javacord.api.entity.message.mention.AllowedMentions;
 import org.javacord.api.interaction.InteractionBase;
+import org.javacord.api.interaction.callback.InteractionCallbackDataFlag;
 import org.javacord.api.interaction.callback.InteractionOriginalResponseUpdater;
-
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.InputStream;
@@ -317,14 +316,15 @@ public class InteractionOriginalResponseUpdaterImpl
     }
 
     @Override
-    public InteractionOriginalResponseUpdater setFlags(MessageFlag... messageFlags) {
-        setFlags(EnumSet.copyOf(Arrays.asList(messageFlags)));
+    public InteractionOriginalResponseUpdater setFlags(InteractionCallbackDataFlag... interactionCallbackDataFlags) {
+        setFlags(EnumSet.copyOf(Arrays.asList(interactionCallbackDataFlags)));
         return this;
     }
 
     @Override
-    public InteractionOriginalResponseUpdater setFlags(EnumSet<MessageFlag> messageFlags) {
-        delegate.setFlags(messageFlags);
+    public InteractionOriginalResponseUpdater setFlags(
+            EnumSet<InteractionCallbackDataFlag> interactionCallbackDataFlags) {
+        delegate.setFlags(interactionCallbackDataFlags);
         return this;
     }
 }


### PR DESCRIPTION
Contains a breaking change in the `InteractionMessageBuilder` where the `MessageFlag` was replaced with the new `InteractionCallbackDataFlag`