### PR TITLE
Bugfix: URL-Encode audit log reason header

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/rest/RestRequest.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/rest/RestRequest.java
@@ -15,8 +15,11 @@ import org.javacord.api.util.rest.RestRequestResponseInformation;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.util.logging.LoggerUtil;
 
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -181,7 +184,12 @@ public class RestRequest<T> {
      */
     public RestRequest<T> setAuditLogReason(String reason) {
         if (reason != null) {
-            addHeader("X-Audit-Log-Reason", reason);
+            try {
+                addHeader("X-Audit-Log-Reason",
+                        URLEncoder.encode(reason, StandardCharsets.UTF_8.name()).replace("+", " "));
+            } catch (UnsupportedEncodingException e) {
+                throw new AssertionError(e); // UTF-8 is always available
+            }
         }
         return this;
     }


### PR DESCRIPTION
If you try to add a audit log reason including characters outside ASCII (e.g. when you add a role to a user), the request is not sent as Javacord tries to add illegal characters to a header value.

According to Discord docs, they accept URL-encoded UTF-8 characters in the header: https://discord.com/developers/docs/resources/audit-log#audit-logs

This PR adds URL-encoding for the header by default, replacing "+" with spaces again as spaces are encoded to plus signs.