### PR TITLE
Add `requestBan` to access individual bans

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2157,6 +2157,24 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     }
 
     /**
+     * Requests a ban object for the specified user.
+     *
+     * @param user The user to request the ban object for.
+     * @return A future to get a server ban object if the user is currently banned.
+     */
+    default CompletableFuture<Ban> requestBan(User user) {
+        return requestBan(user.getId());
+    }
+
+    /**
+     * Requests a ban object for the specified user.
+     *
+     * @param userId The user id to request the ban object for.
+     * @return A future to get a server ban object if the user is currently banned.
+     */
+    CompletableFuture<Ban> requestBan(long userId);
+
+    /**
      * Gets a collection with all server bans.
      *
      * @return A collection with all server bans.

--- a/javacord-api/src/main/java/org/javacord/api/event/server/member/ServerMemberBanEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/server/member/ServerMemberBanEvent.java
@@ -15,7 +15,7 @@ public interface ServerMemberBanEvent extends ServerMemberEvent {
      *
      * @return The ban object.
      */
-    CompletableFuture<Optional<Ban>> requestBan();
+    CompletableFuture<Ban> requestBan();
 
     /**
      * Requests the reason of the ban.
@@ -23,7 +23,7 @@ public interface ServerMemberBanEvent extends ServerMemberEvent {
      * @return The reason of the ban.
      */
     default CompletableFuture<Optional<String>> requestReason() {
-        return requestBan().thenApply(ban -> ban.flatMap(Ban::getReason));
+        return requestBan().thenApply(Ban::getReason);
     }
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1548,6 +1548,13 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     }
 
     @Override
+    public CompletableFuture<Ban> requestBan(long userId) {
+        return new RestRequest<Ban>(getApi(), RestMethod.GET, RestEndpoint.BAN)
+                .setUrlParameters(getIdAsString(), Long.toUnsignedString(userId))
+                .execute(result -> new BanImpl(this, result.getJsonBody()));
+    }
+
+    @Override
     public CompletableFuture<Collection<Ban>> getBans() {
         return new RestRequest<Collection<Ban>>(getApi(), RestMethod.GET, RestEndpoint.BAN)
                 .setUrlParameters(getIdAsString())

--- a/javacord-core/src/main/java/org/javacord/core/event/server/member/ServerMemberBanEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/server/member/ServerMemberBanEventImpl.java
@@ -6,7 +6,6 @@ import org.javacord.api.entity.user.User;
 import org.javacord.api.event.server.member.ServerMemberBanEvent;
 import org.javacord.core.event.server.ServerEventImpl;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -28,11 +27,8 @@ public class ServerMemberBanEventImpl extends ServerEventImpl implements ServerM
     }
 
     @Override
-    public CompletableFuture<Optional<Ban>> requestBan() {
-        return getServer().getBans()
-                .thenApply(bans -> bans.stream()
-                        .filter(ban -> ban.getUser().equals(getUser()))
-                        .findAny());
+    public CompletableFuture<Ban> requestBan() {
+        return getServer().requestBan(getUser());
     }
 
     @Override


### PR DESCRIPTION
Related to #969 ; This PR simply implements the `requestBan` method to access the `GET /guilds/{guild_id}/bans/{user_id}` endpoint.

Code has been live-tested in the following scenarios:
- Getting a ban that exists
- Getting a ban that doesn't exist (with `exceptionally()`)