### PR TITLE
Remove test execution in gradle build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           java-version: 11
       - name: Build project
-        run: ./gradlew build
+        run: ./gradlew build -x test
       - name: Run tests
         run: ./gradlew test


### PR DESCRIPTION
The tests will be executed right after the build again so they will get executed twice