### PR TITLE
Fix SlashCommandInteractionOptionImpl#getUserValue NPE

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandInteractionOptionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandInteractionOptionImpl.java
@@ -155,8 +155,8 @@ public class SlashCommandInteractionOptionImpl implements SlashCommandInteractio
 
     @Override
     public Optional<User> getUserValue() {
-        return Optional.ofNullable(api.getCachedUserById(userValue)
-                .orElseGet(() -> resolvedUsers.get(userValue)));
+        return Optional.ofNullable(userValue)
+                .map(id -> api.getCachedUserById(id).orElseGet(() -> resolvedUsers.get(id)));
     }
 
     @Override


### PR DESCRIPTION
Fix SlashCommandInteractionOptionImpl#getUserValue to get the user always from the map which contains the users if any instead of using api#getCachedUserById which throws an NPE if the user value is null.