### PR TITLE
Add teams

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -1,6 +1,7 @@
 package org.javacord.api;
 
 import org.javacord.api.entity.ApplicationInfo;
+import org.javacord.api.entity.ApplicationOwner;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.activity.Activity;
 import org.javacord.api.entity.activity.ActivityType;
@@ -536,40 +537,56 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
      * Gets the id of the application's owner.
      *
      * @return The id of the application's owner.
+     * @see ApplicationInfo#getOwner()
+     * @see ApplicationOwner#getId()
      */
-    long getOwnerId();
+    default Optional<Long> getOwnerId() {
+        ApplicationInfo applicationInfo = getCachedApplicationInfo();
+        return applicationInfo.getOwner()
+                .map(ApplicationOwner::getId);
+    }
 
     /**
      * Gets the owner of the application.
      *
-     * @return The owner of the application.
+     * @return The owner of the application, if applicable.
+     * @see ApplicationInfo#getOwner()
+     * @see ApplicationOwner#requestUser()
      */
-    default CompletableFuture<User> getOwner() {
-        return getUserById(getOwnerId());
+    default Optional<CompletableFuture<User>> getOwner() {
+        return getCachedApplicationInfo().getOwner()
+                .map(ApplicationOwner::requestUser);
     }
 
     /**
      * Gets the team of the application.
      *
-     * @return The team of the application.
+     * @return The team of the application, if applicable.
+     * @see ApplicationInfo#getTeam()
      */
-    Optional<Team> getCachedTeam();
+    default Optional<Team> getCachedTeam() {
+        return getCachedApplicationInfo().getTeam();
+    }
 
     /**
      * Requests the team of the application.
      *
      * @return The team of the application.
+     * @see ApplicationInfo#getTeam()
      */
     default CompletableFuture<Optional<Team>> requestTeam() {
-        return getApplicationInfo().thenApply(ApplicationInfo::getTeam);
+        return requestApplicationInfo().thenApply(ApplicationInfo::getTeam);
     }
 
     /**
      * Gets the client id of the application.
      *
      * @return The client id of the application.
+     * @see ApplicationInfo#getClientId()
      */
-    long getClientId();
+    default long getClientId() {
+        return getCachedApplicationInfo().getClientId();
+    }
 
     /**
      * Disconnects the bot.
@@ -623,12 +640,22 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
     int getReconnectDelay(int attempt);
 
     /**
+     * Gets the cached application info of the bot.
+     *
+     * @return The cached application info.
+     * @see #requestApplicationInfo()
+     */
+    ApplicationInfo getCachedApplicationInfo();
+
+    /**
      * Gets the application info of the bot.
-     * The method only works for bot accounts.
+     *
+     * <p>This will always request the up to date application info and update the cache.</p>
      *
      * @return The application info of the bot.
+     * @see #getCachedApplicationInfo()
      */
-    CompletableFuture<ApplicationInfo> getApplicationInfo();
+    CompletableFuture<ApplicationInfo> requestApplicationInfo();
 
     /**
      * Gets a webhook by its id.

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -29,6 +29,7 @@ import org.javacord.api.entity.server.ServerBuilder;
 import org.javacord.api.entity.server.invite.Invite;
 import org.javacord.api.entity.sticker.Sticker;
 import org.javacord.api.entity.sticker.StickerPack;
+import org.javacord.api.entity.team.Team;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.user.UserStatus;
 import org.javacord.api.entity.webhook.IncomingWebhook;
@@ -545,6 +546,22 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
      */
     default CompletableFuture<User> getOwner() {
         return getUserById(getOwnerId());
+    }
+
+    /**
+     * Gets the team of the application.
+     *
+     * @return The team of the application.
+     */
+    Optional<Team> getCachedTeam();
+
+    /**
+     * Requests the team of the application.
+     *
+     * @return The team of the application.
+     */
+    default CompletableFuture<Optional<Team>> requestTeam() {
+        return getApplicationInfo().thenApply(ApplicationInfo::getTeam);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/ApplicationInfo.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/ApplicationInfo.java
@@ -1,7 +1,9 @@
 package org.javacord.api.entity;
 
+import org.javacord.api.entity.team.Team;
 import org.javacord.api.entity.user.User;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -65,5 +67,13 @@ public interface ApplicationInfo extends Nameable {
      * @return The owner of the application.
      */
     CompletableFuture<User> getOwner();
+
+    /**
+     * Gets the team of the application.
+     *
+     * @return The team of the application.
+     */
+
+    Optional<Team> getTeam();
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/ApplicationInfo.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/ApplicationInfo.java
@@ -34,6 +34,15 @@ public interface ApplicationInfo extends Nameable {
     boolean isPublicBot();
 
     /**
+     * Check if the application is owned by a team rather than a single user.
+     *
+     * @return Whether the application is owned by a team.
+     */
+    default boolean isOwnedByTeam() {
+        return getTeam().isPresent();
+    }
+
+    /**
      * Check if the application's bot require OAuth2 code grant.
      *
      * @return Whether the application's bot require OAuth2 code grant or not.
@@ -43,37 +52,72 @@ public interface ApplicationInfo extends Nameable {
     /**
      * Gets the name of the application owner.
      *
-     * @return The name of the application owner.
+     * <p>If the application is owned by a user, this will be the username. If it
+     * is owned by a team, the return value will be empty.</p>
+     *
+     * @return The name of the application owner, if applicable.
+     * @deprecated This method is deprecated. Access {@link #getOwner()} instead. This method is scheduled for removal.
      */
-    String getOwnerName();
+    @Deprecated
+    default Optional<String> getOwnerName() {
+        return getOwner().map(ApplicationOwner::getName);
+    }
 
     /**
      * Gets the id of the application owner.
      *
      * @return The id of the application owner.
+     * @deprecated This method is deprecated. Access {@link #getOwner()} instead. This method is scheduled for removal.
      */
-    long getOwnerId();
+    @Deprecated
+    default Optional<Long> getOwnerId() {
+        return getOwner().isPresent() ? Optional.of(getOwner().get().getId()) : Optional.empty();
+    }
+
+    /**
+     * Gets the owner of the Application.
+     *
+     * <p>An application might be owned by a user or team. If it is not owned
+     * by a user, this methods return value will be empty.</p>
+     *
+     * @return The user owning this application, if applicable.
+     */
+    Optional<ApplicationOwner> getOwner();
 
     /**
      * Gets the discriminator of the application owner.
      *
-     * @return The discriminator of the application owner.
+     * <p>The contents of this are undefined if the owner is a team, but will
+     * likely always be "0000"</p>
+     *
+     * @return The discriminator of the application owner, if applicable.
+     * @deprecated This method is deprecated. Access {@link #getOwner()} instead. This method is scheduled for removal.
      */
-    String getOwnerDiscriminator();
+    @Deprecated
+    default Optional<String> getOwnerDiscriminator() {
+        return getOwner().map(ApplicationOwner::getDiscriminator);
+    }
 
     /**
-     * Gets the owner of the application.
+     * Requests the owner of the application.
      *
      * @return The owner of the application.
+     * @deprecated This method is deprecated. Access {@link #getOwner()} instead. This method is scheduled for removal.
      */
-    CompletableFuture<User> getOwner();
+    @Deprecated
+    default CompletableFuture<Optional<User>> requestOwner() {
+        if (getOwner().isPresent()) {
+            return getOwner().get().requestUser().thenApply(Optional::of);
+        } else {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+    }
 
     /**
-     * Gets the team of the application.
+     * Gets the team owning the application.
      *
-     * @return The team of the application.
+     * @return The team owning the application, if applicable.
      */
-
     Optional<Team> getTeam();
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/ApplicationOwner.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/ApplicationOwner.java
@@ -1,0 +1,46 @@
+package org.javacord.api.entity;
+
+import org.javacord.api.entity.user.User;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The owner of an application.
+ *
+ * @see ApplicationInfo
+ * @see org.javacord.api.entity.team.Team
+ */
+public interface ApplicationOwner extends DiscordEntity, Nameable {
+
+    /**
+     * The owner's name without discriminator.
+     *
+     * @return The owner's name.
+     */
+    @Override
+    String getName();
+
+    /**
+     * The owner's discriminator.
+     *
+     * @return The owner's discriminator.
+     */
+    String getDiscriminator();
+
+    /**
+     * The owner's discriminated name.
+     *
+     * @return The owner's discriminated name.
+     */
+    default String getDiscriminatedName() {
+        return getName() + "#" + getDiscriminator();
+    }
+
+    /**
+     * Requests the owner as a User.
+     *
+     * @return The owner as a User.
+     */
+    CompletableFuture<User> requestUser();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
@@ -98,12 +98,22 @@ public interface MessageAuthor extends DiscordEntity, Nameable {
 
     /**
      * Checks if the author is the owner of the current account.
-     * Always returns <code>false</code> if logged in to a user account.
+     *
+     * <p>Will return false if the account is owned by a team.</p>
      *
      * @return Whether the author is the owner of the current account.
      */
     default boolean isBotOwner() {
-        return isUser() && getApi().getOwnerId() == getId();
+        return asUser().map(User::isBotOwner).orElse(false);
+    }
+
+    /**
+     * Checks if the author is a member of the team owning the bot account.
+     *
+     * @return Whether the author is a member of the team owning the bot account.
+     */
+    default boolean isTeamMember() {
+        return asUser().map(User::isTeamMember).orElse(false);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/team/Team.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/team/Team.java
@@ -1,0 +1,41 @@
+package org.javacord.api.entity.team;
+
+import org.javacord.api.entity.DiscordEntity;
+import org.javacord.api.entity.Icon;
+import org.javacord.api.entity.user.User;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public interface Team extends DiscordEntity {
+    /**
+     * Gets the icon of the team.
+     *
+     * @return The icon of the team.
+     */
+    Optional<Icon> getIcon();
+
+    /**
+     * Gets the members of the team.
+     *
+     * @return The members of the team.
+     */
+    Collection<TeamMember> getTeamMembers();
+
+    /**
+     * Gets the id of the owner.
+     *
+     * @return The if of the owner.
+     */
+    long getOwnerId();
+
+    /**
+     * Gets the owner of the team.
+     *
+     * @return The owner of the team.
+     */
+    default CompletableFuture<User> getOwner() {
+        return getApi().getUserById(getOwnerId());
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/team/Team.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/team/Team.java
@@ -2,13 +2,14 @@ package org.javacord.api.entity.team;
 
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
+import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.user.User;
 
-import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-public interface Team extends DiscordEntity {
+public interface Team extends DiscordEntity, Nameable {
     /**
      * Gets the icon of the team.
      *
@@ -21,21 +22,28 @@ public interface Team extends DiscordEntity {
      *
      * @return The members of the team.
      */
-    Collection<TeamMember> getTeamMembers();
+    Set<TeamMember> getTeamMembers();
 
     /**
      * Gets the id of the owner.
      *
-     * @return The if of the owner.
+     * @return The id of the owner.
      */
     long getOwnerId();
 
     /**
-     * Gets the owner of the team.
+     * Gets the name of the team.
+     *
+     * @return The name of the team.
+     */
+    String getName();
+
+    /**
+     * Requests the owner of the team.
      *
      * @return The owner of the team.
      */
-    default CompletableFuture<User> getOwner() {
+    default CompletableFuture<User> requestOwner() {
         return getApi().getUserById(getOwnerId());
     }
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/team/TeamMember.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/team/TeamMember.java
@@ -1,0 +1,23 @@
+package org.javacord.api.entity.team;
+
+import org.javacord.api.entity.DiscordEntity;
+import org.javacord.api.entity.user.User;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface TeamMember extends DiscordEntity {
+
+    /**
+     * Gets the state of the membership.
+     *
+     * @return The state of the membership.
+     */
+    TeamMembershipState getMembershipState();
+
+    /**
+     * Gets the member as user.
+     *
+     * @return The member as user.
+     */
+    CompletableFuture<User> getUser();
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/team/TeamMember.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/team/TeamMember.java
@@ -15,9 +15,21 @@ public interface TeamMember extends DiscordEntity {
     TeamMembershipState getMembershipState();
 
     /**
-     * Gets the member as user.
+     * Gets the user id of this member.
+     *
+     * @return The user id.
+     */
+    @Override
+    long getId();
+
+    /**
+     * Requests the member as user.
+     *
+     * <p>If the user is not cached, it will be requested.</p>
      *
      * @return The member as user.
      */
-    CompletableFuture<User> getUser();
+    default CompletableFuture<User> requestUser() {
+        return getApi().getUserById(getId());
+    }
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/team/TeamMembershipState.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/team/TeamMembershipState.java
@@ -1,0 +1,55 @@
+package org.javacord.api.entity.team;
+
+
+public enum TeamMembershipState {
+
+    /**
+     * User is invited as a team member.
+     */
+    INVITED(1),
+
+    /**
+     * User is accepted as a team member.
+     */
+    ACCEPTED(2),
+
+    /**
+     * An unknown team membership state, most likely due to new team membership states.
+     */
+    UNKNOWN(-1);
+
+    private final int id;
+
+    /**
+     * Class constructor.
+     *
+     * @param id The id of the membership state
+     */
+    TeamMembershipState(int id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the id of the membership state.
+     *
+     * @return The id of the membership state.
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Gets the team membership state by its id.
+     *
+     * @param id The id of the team membership state.
+     * @return The team membership state with the given id.
+     */
+    public static TeamMembershipState fromId(int id) {
+        for (TeamMembershipState membershipState : values()) {
+            if (membershipState.getId() == id) {
+                return membershipState;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -73,6 +73,18 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
     }
 
     /**
+     * Checks if this user is a member of the team of the current account.
+     * Always returns <code>false</code> if logged in to a user account.
+     *
+     * @return Whether this user is a member of the team of the current account.
+     */
+    default boolean isTeamMember() {
+        return getApi().getAccountType() == AccountType.BOT
+                && getApi().getCachedTeam().map(team -> team.getOwnerId() == getId()
+                || team.getTeamMembers().stream().anyMatch(teamMember -> teamMember.getId() == getId())).orElse(false);
+    }
+
+    /**
      * Gets the activities of the user.
      *
      * @return The activities of the user.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -16,6 +16,7 @@ import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.server.ServerUpdater;
 import org.javacord.api.listener.user.UserAttachableListenerManager;
+
 import java.awt.Color;
 import java.time.Duration;
 import java.time.Instant;
@@ -63,25 +64,31 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
     boolean isBot();
 
     /**
-     * Checks if this user is the owner of the current account.
-     * Always returns <code>false</code> if logged in to a user account.
+     * Checks if this user is the owner of the current account or the current account's team.
      *
      * @return Whether this user is the owner of the current account.
      */
     default boolean isBotOwner() {
-        return getApi().getOwnerId() == getId();
+        return getApi().getOwnerId().isPresent() && getApi().getOwnerId().get() == getId();
     }
 
     /**
      * Checks if this user is a member of the team of the current account.
-     * Always returns <code>false</code> if logged in to a user account.
      *
      * @return Whether this user is a member of the team of the current account.
      */
     default boolean isTeamMember() {
-        return getApi().getAccountType() == AccountType.BOT
-                && getApi().getCachedTeam().map(team -> team.getOwnerId() == getId()
+        return getApi().getCachedTeam().map(team -> team.getOwnerId() == getId()
                 || team.getTeamMembers().stream().anyMatch(teamMember -> teamMember.getId() == getId())).orElse(false);
+    }
+
+    /**
+     * Checks if this user is the owner or a member of the team of the current account.
+     *
+     * @return Whether this user is the owner or a member of the team of the current account.
+     */
+    default boolean isBotOwnerOrTeamMember() {
+        return isBotOwner() || isTeamMember();
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/entity/ApplicationOwnerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/ApplicationOwnerImpl.java
@@ -1,0 +1,56 @@
+package org.javacord.core.entity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.ApplicationOwner;
+import org.javacord.api.entity.user.User;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An implementation for {@link ApplicationOwner}.
+ */
+public class ApplicationOwnerImpl implements ApplicationOwner {
+
+    private final DiscordApi api;
+    private final long id;
+    private final String name;
+    private final String discriminator;
+
+    /**
+     * Construct the owner from json.
+     * @param api The discord api instance.
+     * @param data The json node.
+     */
+    public ApplicationOwnerImpl(DiscordApi api, JsonNode data) {
+        this.api = api;
+        id = data.get("id").asLong();
+        name = data.get("username").asText();
+        discriminator = data.get("discriminator").asText();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getDiscriminator() {
+        return discriminator;
+    }
+
+    @Override
+    public CompletableFuture<User> requestUser() {
+        return api.getUserById(id);
+    }
+
+    @Override
+    public DiscordApi getApi() {
+        return api;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/activity/ApplicationInfoImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/activity/ApplicationInfoImpl.java
@@ -3,8 +3,12 @@ package org.javacord.core.entity.activity;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.ApplicationInfo;
+import org.javacord.api.entity.team.Team;
 import org.javacord.api.entity.user.User;
+import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.entity.team.TeamImpl;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -22,6 +26,7 @@ public class ApplicationInfoImpl implements ApplicationInfo {
     private final long ownerId;
     private final String ownerName;
     private final String ownerDiscriminator;
+    private final Team team;
 
     /**
      * Creates a new application info object.
@@ -40,6 +45,7 @@ public class ApplicationInfoImpl implements ApplicationInfo {
         ownerId = data.get("owner").get("id").asLong();
         ownerName = data.get("owner").get("username").asText();
         ownerDiscriminator = data.get("owner").get("discriminator").asText();
+        team = data.hasNonNull("team") ? new TeamImpl((DiscordApiImpl) api, data.get("team")) : null;
     }
 
     @Override
@@ -85,5 +91,10 @@ public class ApplicationInfoImpl implements ApplicationInfo {
     @Override
     public CompletableFuture<User> getOwner() {
         return api.getUserById(getOwnerId());
+    }
+
+    @Override
+    public Optional<Team> getTeam() {
+        return Optional.ofNullable(team);
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/activity/ApplicationInfoImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/activity/ApplicationInfoImpl.java
@@ -3,29 +3,25 @@ package org.javacord.core.entity.activity;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.ApplicationInfo;
+import org.javacord.api.entity.ApplicationOwner;
 import org.javacord.api.entity.team.Team;
-import org.javacord.api.entity.user.User;
 import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.entity.ApplicationOwnerImpl;
 import org.javacord.core.entity.team.TeamImpl;
 
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * The implementation of {@link ApplicationInfo}.
  */
 public class ApplicationInfoImpl implements ApplicationInfo {
 
-    private final DiscordApi api;
-
     private final long clientId;
     private final String name;
     private final String description;
     private final boolean publicBot;
     private final boolean botRequiresCodeGrant;
-    private final long ownerId;
-    private final String ownerName;
-    private final String ownerDiscriminator;
+    private final ApplicationOwner owner;
     private final Team team;
 
     /**
@@ -35,17 +31,15 @@ public class ApplicationInfoImpl implements ApplicationInfo {
      * @param data The json data of the application.
      */
     public ApplicationInfoImpl(DiscordApi api, JsonNode data) {
-        this.api = api;
 
         clientId = data.get("id").asLong();
         name = data.get("name").asText();
         description = data.get("description").asText();
         publicBot = data.get("bot_public").asBoolean();
         botRequiresCodeGrant = data.get("bot_require_code_grant").asBoolean();
-        ownerId = data.get("owner").get("id").asLong();
-        ownerName = data.get("owner").get("username").asText();
-        ownerDiscriminator = data.get("owner").get("discriminator").asText();
         team = data.hasNonNull("team") ? new TeamImpl((DiscordApiImpl) api, data.get("team")) : null;
+        // Discord appears to send dummy owner data as a fallback, so we have to check for a team
+        owner = (team == null) ? new ApplicationOwnerImpl(api, data.get("owner")) : null;
     }
 
     @Override
@@ -74,23 +68,8 @@ public class ApplicationInfoImpl implements ApplicationInfo {
     }
 
     @Override
-    public String getOwnerName() {
-        return ownerName;
-    }
-
-    @Override
-    public long getOwnerId() {
-        return ownerId;
-    }
-
-    @Override
-    public String getOwnerDiscriminator() {
-        return ownerDiscriminator;
-    }
-
-    @Override
-    public CompletableFuture<User> getOwner() {
-        return api.getUserById(getOwnerId());
+    public Optional<ApplicationOwner> getOwner() {
+        return Optional.ofNullable(owner);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/team/TeamImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/team/TeamImpl.java
@@ -1,0 +1,111 @@
+package org.javacord.core.entity.team;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.logging.log4j.Logger;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.Javacord;
+import org.javacord.api.entity.Icon;
+import org.javacord.api.entity.team.Team;
+import org.javacord.api.entity.team.TeamMember;
+import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.entity.IconImpl;
+import org.javacord.core.util.logging.LoggerUtil;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+public class TeamImpl implements Team {
+
+    /**
+     * The logger of this class.
+     */
+    private static final Logger logger = LoggerUtil.getLogger(TeamImpl.class);
+
+    /**
+     * The discord api instance.
+     */
+    private final DiscordApiImpl api;
+
+    /**
+     * The id of the team.
+     */
+    private final long id;
+
+    /**
+     * The id of the owner.
+     */
+    private final long ownerId;
+
+    /**
+     * The avatar hash of the team.
+     */
+    private final String iconHash;
+
+    /**
+     * The members of the team.
+     */
+    private final List<TeamMember> members = new LinkedList<TeamMember>();
+
+    /**
+     * Creates a new user.
+     *
+     * @param api The discord api instance.
+     * @param data The json data of the user.
+     */
+    public TeamImpl(DiscordApiImpl api, JsonNode data) {
+        this.api = api;
+
+        id = Long.parseLong(data.get("id").asText());
+
+
+        iconHash = data.has("icon") ? data.get("icon").asText() : null;
+
+
+        ownerId = data.get("owner_user_id").asLong();
+
+        for (JsonNode member : data.get("members")) {
+            members.add(new TeamMemberImpl(api, member));
+        }
+    }
+
+    @Override
+    public Optional<Icon> getIcon() {
+        if (iconHash == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(new IconImpl(
+                    getApi(),
+                    new URL("https://" + Javacord.DISCORD_CDN_DOMAIN
+                            + "/team-icons/" + getIdAsString() + "/" + iconHash + ".png")));
+        } catch (MalformedURLException e) {
+            logger.warn("Seems like the url of the icon is malformed! Please contact the developer!", e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Collection<TeamMember> getTeamMembers() {
+        return new ArrayList<>(members);
+    }
+
+    @Override
+    public long getOwnerId() {
+        return ownerId;
+    }
+
+    @Override
+    public DiscordApi getApi() {
+        return api;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/team/TeamImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/team/TeamImpl.java
@@ -13,11 +13,10 @@ import org.javacord.core.util.logging.LoggerUtil;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 public class TeamImpl implements Team {
 
@@ -47,27 +46,28 @@ public class TeamImpl implements Team {
     private final String iconHash;
 
     /**
-     * The members of the team.
+     * The name of the team.
      */
-    private final List<TeamMember> members = new LinkedList<TeamMember>();
+    private final String name;
 
     /**
-     * Creates a new user.
+     * The members of the team.
+     */
+    private final Set<TeamMember> members = new HashSet<>();
+
+    /**
+     * Creates a new team.
      *
      * @param api The discord api instance.
-     * @param data The json data of the user.
+     * @param data The json data of the team.
      */
     public TeamImpl(DiscordApiImpl api, JsonNode data) {
         this.api = api;
 
-        id = Long.parseLong(data.get("id").asText());
-
-
-        iconHash = data.has("icon") ? data.get("icon").asText() : null;
-
-
+        id = data.get("id").asLong();
+        iconHash = data.path("icon").asText(null);
+        name = data.get("name").asText();
         ownerId = data.get("owner_user_id").asLong();
-
         for (JsonNode member : data.get("members")) {
             members.add(new TeamMemberImpl(api, member));
         }
@@ -90,13 +90,18 @@ public class TeamImpl implements Team {
     }
 
     @Override
-    public Collection<TeamMember> getTeamMembers() {
-        return new ArrayList<>(members);
+    public Set<TeamMember> getTeamMembers() {
+        return Collections.unmodifiableSet(members);
     }
 
     @Override
     public long getOwnerId() {
         return ownerId;
+    }
+
+    @Override
+    public String getName() {
+        return name;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/team/TeamMemberImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/team/TeamMemberImpl.java
@@ -1,0 +1,62 @@
+package org.javacord.core.entity.team;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.team.TeamMember;
+import org.javacord.api.entity.team.TeamMembershipState;
+import org.javacord.api.entity.user.User;
+import org.javacord.core.DiscordApiImpl;
+
+import java.util.concurrent.CompletableFuture;
+
+public class TeamMemberImpl implements TeamMember  {
+
+    /**
+     * The discord api instance.
+     */
+    private final DiscordApiImpl api;
+
+    /**
+     * The id of the team member.
+     */
+    private final long id;
+
+    /**
+     * The state of the membership of the team member.
+     */
+    private final TeamMembershipState membershipState;
+
+    /**
+     * Creates a new TeamMember.
+     *
+     * @param api The discord api instance.
+     * @param data The json data of the team member.
+     */
+    TeamMemberImpl(DiscordApiImpl api, JsonNode data) {
+        this.api = api;
+
+        this.id = data.get("user").get("id").asLong();
+
+        this.membershipState = TeamMembershipState.fromId(data.get("membership_state").asInt());
+    }
+
+    @Override
+    public TeamMembershipState getMembershipState() {
+        return membershipState;
+    }
+
+    @Override
+    public CompletableFuture<User> getUser() {
+        return api.getUserById(id);
+    }
+
+    @Override
+    public DiscordApi getApi() {
+        return api;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/team/TeamMemberImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/team/TeamMemberImpl.java
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.team.TeamMember;
 import org.javacord.api.entity.team.TeamMembershipState;
-import org.javacord.api.entity.user.User;
 import org.javacord.core.DiscordApiImpl;
-
-import java.util.concurrent.CompletableFuture;
 
 public class TeamMemberImpl implements TeamMember  {
 
@@ -43,11 +40,6 @@ public class TeamMemberImpl implements TeamMember  {
     @Override
     public TeamMembershipState getMembershipState() {
         return membershipState;
-    }
-
-    @Override
-    public CompletableFuture<User> getUser() {
-        return api.getUserById(id);
     }
 
     @Override

--- a/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
+++ b/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
@@ -99,7 +99,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, false)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -116,7 +116,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -149,7 +149,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -170,7 +170,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -192,7 +192,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -220,7 +220,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.proxySelector, null, null, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -252,7 +252,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -287,7 +287,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, authenticator, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -320,7 +320,7 @@ class DiscordApiImplTest extends Specification {
                     null, true, null, { [InetAddress.getLoopbackAddress()] })
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -349,7 +349,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -389,7 +389,7 @@ class DiscordApiImplTest extends Specification {
             }
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -427,7 +427,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -465,7 +465,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.proxySelector, null, null, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -492,7 +492,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()
@@ -531,7 +531,7 @@ class DiscordApiImplTest extends Specification {
             def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, authenticator, true)
 
         when:
-            api.applicationInfo.join()
+            api.requestApplicationInfo().join()
 
         then:
             CompletionException ce = thrown()


### PR DESCRIPTION
This is #615 updated and expanded. 

Probably the most controversial change is how `getOwner()` and `getOwnerId()` are handled. No existing behavior is broken, however:

If an application (like our bot) is owned by a Team, the ownerId field will be the team ID for the owner, there may be a pseudo user with the team id, the username `team[teamid]` etc. 

To preserve api stability, if a team is the owner of the application, the `getOwner()` and `getOwnerId`  methods will return the owner of the team. This way, we don't need to break `getOwner()` and make it return `Optional<User>`.