### PR TITLE
Enable the user cache by default

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiBuilderDelegateImpl.java
@@ -132,7 +132,7 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
     /**
      * Whether the user cache should be enabled or not.
      */
-    private boolean userCacheEnabled = false;
+    private boolean userCacheEnabled = true;
 
     /**
      * The globally attachable listeners to register for every created DiscordApi instance.


### PR DESCRIPTION
The snapshot version has not been released and already quiet a few questions came up by users that the cache seems not to be working and that's because they didn't explicitly enabled the user cache.
To be more user friendly, the cache should be enabled by default so there is just a need to activate the `GUILD_MEMBERS` intent. And since beginners are just starting out there shouldn't be a problem with the memory footprint.