### PR TITLE
Add support for avatar sizes via MessageAuthor

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
@@ -68,6 +68,14 @@ public interface MessageAuthor extends DiscordEntity, Nameable {
     Icon getAvatar();
 
     /**
+     * Gets the avatar of the user.
+     *
+     * @param size The size of the image, must be any power of 2 between 16 and 4096.
+     * @return The avatar of the user.
+     */
+    Icon getAvatar(int size);
+
+    /**
      * Gets the voice channel this MessageAuthor (if it is a User)
      * is connected to on the server where the message has been sent.
      *

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageAuthorImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageAuthorImpl.java
@@ -97,6 +97,11 @@ public class MessageAuthorImpl implements MessageAuthor {
     }
 
     @Override
+    public Icon getAvatar(int size) {
+        return UserImpl.getAvatar(message.getApi(), avatarId, discriminator, id, size);
+    }
+
+    @Override
     public boolean isUser() {
         return webhookId == null;
     }


### PR DESCRIPTION
It seems like the #885 forgot about `MessageAuthor` instance which can work with avatar's `size` parameter.