### PR TITLE
Skip role in ChannelUpdateHandler if not present in cache.

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelUpdateHandler.java
@@ -223,12 +223,17 @@ public class ChannelUpdateHandler extends PacketHandler {
                 Optional<DiscordEntity> entity;
                 switch (permissionOverwriteJson.get("type").asInt()) {
                     case 0:
-                        Role role = server.getRoleById(entityId).orElseThrow(() ->
-                                new IllegalStateException("Received channel update event with unknown role!"));
-                        entity = Optional.of(role);
-                        oldOverwrittenPermissions = regularServerChannel.getOverwrittenPermissions(role);
-                        overwrittenPermissions = regularServerChannel.getInternalOverwrittenRolePermissions();
-                        rolesWithOverwrittenPermissions.add(entityId);
+                        //Skip role if not present. See: https://github.com/discord/discord-api-docs/issues/4303
+                        Optional<Role> optionalRole = server.getRoleById(entityId);
+                        if (optionalRole.isPresent()) {
+                            Role role = optionalRole.get();
+                            entity = Optional.of(role);
+                            oldOverwrittenPermissions = regularServerChannel.getOverwrittenPermissions(role);
+                            overwrittenPermissions = regularServerChannel.getInternalOverwrittenRolePermissions();
+                            rolesWithOverwrittenPermissions.add(entityId);
+                        } else {
+                            continue;
+                        }
                         break;
                     case 1:
                         oldOverwrittenPermissions = regularServerChannel.getOverwrittenUserPermissions()


### PR DESCRIPTION
So far I only got this exception for roles in the past 4-5 months. If anyone else experiences this for members we can skip them in a follow-up PR.
https://github.com/discord/discord-api-docs/issues/4303