### PR TITLE
Fix `BotInviteBuilder` shortcomings with additional features.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/BotInviteBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/BotInviteBuilder.java
@@ -1,7 +1,15 @@
 package org.javacord.api;
 
+import org.javacord.api.entity.permission.PermissionType;
 import org.javacord.api.entity.permission.Permissions;
 import org.javacord.api.entity.permission.PermissionsBuilder;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 /**
  * A tool to create bot invites.
@@ -9,20 +17,35 @@ import org.javacord.api.entity.permission.PermissionsBuilder;
 public class BotInviteBuilder {
 
     /**
-     * The base link of a bot invite.
-     */
-    public static final String BASE_LINK =
-            "https://" + Javacord.DISCORD_DOMAIN + "/oauth2/authorize?client_id=%s&scope=bot&permissions=%s";
-
-    /**
-     * The client id of the bot's application.
+     * The application client identification.
      */
     private long clientId;
+
+    /**
+     * The base link for a bot application invite link.
+     */
+    public static final String BASE_LINK =
+            "https://" + Javacord.DISCORD_DOMAIN + "/oauth2/authorize?client_id=";
+
+    /**
+     * The URI to redirect after inviting.
+     */
+    private String redirectUri = "";
+
+    /**
+     * The scopes to append to the link.
+     */
+    private Collection<BotInviteScope> inviteScopes = new ArrayList<>();
 
     /**
      * The permissions for the bot.
      */
     private Permissions permissions = new PermissionsBuilder().build();
+
+    /**
+     * To append the consent field into the invite builder or not.
+     */
+    private boolean consent = true;
 
     /**
      * Creates a new bot invite builder.
@@ -42,8 +65,17 @@ public class BotInviteBuilder {
         try {
             this.clientId = Long.parseLong(clientId);
         } catch (NumberFormatException e) {
-            this.clientId = 0;
+            this.clientId = 0L;
         }
+    }
+
+    /**
+     * Creates a new bot invite builder.
+     *
+     * @param api The Discord API to use.
+     */
+    public BotInviteBuilder(DiscordApi api) {
+        this.clientId = api.getClientId();
     }
 
     /**
@@ -58,12 +90,120 @@ public class BotInviteBuilder {
     }
 
     /**
+     * Sets the permissions the bot should have.
+     *
+     * @param permissions The permissions to set.
+     * @return The current instance in order to chain call methods.
+     */
+    public BotInviteBuilder setPermissions(PermissionType... permissions) {
+        this.permissions = new PermissionsBuilder()
+                .setAllowed(permissions)
+                .build();
+        return this;
+    }
+
+    /**
+     * Sets the redirect uri for this invite builder.
+     *
+     * @param redirectUri The redirect uri to set.
+     * @return The current instance in order to chain call methods.
+     */
+    public BotInviteBuilder setRedirectUri(String redirectUri) {
+        this.redirectUri = redirectUri;
+        return this;
+    }
+
+    /**
+     * Sets the scopes for this invite builder.
+     *
+     * @param scopes The scopes to set.
+     * @return The current instance in order to chain call methods.
+     */
+    public BotInviteBuilder setScopes(Collection<BotInviteScope> scopes) {
+        this.inviteScopes = scopes;
+        return this;
+    }
+
+    /**
+     * Sets the scopes for this invite builder.
+     *
+     * @param scopes The scopes to set.
+     * @return The current instance in order to chain call methods.
+     */
+    public BotInviteBuilder setScopes(BotInviteScope... scopes) {
+        this.inviteScopes = Arrays.asList(scopes);
+        return this;
+    }
+
+    /**
+     * Adds the scopes for this invite builder.
+     *
+     * @param scopes The scopes to add.
+     * @return The current instance in order to chain call methods.
+     */
+    public BotInviteBuilder addScopes(Collection<BotInviteScope> scopes) {
+        this.inviteScopes.addAll(scopes);
+        return this;
+    }
+
+    /**
+     * Adds the scopes for this invite builder.
+     *
+     * @param scopes The scopes to add.
+     * @return The current instance in order to chain call methods.
+     */
+    public BotInviteBuilder addScopes(BotInviteScope... scopes) {
+        this.inviteScopes.addAll(Arrays.asList(scopes));
+        return this;
+    }
+
+    /**
+     * Sets whether to append prompt consent to the invite link.
+     *
+     * @param promptConsent Whether to append prompt consent or not.
+     * @return The current instance in order to chain call methods.
+     */
+    public BotInviteBuilder setPromptConsent(boolean promptConsent) {
+        this.consent = promptConsent;
+        return this;
+    }
+
+    /**
      * Creates the invite link.
      *
      * @return The invite link for the bot.
      */
     public String build() {
-        return String.format(BASE_LINK, clientId, permissions.getAllowedBitmask());
+        if (inviteScopes.isEmpty()) {
+            addScopes(BotInviteScope.BOT, BotInviteScope.APPLICATIONS_COMMANDS);
+        }
+
+        StringBuilder builder = new StringBuilder(BASE_LINK);
+        builder.append(clientId)
+                .append("&scope=")
+                .append(
+                        inviteScopes.stream()
+                                .map(BotInviteScope::getScope)
+                                .collect(Collectors.joining("%20"))
+                )
+                .append("&permissions=")
+                .append(permissions.getAllowedBitmask());
+
+        if (redirectUri != null && !redirectUri.isEmpty()) {
+            try {
+                builder.append("&redirect_uri=")
+                        .append(URLEncoder.encode(redirectUri, "UTF-8"))
+                        .append("&response_type=code");
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (consent) {
+            builder.append("&prompt=consent");
+        }
+
+        return builder.toString();
     }
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/BotInviteScope.java
+++ b/javacord-api/src/main/java/org/javacord/api/BotInviteScope.java
@@ -1,0 +1,55 @@
+package org.javacord.api;
+
+
+/**
+ * An enum for the Invite Scope that is used for
+ * building bot invite links.
+ */
+public enum BotInviteScope {
+
+    IDENTIFY("identify"),
+    EMAIL("email"),
+    CONNECTIONS("connections"),
+    GUILDS("guilds"),
+    GUILDS_JOIN("guilds.join"),
+    GUILDS_MEMBERS_READ("guilds.members.read"),
+    GDM_JOIN("gdm.join"),
+    RPC("rpc"),
+    RPC_NOTIFICATIONS_READ("rpc.notifications.read"),
+    RPC_VOICE_READ("rpc.voice.read"),
+    RPC_VOICE_WRITE("rpc.voice.write"),
+    RPC_ACTIVITIES_WRITE("rpc.activities.write"),
+    BOT("bot"),
+    WEBHOOK_INCOMING("webhook.incoming"),
+    MESSAGES_READ("messages.read"),
+    APPLICATIONS_BUILDS_UPLOAD("applications.builds.upload"),
+    APPLICATIONS_BUILDS_READ("applications.builds.read"),
+    APPLICATIONS_COMMANDS("applications.commands"),
+    APPLICATIONS_COMMANDS_PERMISSIONS_UPDATE("applications.commands.permissions.update"),
+    APPLICATIONS_STORE_UPDATE("applications.store.update"),
+    APPLICATIONS_ENTITLEMENTS("applications.entitlements"),
+    ACTIVITIES_READ("activities.read"),
+    ACTIVITIES_WRITE("activities.write"),
+    RELATIONSHIPS_READ("relationships.read");
+
+    private final String scope;
+
+    /**
+     * Creates a {@link BotInviteScope} which can be used in the
+     * bot invite builder for scoping.
+     *
+     * @param scope The value for the query of this scope.
+     */
+    BotInviteScope(String scope) {
+        this.scope = scope;
+    }
+
+    /**
+     * Gets the query paramater value for this scope.
+     *
+     * @return The parameter for the query value of this scope.
+     */
+    public String getScope() {
+        return scope;
+    }
+}


### PR DESCRIPTION
This is sort of an entire revamp of the BotInviteBuilder that allows the addition of `BotInviteScope`, `Prompt Consent`, and `Redirect URIs` for completeness. This also adds a few more conveience methods such as `addScopes`, `addPermissions`, and so forth with an extra builder for `DiscordApi`.

> 🟥 I think this change would be marked as "breaking" because the `BASE_LINK` was changed to utilize a StringBuilder approach into building the links. I could use `String#Format` plus concatenation but considering how this is 3.5.0, I was thinking of just going with this.

> 🟨  This also follows the suggestion of which it shouldn't throw an exception when **REDIRECT_URI** is not set while using specific scopes that require the **REDIRECT_URI** to be set.

I also have no idea where to place the Enum for `BotInviteScope` but since the other common enums were found in the `api.entity` package, I decided to follow that instead. Feel free to correct me if I need to place it somewhere else instead.

✅  This commit has been tested for all functionality, thoroughly.
🧷 Fixes #908 
