### PR TITLE
Let interactions and webhooks not consume the global ratelimit

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionMessageBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/InteractionMessageBuilderDelegateImpl.java
@@ -43,6 +43,8 @@ public class InteractionMessageBuilderDelegateImpl extends MessageBuilderBaseDel
         return new RestRequest<Void>(interaction.getApi(),
                 RestMethod.POST, RestEndpoint.INTERACTION_RESPONSE)
                 .setUrlParameters(interaction.getIdAsString(), interaction.getToken())
+                .consumeGlobalRatelimit(false)
+                .includeAuthorizationHeader(false)
                 .setBody(topBody)
                 .execute(result -> null);
     }
@@ -52,6 +54,8 @@ public class InteractionMessageBuilderDelegateImpl extends MessageBuilderBaseDel
         return new RestRequest<Void>(interaction.getApi(),
                 RestMethod.DELETE, RestEndpoint.ORIGINAL_INTERACTION_RESPONSE)
                 .setUrlParameters(Long.toUnsignedString(interaction.getApplicationId()), interaction.getToken())
+                .consumeGlobalRatelimit(false)
+                .includeAuthorizationHeader(false)
                 .execute(result -> null);
     }
 
@@ -59,7 +63,9 @@ public class InteractionMessageBuilderDelegateImpl extends MessageBuilderBaseDel
     public CompletableFuture<Message> editOriginalResponse(InteractionBase interaction) {
         RestRequest<Message> request = new RestRequest<Message>(interaction.getApi(),
                 RestMethod.PATCH, RestEndpoint.ORIGINAL_INTERACTION_RESPONSE)
-                .setUrlParameters(Long.toUnsignedString(interaction.getApplicationId()), interaction.getToken());
+                .setUrlParameters(Long.toUnsignedString(interaction.getApplicationId()), interaction.getToken())
+                .consumeGlobalRatelimit(false)
+                .includeAuthorizationHeader(false);
 
         return executeResponse(request);
     }
@@ -68,7 +74,9 @@ public class InteractionMessageBuilderDelegateImpl extends MessageBuilderBaseDel
     public CompletableFuture<Message> sendFollowupMessage(InteractionBase interaction) {
         RestRequest<Message> request = new RestRequest<Message>(interaction.getApi(),
                 RestMethod.POST, RestEndpoint.WEBHOOK_SEND)
-                .setUrlParameters(Long.toUnsignedString(interaction.getApplicationId()), interaction.getToken());
+                .setUrlParameters(Long.toUnsignedString(interaction.getApplicationId()), interaction.getToken())
+                .consumeGlobalRatelimit(false)
+                .includeAuthorizationHeader(false);
 
         return executeResponse(request);
     }
@@ -85,6 +93,8 @@ public class InteractionMessageBuilderDelegateImpl extends MessageBuilderBaseDel
         return new RestRequest<Void>(interaction.getApi(),
                 RestMethod.POST, RestEndpoint.INTERACTION_RESPONSE)
                 .setUrlParameters(interaction.getIdAsString(), interaction.getToken())
+                .consumeGlobalRatelimit(false)
+                .includeAuthorizationHeader(false)
                 .setBody(topBody)
                 .execute(result -> null);
     }
@@ -95,6 +105,8 @@ public class InteractionMessageBuilderDelegateImpl extends MessageBuilderBaseDel
                 RestEndpoint.WEBHOOK_MESSAGE)
                 .setUrlParameters(Long.toUnsignedString(interaction.getApplicationId()),
                         interaction.getToken(), messageId)
+                .consumeGlobalRatelimit(false)
+                .includeAuthorizationHeader(false)
                 .execute(result -> null);
     }
 
@@ -103,7 +115,9 @@ public class InteractionMessageBuilderDelegateImpl extends MessageBuilderBaseDel
         RestRequest<Message> request = new RestRequest<Message>(interaction.getApi(), RestMethod.PATCH,
                 RestEndpoint.WEBHOOK_MESSAGE)
                 .setUrlParameters(Long.toUnsignedString(interaction.getApplicationId()),
-                        interaction.getToken(), messageId);
+                        interaction.getToken(), messageId)
+                .consumeGlobalRatelimit(false)
+                .includeAuthorizationHeader(false);
 
         return executeResponse(request);
     }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderBaseDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageBuilderBaseDelegateImpl.java
@@ -540,7 +540,9 @@ public class MessageBuilderBaseDelegateImpl implements MessageBuilderBaseDelegat
         RestRequest<Message> request =
                 new RestRequest<Message>(api, RestMethod.POST, RestEndpoint.WEBHOOK_SEND)
                         .addQueryParameter("wait", Boolean.toString(wait))
-                        .setUrlParameters(webhookId, webhookToken);
+                        .setUrlParameters(webhookId, webhookToken)
+                        .consumeGlobalRatelimit(false)
+                        .includeAuthorizationHeader(false);
         CompletableFuture<Message> future = new CompletableFuture<>();
         if (!attachments.isEmpty() || embeds.stream().anyMatch(EmbedBuilder::requiresAttachments)) {
             // We access files etc. so this should be async

--- a/javacord-core/src/main/java/org/javacord/core/interaction/AutocompleteInteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/AutocompleteInteractionImpl.java
@@ -55,6 +55,8 @@ public class AutocompleteInteractionImpl extends SlashCommandInteractionImpl imp
         return new RestRequest<Void>(getApi(),
                 RestMethod.POST, RestEndpoint.INTERACTION_RESPONSE)
                 .setUrlParameters(getIdAsString(), getToken())
+                .consumeGlobalRatelimit(false)
+                .includeAuthorizationHeader(false)
                 .setBody(topBody)
                 .execute(result -> null);
     }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/InteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/InteractionImpl.java
@@ -144,6 +144,8 @@ public abstract class InteractionImpl implements Interaction {
 
         return new RestRequest<Void>(this.api, RestMethod.POST, RestEndpoint.INTERACTION_RESPONSE)
                 .setUrlParameters(getIdAsString(), token)
+                .includeAuthorizationHeader(false)
+                .consumeGlobalRatelimit(false)
                 .setBody(body)
                 .execute(result -> {
                     System.out.println(result.getJsonBody());

--- a/javacord-core/src/main/java/org/javacord/core/interaction/InteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/InteractionImpl.java
@@ -120,6 +120,8 @@ public abstract class InteractionImpl implements Interaction {
         return new RestRequest<InteractionOriginalResponseUpdater>(this.api,
                 RestMethod.POST, RestEndpoint.INTERACTION_RESPONSE)
                 .setUrlParameters(getIdAsString(), token)
+                .consumeGlobalRatelimit(false)
+                .includeAuthorizationHeader(false)
                 .setBody(ephemeral ? RESPOND_LATER_EPHEMERAL_BODY : RESPOND_LATER_BODY)
                 .execute(result -> new InteractionOriginalResponseUpdaterImpl(this));
     }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/MessageComponentInteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/MessageComponentInteractionImpl.java
@@ -49,6 +49,8 @@ public abstract class MessageComponentInteractionImpl extends InteractionImpl im
         return new RestRequest<Void>(getApi(),
                 RestMethod.POST, RestEndpoint.INTERACTION_RESPONSE)
                 .setUrlParameters(getIdAsString(), getToken())
+                .consumeGlobalRatelimit(false)
+                .includeAuthorizationHeader(false)
                 .setBody(UPDATE_LATER_BODY)
                 .execute(result -> null);
     }


### PR DESCRIPTION
Webhooks and interactions work indepedently of the bot account. Therefore, it's not required, but rather contraproductive to let webhook and interaction requests consume a quota from the global ratelimiter that are then not available for actual bot requests, even though they aren't really consuming a quota on Discord's side.

For the same reason, it's not required to add the general bot authorization header to these requests.

Yunite runs on this patch for a few weeks now without any issues (even though it is not using actual webhooks anywhere, only interactions; it's using follow up messages though, which go through the WEBHOOK_SEND endpoint).