### PR TITLE
Add getFocusedOption & getArguments methods for interactions

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/AutocompleteInteraction.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/AutocompleteInteraction.java
@@ -13,4 +13,11 @@ public interface AutocompleteInteraction extends SlashCommandInteraction {
      */
     CompletableFuture<Void> respondWithChoices(List<SlashCommandOptionChoice> choices);
 
+    /**
+     * Gets the focused option that triggered this AutocompleteInteraction.
+     *
+     * @return The focused option.
+     */
+    SlashCommandInteractionOption getFocusedOption();
+
 }

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteraction.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteraction.java
@@ -1,5 +1,17 @@
 package org.javacord.api.interaction;
 
+import java.util.List;
+
 public interface SlashCommandInteraction extends ApplicationCommandInteraction, SlashCommandInteractionOptionsProvider {
+
+    /**
+     * Gets the arguments of this slash command if there are any.
+     *
+     * <p>This is a shorthand method to avoid checking for Subcommmands or SubcommandGroups
+     * to get the slash command arguments.
+     *
+     * @return The argument options.
+     */
+    List<SlashCommandInteractionOption> getArguments();
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/AutocompleteInteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/AutocompleteInteractionImpl.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.interaction.AutocompleteInteraction;
 import org.javacord.api.interaction.InteractionType;
+import org.javacord.api.interaction.SlashCommandInteractionOption;
 import org.javacord.api.interaction.SlashCommandOptionChoice;
 import org.javacord.api.interaction.callback.InteractionFollowupMessageBuilder;
 import org.javacord.api.interaction.callback.InteractionImmediateResponseBuilder;
@@ -55,6 +56,15 @@ public class AutocompleteInteractionImpl extends SlashCommandInteractionImpl imp
                 .setUrlParameters(getIdAsString(), getToken())
                 .setBody(topBody)
                 .execute(result -> null);
+    }
+
+    @Override
+    public SlashCommandInteractionOption getFocusedOption() {
+        return getArguments().stream()
+                .filter(slashCommandInteractionOption -> slashCommandInteractionOption.isFocused().orElse(false))
+                .findFirst()
+                .orElseThrow(() ->
+                        new IllegalStateException("Autocomplete interaction does not have a focused option"));
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandInteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandInteractionImpl.java
@@ -87,4 +87,20 @@ public class SlashCommandInteractionImpl extends ApplicationCommandInteractionIm
     public String getCommandName() {
         return commandName;
     }
+
+    @Override
+    public List<SlashCommandInteractionOption> getArguments() {
+        return getArgumentsRecursive(getOptions());
+    }
+
+    private List<SlashCommandInteractionOption> getArgumentsRecursive(List<SlashCommandInteractionOption> options) {
+        if (options.isEmpty()) {
+            return Collections.emptyList();
+        } else if (options.get(0).isSubcommandOrGroup()) {
+            return getArgumentsRecursive(options.get(0).getOptions());
+        } else {
+            return options;
+        }
+    }
+
 }


### PR DESCRIPTION
- Improved existing API for SlashCommandInteraction by adding `getArguments` method to directly get the command arguments without checking for subcommands or groups
- AutocompleteInteraction now has a `getFocusedOption` method to get the focused option that triggered this event.