### PR TITLE
Update log4j-api and recommended log4j-core version

### DIFF
--- a/.github/README_template.md
+++ b/.github/README_template.md
@@ -121,7 +121,7 @@ log levels per class, and much more.
 
 For example, Log4j Core in Gradle
 ```groovy
-dependencies { runtimeOnly 'org.apache.logging.log4j:log4j-core:2.11.0' }
+dependencies { runtimeOnly 'org.apache.logging.log4j:log4j-core:2.17.0' }
 ```
 Take a look at the [logger configuration](https://javacord.org/wiki/basic-tutorials/logger-config.html) wiki article for further information.
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -35,7 +35,7 @@ project(':javacord-core') {
         implementation 'com.codahale:xsalsa20poly1305:0.10.1'
 
         // logging
-        implementation 'org.apache.logging.log4j:log4j-api:2.11.0'
+        implementation 'org.apache.logging.log4j:log4j-api:2.17.0'
 
         // Vavr, mainly for immutable collections
         // We are using 0.10.1, because of an issue in 0.10.2: https://github.com/vavr-io/vavr/issues/2573


### PR DESCRIPTION
See https://github.com/advisories/GHSA-jfh8-c2jp-5v3q

While Javacord itself is not affected by the security vulnerability (since we are only using the api and have our own "fallback" logger implementation), the README recommended Log4J with a vulnerable version.

This PRupdates the README to recommend the use of a patched version. It also updates the log4j-api dependency to the latest version just to make sure that there aren't any version conflicts.