### PR TITLE
Deprecate in all Message builders #addFile

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageBuilderBase.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageBuilderBase.java
@@ -235,8 +235,10 @@ abstract class MessageBuilderBase<T> {
      * @param image The image to add as an attachment.
      * @param fileName The file name of the image.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(BufferedImage, String)} instead.
      * @see #addAttachment(BufferedImage, String)
      */
+    @Deprecated
     public T addFile(BufferedImage image, String fileName) {
         delegate.addFile(image, fileName);
         return myClass.cast(this);
@@ -247,8 +249,10 @@ abstract class MessageBuilderBase<T> {
      *
      * @param file The file to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(File)} instead.
      * @see #addAttachment(File)
      */
+    @Deprecated
     public T addFile(File file) {
         delegate.addFile(file);
         return myClass.cast(this);
@@ -259,8 +263,10 @@ abstract class MessageBuilderBase<T> {
      *
      * @param icon The icon to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(Icon)} instead.
      * @see #addAttachment(Icon)
      */
+    @Deprecated
     public T addFile(Icon icon) {
         delegate.addFile(icon);
         return myClass.cast(this);
@@ -271,8 +277,10 @@ abstract class MessageBuilderBase<T> {
      *
      * @param url The url of the attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(URL)} instead.
      * @see #addAttachment(URL)
      */
+    @Deprecated
     public T addFile(URL url) {
         delegate.addFile(url);
         return myClass.cast(this);
@@ -284,8 +292,10 @@ abstract class MessageBuilderBase<T> {
      * @param bytes The bytes of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(byte[], String)} instead.
      * @see #addAttachment(byte[], String)
      */
+    @Deprecated
     public T addFile(byte[] bytes, String fileName) {
         delegate.addFile(bytes, fileName);
         return myClass.cast(this);
@@ -297,8 +307,10 @@ abstract class MessageBuilderBase<T> {
      * @param stream The stream of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(InputStream, String)} instead.
      * @see #addAttachment(InputStream, String)
      */
+    @Deprecated
     public T addFile(InputStream stream, String fileName) {
         delegate.addFile(stream, fileName);
         return myClass.cast(this);
@@ -310,8 +322,10 @@ abstract class MessageBuilderBase<T> {
      * @param image The image to add as an attachment.
      * @param fileName The file name of the image.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(BufferedImage, String)} instead.
      * @see #addAttachmentAsSpoiler(BufferedImage, String)
      */
+    @Deprecated
     public T addFileAsSpoiler(BufferedImage image, String fileName) {
         delegate.addFile(image, "SPOILER_" + fileName);
         return myClass.cast(this);
@@ -322,8 +336,10 @@ abstract class MessageBuilderBase<T> {
      *
      * @param file The file to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(File)} instead.
      * @see #addAttachmentAsSpoiler(File)
      */
+    @Deprecated
     public T addFileAsSpoiler(File file) {
         delegate.addFileAsSpoiler(file);
         return myClass.cast(this);
@@ -334,8 +350,10 @@ abstract class MessageBuilderBase<T> {
      *
      * @param icon The icon to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(Icon)} instead.
      * @see #addAttachmentAsSpoiler(Icon)
      */
+    @Deprecated
     public T addFileAsSpoiler(Icon icon) {
         delegate.addFileAsSpoiler(icon);
         return myClass.cast(this);
@@ -346,8 +364,10 @@ abstract class MessageBuilderBase<T> {
      *
      * @param url The url of the attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(URL)} instead.
      * @see #addAttachment(URL)
      */
+    @Deprecated
     public T addFileAsSpoiler(URL url) {
         delegate.addFileAsSpoiler(url);
         return myClass.cast(this);
@@ -359,8 +379,10 @@ abstract class MessageBuilderBase<T> {
      * @param bytes The bytes of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(byte[], String)} instead.
      * @see #addAttachmentAsSpoiler(byte[], String)
      */
+    @Deprecated
     public T addFileAsSpoiler(byte[] bytes, String fileName) {
         delegate.addFile(bytes, "SPOILER_" + fileName);
         return myClass.cast(this);
@@ -372,8 +394,10 @@ abstract class MessageBuilderBase<T> {
      * @param stream The stream of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(InputStream, String)} instead.
      * @see #addAttachment(InputStream, String)
      */
+    @Deprecated
     public T addFileAsSpoiler(InputStream stream, String fileName) {
         delegate.addFile(stream, "SPOILER_" + fileName);
         return myClass.cast(this);

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/WebhookMessageBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/WebhookMessageBuilder.java
@@ -235,8 +235,10 @@ public class WebhookMessageBuilder {
      * @param image The image to add as an attachment.
      * @param fileName The file name of the image.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(BufferedImage, String)} instead.
      * @see #addAttachment(BufferedImage, String)
      */
+    @Deprecated
     public WebhookMessageBuilder addFile(BufferedImage image, String fileName) {
         delegate.addFile(image, fileName);
         return this;
@@ -247,8 +249,10 @@ public class WebhookMessageBuilder {
      *
      * @param file The file to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(File)} instead.
      * @see #addAttachment(File)
      */
+    @Deprecated
     public WebhookMessageBuilder addFile(File file) {
         delegate.addFile(file);
         return this;
@@ -259,8 +263,10 @@ public class WebhookMessageBuilder {
      *
      * @param icon The icon to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(Icon)} instead.
      * @see #addAttachment(Icon)
      */
+    @Deprecated
     public WebhookMessageBuilder addFile(Icon icon) {
         delegate.addFile(icon);
         return this;
@@ -271,8 +277,10 @@ public class WebhookMessageBuilder {
      *
      * @param url The url of the attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(URL)} instead.
      * @see #addAttachment(URL)
      */
+    @Deprecated
     public WebhookMessageBuilder addFile(URL url) {
         delegate.addFile(url);
         return this;
@@ -284,8 +292,10 @@ public class WebhookMessageBuilder {
      * @param bytes The bytes of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(byte[], String)} instead.
      * @see #addAttachment(byte[], String)
      */
+    @Deprecated
     public WebhookMessageBuilder addFile(byte[] bytes, String fileName) {
         delegate.addFile(bytes, fileName);
         return this;
@@ -297,8 +307,10 @@ public class WebhookMessageBuilder {
      * @param stream The stream of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(InputStream, String)} instead.
      * @see #addAttachment(InputStream, String)
      */
+    @Deprecated
     public WebhookMessageBuilder addFile(InputStream stream, String fileName) {
         delegate.addFile(stream, fileName);
         return this;
@@ -310,8 +322,10 @@ public class WebhookMessageBuilder {
      * @param image The image to add as an attachment.
      * @param fileName The file name of the image.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(BufferedImage, String)} instead.
      * @see #addAttachmentAsSpoiler(BufferedImage, String)
      */
+    @Deprecated
     public WebhookMessageBuilder addFileAsSpoiler(BufferedImage image, String fileName) {
         delegate.addFile(image, "SPOILER_" + fileName);
         return this;
@@ -322,8 +336,10 @@ public class WebhookMessageBuilder {
      *
      * @param file The file to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(File)} instead.
      * @see #addAttachmentAsSpoiler(File)
      */
+    @Deprecated
     public WebhookMessageBuilder addFileAsSpoiler(File file) {
         delegate.addFileAsSpoiler(file);
         return this;
@@ -334,8 +350,10 @@ public class WebhookMessageBuilder {
      *
      * @param icon The icon to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(Icon)} instead.
      * @see #addAttachmentAsSpoiler(Icon)
      */
+    @Deprecated
     public WebhookMessageBuilder addFileAsSpoiler(Icon icon) {
         delegate.addFileAsSpoiler(icon);
         return this;
@@ -346,8 +364,10 @@ public class WebhookMessageBuilder {
      *
      * @param url The url of the attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(URL)} instead.
      * @see #addAttachment(URL)
      */
+    @Deprecated
     public WebhookMessageBuilder addFileAsSpoiler(URL url) {
         delegate.addFileAsSpoiler(url);
         return this;
@@ -359,8 +379,10 @@ public class WebhookMessageBuilder {
      * @param bytes The bytes of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(byte[], String)} instead.
      * @see #addAttachmentAsSpoiler(byte[], String)
      */
+    @Deprecated
     public WebhookMessageBuilder addFileAsSpoiler(byte[] bytes, String fileName) {
         delegate.addFile(bytes, "SPOILER_" + fileName);
         return this;
@@ -372,8 +394,10 @@ public class WebhookMessageBuilder {
      * @param stream The stream of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(InputStream, String)} instead.
      * @see #addAttachment(InputStream, String)
      */
+    @Deprecated
     public WebhookMessageBuilder addFileAsSpoiler(InputStream stream, String fileName) {
         delegate.addFile(stream, "SPOILER_" + fileName);
         return this;

--- a/javacord-api/src/main/java/org/javacord/api/interaction/callback/ExtendedInteractionMessageBuilderBase.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/callback/ExtendedInteractionMessageBuilderBase.java
@@ -33,8 +33,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      * @param image    The image to add as an attachment.
      * @param fileName The file name of the image.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(BufferedImage, String)} instead.
      * @see #addAttachment(BufferedImage, String)
      */
+    @Deprecated
     T addFile(BufferedImage image, String fileName);
 
     /**
@@ -42,8 +44,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      *
      * @param file The file to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(File)} instead.
      * @see #addAttachment(File)
      */
+    @Deprecated
     T addFile(File file);
 
     /**
@@ -51,8 +55,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      *
      * @param icon The icon to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(Icon)} instead.
      * @see #addAttachment(Icon)
      */
+    @Deprecated
     T addFile(Icon icon);
 
     /**
@@ -60,8 +66,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      *
      * @param url The url of the attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(URL)} instead.
      * @see #addAttachment(URL)
      */
+    @Deprecated
     T addFile(URL url);
 
     /**
@@ -70,8 +78,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      * @param bytes    The bytes of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(byte[], String)} instead.
      * @see #addAttachment(byte[], String)
      */
+    @Deprecated
     T addFile(byte[] bytes, String fileName);
 
     /**
@@ -80,8 +90,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      * @param stream   The stream of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(InputStream, String)} instead.
      * @see #addAttachment(InputStream, String)
      */
+    @Deprecated
     T addFile(InputStream stream, String fileName);
 
     /**
@@ -90,8 +102,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      * @param image    The image to add as an attachment.
      * @param fileName The file name of the image.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(BufferedImage, String)} instead.
      * @see #addAttachmentAsSpoiler(BufferedImage, String)
      */
+    @Deprecated
     T addFileAsSpoiler(BufferedImage image, String fileName);
 
     /**
@@ -99,8 +113,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      *
      * @param file The file to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(File)} instead.
      * @see #addAttachmentAsSpoiler(File)
      */
+    @Deprecated
     T addFileAsSpoiler(File file);
 
     /**
@@ -108,8 +124,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      *
      * @param icon The icon to add as an attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(Icon)} instead.
      * @see #addAttachmentAsSpoiler(Icon)
      */
+    @Deprecated
     T addFileAsSpoiler(Icon icon);
 
     /**
@@ -117,8 +135,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      *
      * @param url The url of the attachment.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(URL)} instead.
      * @see #addAttachment(URL)
      */
+    @Deprecated
     T addFileAsSpoiler(URL url);
 
     /**
@@ -127,8 +147,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      * @param bytes    The bytes of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(byte[], String)} instead.
      * @see #addAttachmentAsSpoiler(byte[], String)
      */
+    @Deprecated
     T addFileAsSpoiler(byte[] bytes, String fileName);
 
     /**
@@ -137,8 +159,10 @@ public interface ExtendedInteractionMessageBuilderBase<T> extends InteractionMes
      * @param stream   The stream of the file.
      * @param fileName The name of the file.
      * @return The current instance in order to chain call methods.
+     * @deprecated Use {@link #addAttachment(InputStream, String)} instead.
      * @see #addAttachment(InputStream, String)
      */
+    @Deprecated
     T addFileAsSpoiler(InputStream stream, String fileName);
 
     /**


### PR DESCRIPTION
As the methods `addFile` just redirect to the `addAtachement` methods they are redundant and would just cause some confusion.