### PR TITLE
Convert interaction int option to long

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteractionOption.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteractionOption.java
@@ -50,14 +50,14 @@ public interface SlashCommandInteractionOption extends SlashCommandInteractionOp
     Optional<String> getStringValue();
 
     /**
-     * Gets the integer value of this option.
+     * Gets the long value of this option.
      *
-     * <p>If this option does not have an integer value or the option itself is a subcommand or group,
+     * <p>If this option does not have a long value or the option itself is a subcommand or group,
      *     the optional will be empty.
      *
-     * @return The integer value of this option.
+     * @return The long value of this option.
      */
-    Optional<Integer> getIntValue();
+    Optional<Long> getLongValue();
 
     /**
      * Gets the boolean value of this option.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteractionOptionsProvider.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteractionOptionsProvider.java
@@ -60,15 +60,16 @@ public interface SlashCommandInteractionOptionsProvider {
     }
 
     /**
-     * Gets the integer value of the first option (if present).
+     * Gets the long value of the first option (if present).
+     * This will be present if the option is of type {@link SlashCommandOptionType#INTEGER}.
      *
-     * @return An Optional with the integer value of such an option if it exists; an empty Optional otherwise
-     * @deprecated Use {@link #getOptions() getOptions().get(0).getIntValue()}
-     *     or {@link #getOptionIntValueByIndex(int) getOptionIntValueByIndex(0)} instead.
+     * @return An Optional with the long value of such an option if it exists; an empty Optional otherwise
+     * @deprecated Use {@link #getOptions() getOptions().get(0).getLongValue()}
+     *     or {@link #getOptionLongValueByIndex(int) getOptionLongValueByIndex(0)} instead.
      */
     @Deprecated
-    default Optional<Integer> getFirstOptionIntValue() {
-        return getFirstOption().flatMap(SlashCommandInteractionOption::getIntValue);
+    default Optional<Long> getFirstOptionLongValue() {
+        return getFirstOption().flatMap(SlashCommandInteractionOption::getLongValue);
     }
 
     /**
@@ -212,15 +213,16 @@ public interface SlashCommandInteractionOptionsProvider {
     }
 
     /**
-     * Gets the integer value of the second option (if present).
+     * Gets the long value of the second option (if present).
+     * This will be present if the option is of type {@link SlashCommandOptionType#INTEGER}.
      *
-     * @return An Optional with the integer value of such an option if it exists; an empty Optional otherwise
-     * @deprecated Use {@link #getOptions() getOptions().get(1).getIntValue()}
-     *     or {@link #getOptionIntValueByIndex(int) getOptionIntValueByIndex(1)} instead.
+     * @return An Optional with the long value of such an option if it exists; an empty Optional otherwise
+     * @deprecated Use {@link #getOptions() getOptions().get(1).getLongValue()}
+     *     or {@link #getOptionLongValueByIndex(int) getOptionLongValueByIndex(1)} instead.
      */
     @Deprecated
-    default Optional<Integer> getSecondOptionIntValue() {
-        return getSecondOption().flatMap(SlashCommandInteractionOption::getIntValue);
+    default Optional<Long> getSecondOptionLongValue() {
+        return getSecondOption().flatMap(SlashCommandInteractionOption::getLongValue);
     }
 
     /**
@@ -364,15 +366,16 @@ public interface SlashCommandInteractionOptionsProvider {
     }
 
     /**
-     * Gets the integer value of the third option (if present).
+     * Gets the long value of the third option (if present).
+     * This will be present if the option is of type {@link SlashCommandOptionType#INTEGER}.
      *
-     * @return An Optional with the integer value of such an option if it exists; an empty Optional otherwise
-     * @deprecated Use {@link #getOptions() getOptions().get(2).getIntValue()}
-     *     or {@link #getOptionIntValueByIndex(int) getOptionIntValueByIndex(2)} instead.
+     * @return An Optional with the long value of such an option if it exists; an empty Optional otherwise
+     * @deprecated Use {@link #getOptions() getOptions().get(2).getLongValue()}
+     *     or {@link #getOptionLongValueByIndex(int) getOptionLongValueByIndex(2)} instead.
      */
     @Deprecated
-    default Optional<Integer> getThirdOptionIntValue() {
-        return getThirdOption().flatMap(SlashCommandInteractionOption::getIntValue);
+    default Optional<Long> getThirdOptionLongValue() {
+        return getThirdOption().flatMap(SlashCommandInteractionOption::getLongValue);
     }
 
     /**
@@ -513,13 +516,14 @@ public interface SlashCommandInteractionOptionsProvider {
     }
 
     /**
-     * Gets the integer value of an option having the specified name.
+     * Gets the long value of an option having the specified name.
+     * This will be present if the option is of type {@link SlashCommandOptionType#INTEGER}.
      *
      * @param name The name of the option to search for.
-     * @return An Optional with the integer value of such an option if it exists; an empty Optional otherwise
+     * @return An Optional with the long value of such an option if it exists; an empty Optional otherwise
      */
-    default Optional<Integer> getOptionIntValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getIntValue);
+    default Optional<Long> getOptionLongValueByName(String name) {
+        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getLongValue);
     }
 
     /**
@@ -641,13 +645,14 @@ public interface SlashCommandInteractionOptionsProvider {
     }
 
     /**
-     * Gets the integer value of an option at the specified index.
+     * Gets the long value of an option at the specified index.
+     * This will be present if the option is of type {@link SlashCommandOptionType#INTEGER}.
      *
      * @param index The index of the option to search for.
-     * @return An Optional with the integer value of such an option if it exists; an empty Optional otherwise
+     * @return An Optional with the long value of such an option if it exists; an empty Optional otherwise
      */
-    default Optional<Integer> getOptionIntValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getIntValue);
+    default Optional<Long> getOptionLongValueByIndex(int index) {
+        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getLongValue);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionChoice.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionChoice.java
@@ -24,13 +24,13 @@ public interface SlashCommandOptionChoice {
     Optional<String> getStringValue();
 
     /**
-     * Gets the integer value of this choice.
+     * Gets the long value of this choice.
      *
      * <p>If this option is a string choice, the optional will be empty.
      *
-     * @return The integer value of this choice.
+     * @return The long value of this choice.
      */
-    Optional<Integer> getIntValue();
+    Optional<Long> getLongValue();
 
     /**
      * Gets the value of this choice as a string.
@@ -40,7 +40,7 @@ public interface SlashCommandOptionChoice {
      * @return The value of the choice as a string.
      */
     default String getValueAsString() {
-        return getStringValue().orElseGet(() -> getIntValue()
+        return getStringValue().orElseGet(() -> getLongValue()
             .map(String::valueOf)
             .orElseThrow(() ->
                 new AssertionError("slash command option choice value that's neither a string nor int")));
@@ -64,10 +64,10 @@ public interface SlashCommandOptionChoice {
      * Create a new option choice builder to be used with a command option builder.
      *
      * @param name The name of the choice.
-     * @param value The value of the choice.
+     * @param value The value of the choice. Can be any long between -2^53 and 2^53.
      * @return The new choice builder.
      */
-    static SlashCommandOptionChoice create(String name, int value) {
+    static SlashCommandOptionChoice create(String name, long value) {
         return new SlashCommandOptionChoiceBuilder()
             .setName(name)
             .setValue(value)

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionChoiceBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionChoiceBuilder.java
@@ -36,12 +36,13 @@ public class SlashCommandOptionChoiceBuilder {
     }
 
     /**
-     * Sets the int value of the slash command option choice.
+     * Sets the long value of the slash command option choice.
+     * Can be any long between -2^53 and 2^53.
      *
      * @param value The value.
      * @return The current instance in order to chain call methods.
      */
-    public SlashCommandOptionChoiceBuilder setValue(int value) {
+    public SlashCommandOptionChoiceBuilder setValue(long value) {
         delegate.setValue(value);
         return this;
     }

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionType.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionType.java
@@ -5,12 +5,19 @@ public enum SlashCommandOptionType {
     SUB_COMMAND(1),
     SUB_COMMAND_GROUP(2),
     STRING(3),
+    /**
+     * This is implemented as a long because it can be any integer between -2^53 and 2^53 and
+     * therefore exceeds Javas Integer range.
+     */
     INTEGER(4),
     BOOLEAN(5),
     USER(6),
     CHANNEL(7),
     ROLE(8),
     MENTIONABLE(9),
+    /**
+     * Any double between -2^53 and 2^53.
+     */
     NUMBER(10),
     UNKNOWN(-1);
 

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandOptionChoiceBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandOptionChoiceBuilderDelegate.java
@@ -24,11 +24,12 @@ public interface SlashCommandOptionChoiceBuilderDelegate {
     void setValue(String value);
 
     /**
-     * Sets the int value of the slash command option choice.
+     * Sets the long value of the slash command option choice.
+     * Can be any long between -2^53 and 2^53.
      *
      * @param value The value.
      */
-    void setValue(int value);
+    void setValue(long value);
 
     /**
      * Builds the slash command option choice.

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandInteractionOptionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandInteractionOptionImpl.java
@@ -25,7 +25,11 @@ public class SlashCommandInteractionOptionImpl implements SlashCommandInteractio
     private final String name;
     private final String stringRepresentation;
     private final String stringValue;
-    private final Integer intValue;
+    /**
+     * This is {@link SlashCommandOptionType#INTEGER} but it can be any integer between -2^53 and 2^53 and
+     * therefore exceeds Javas Integer range.
+     */
+    private final Long longValue;
     private final Boolean booleanValue;
     private final Long userValue;
     private final Long channelValue;
@@ -40,8 +44,8 @@ public class SlashCommandInteractionOptionImpl implements SlashCommandInteractio
     /**
      * Class constructor.
      *
-     * @param api      The DiscordApi instance.
-     * @param jsonData The json data of the option.
+     * @param api           The DiscordApi instance.
+     * @param jsonData      The json data of the option.
      * @param resolvedUsers The map of resolved users and their ID.
      */
     public SlashCommandInteractionOptionImpl(final DiscordApi api, final JsonNode jsonData,
@@ -54,7 +58,7 @@ public class SlashCommandInteractionOptionImpl implements SlashCommandInteractio
 
         String localStringRepresentation = null;
         String localStringValue = null;
-        Integer localIntValue = null;
+        Long localLongValue = null;
         Boolean localBooleanValue = null;
         Long localUserValue = null;
         Long localChannelValue = null;
@@ -78,8 +82,8 @@ public class SlashCommandInteractionOptionImpl implements SlashCommandInteractio
                 localStringRepresentation = localStringValue;
                 break;
             case INTEGER:
-                localIntValue = valueNode.asInt();
-                localStringRepresentation = String.valueOf(localIntValue);
+                localLongValue = valueNode.asLong();
+                localStringRepresentation = String.valueOf(localLongValue);
                 break;
             case BOOLEAN:
                 localBooleanValue = valueNode.asBoolean();
@@ -112,7 +116,7 @@ public class SlashCommandInteractionOptionImpl implements SlashCommandInteractio
 
         stringRepresentation = localStringRepresentation;
         stringValue = localStringValue;
-        intValue = localIntValue;
+        longValue = localLongValue;
         booleanValue = localBooleanValue;
         userValue = localUserValue;
         channelValue = localChannelValue;
@@ -137,8 +141,8 @@ public class SlashCommandInteractionOptionImpl implements SlashCommandInteractio
     }
 
     @Override
-    public Optional<Integer> getIntValue() {
-        return Optional.ofNullable(intValue);
+    public Optional<Long> getLongValue() {
+        return Optional.ofNullable(longValue);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionChoiceBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionChoiceBuilderDelegateImpl.java
@@ -3,12 +3,11 @@ package org.javacord.core.interaction;
 import org.javacord.api.interaction.SlashCommandOptionChoice;
 import org.javacord.api.interaction.internal.SlashCommandOptionChoiceBuilderDelegate;
 
-public class SlashCommandOptionChoiceBuilderDelegateImpl
-        implements SlashCommandOptionChoiceBuilderDelegate {
+public class SlashCommandOptionChoiceBuilderDelegateImpl implements SlashCommandOptionChoiceBuilderDelegate {
 
     private String name;
     private String stringValue;
-    private Integer intValue;
+    private Long longValue;
 
     @Override
     public void setName(String name) {
@@ -18,17 +17,17 @@ public class SlashCommandOptionChoiceBuilderDelegateImpl
     @Override
     public void setValue(String value) {
         stringValue = value;
-        intValue = null;
+        longValue = null;
     }
 
     @Override
-    public void setValue(int value) {
+    public void setValue(long value) {
         stringValue = null;
-        intValue = value;
+        longValue = value;
     }
 
     @Override
     public SlashCommandOptionChoice build() {
-        return new SlashCommandOptionChoiceImpl(name, stringValue, intValue);
+        return new SlashCommandOptionChoiceImpl(name, stringValue, longValue);
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionChoiceImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionChoiceImpl.java
@@ -11,7 +11,7 @@ public class SlashCommandOptionChoiceImpl implements SlashCommandOptionChoice {
 
     private final String name;
     private final String stringValue;
-    private final Integer intValue;
+    private final Long longValue;
 
     /**
      * Class constructor.
@@ -25,10 +25,10 @@ public class SlashCommandOptionChoiceImpl implements SlashCommandOptionChoice {
         } else {
             stringValue = null;
         }
-        if (data.get("value").isInt()) {
-            intValue = data.get("value").intValue();
+        if (data.get("value").isLong()) {
+            longValue = data.get("value").asLong();
         } else {
-            intValue = null;
+            longValue = null;
         }
     }
 
@@ -37,12 +37,12 @@ public class SlashCommandOptionChoiceImpl implements SlashCommandOptionChoice {
      *
      * @param name The name of the choice.
      * @param stringValue The string value of the choice or null if it is an int value.
-     * @param intValue The int value of the choice or null if it is a string value.
+     * @param longValue The long value of the choice or null if it is a string value.
      */
-    public SlashCommandOptionChoiceImpl(String name, String stringValue, Integer intValue) {
+    public SlashCommandOptionChoiceImpl(String name, String stringValue, Long longValue) {
         this.name = name;
         this.stringValue = stringValue;
-        this.intValue = intValue;
+        this.longValue = longValue;
     }
 
     @Override
@@ -56,8 +56,8 @@ public class SlashCommandOptionChoiceImpl implements SlashCommandOptionChoice {
     }
 
     @Override
-    public Optional<Integer> getIntValue() {
-        return Optional.ofNullable(intValue);
+    public Optional<Long> getLongValue() {
+        return Optional.ofNullable(longValue);
     }
 
     /**
@@ -68,7 +68,7 @@ public class SlashCommandOptionChoiceImpl implements SlashCommandOptionChoice {
     public JsonNode toJsonNode() {
         ObjectNode node = JsonNodeFactory.instance.objectNode();
         node.put("name", name);
-        getIntValue().ifPresent(value -> node.put("value", value));
+        getLongValue().ifPresent(value -> node.put("value", value));
         getStringValue().ifPresent(value -> node.put("value", value));
         return node;
     }


### PR DESCRIPTION
This change must happen as otherwise the integer can overflow if we receive a larger number.
It is open for discussion(and could also be done in a followup PR) if the method names should be changed to something else as it might be confusing that we return a long if the method is called something like `getIntValue`. But on the other hand it is also confusing if the option type is called different (INTEGER) than the method names (getLongValue).