### PR TITLE
Adjust RestEndpoints to the correct major parameters

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/ratelimit/RatelimitBucket.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/ratelimit/RatelimitBucket.java
@@ -43,9 +43,6 @@ public class RatelimitBucket {
      */
     public RatelimitBucket(DiscordApi api, RestEndpoint endpoint, String majorUrlParameter) {
         this.api = (DiscordApiImpl) api;
-        if (endpoint.isGlobal()) {
-            endpoint = null;
-        }
         this.endpoint = endpoint;
         this.majorUrlParameter = majorUrlParameter;
     }
@@ -128,9 +125,6 @@ public class RatelimitBucket {
      * @return Whether a bucket created with the given parameters would equal this bucket or not.
      */
     public boolean equals(RestEndpoint endpoint, String majorUrlParameter) {
-        if (endpoint.isGlobal()) {
-            endpoint = null;
-        }
         boolean endpointSame = this.endpoint == endpoint;
         boolean majorUrlParameterBothNull = this.majorUrlParameter == null && majorUrlParameter == null;
         boolean majorUrlParameterEqual =

--- a/javacord-core/src/main/java/org/javacord/core/util/ratelimit/RatelimitManager.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/ratelimit/RatelimitManager.java
@@ -174,11 +174,7 @@ public class RatelimitManager {
         Response response = result.getResponse();
         boolean global = response.header("X-RateLimit-Global", "false").equalsIgnoreCase("true");
         int remaining = Integer.parseInt(response.header("X-RateLimit-Remaining", "1"));
-        long reset = request
-                .getEndpoint()
-                .getHardcodedRatelimit()
-                .map(ratelimit -> responseTimestamp + api.getTimeOffset() + ratelimit)
-                .orElseGet(() -> (long) (Double.parseDouble(response.header("X-RateLimit-Reset", "0")) * 1000));
+        long reset =  (long) (Double.parseDouble(response.header("X-RateLimit-Reset", "0")) * 1000);
 
         // Check if we received a 429 response
         if (result.getResponse().code() == 429) {

--- a/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
@@ -29,7 +29,7 @@ public enum RestEndpoint {
     SERVER_SELF("/users/@me/guilds/%s", 0),
     SERVER_CHANNEL("/guilds/%s/channels", 0),
     // hardcoded reactions ratelimit due to https://github.com/discordapp/discord-api-docs/issues/182
-    REACTION("/channels/%s/messages/%s/reactions", 0, 250),
+    REACTION("/channels/%s/messages/%s/reactions", 0),
     PINS("/channels/%s/pins", 0),
     SERVER_MEMBER("/guilds/%s/members/%s", 0),
     SERVER_MEMBER_ROLE("/guilds/%s/members/%s/roles/%s", 0),
@@ -78,24 +78,13 @@ public enum RestEndpoint {
      */
     private final int majorParameterPosition;
 
-    /**
-     * The position of the major parameter starting with <code>0</code> or <code>-1</code> if no major parameter exists.
-     */
-    private final int hardcodedRatelimit;
-
-
     RestEndpoint(String endpointUrl) {
-        this(endpointUrl, -1, -1);
+        this(endpointUrl, -1);
     }
 
     RestEndpoint(String endpointUrl, int majorParameterPosition) {
-        this(endpointUrl, majorParameterPosition, -1);
-    }
-
-    RestEndpoint(String endpointUrl, int majorParameterPosition, int hardcodedRatelimit) {
         this.endpointUrl = endpointUrl;
         this.majorParameterPosition = majorParameterPosition;
-        this.hardcodedRatelimit = hardcodedRatelimit;
     }
 
     /**
@@ -119,18 +108,6 @@ public enum RestEndpoint {
      */
     public String getEndpointUrl() {
         return endpointUrl;
-    }
-
-    /**
-     * Gets the hardcoded ratelimit if one is set.
-     *
-     * @return An optional which is present, if the endpoint has a hardcoded ratelimit.
-     */
-    public Optional<Integer> getHardcodedRatelimit() {
-        if (hardcodedRatelimit >= 0) {
-            return Optional.of(hardcodedRatelimit);
-        }
-        return Optional.empty();
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
@@ -24,7 +24,7 @@ public enum RestEndpoint {
     USER_CHANNEL("/users/@me/channels"),
     CHANNEL("/channels/%s", 0),
     ROLE("/guilds/%s/roles", 0),
-    SERVER("/guilds", 0),
+    SERVER("/guilds"),
     SERVER_PRUNE("/guilds/%s/prune", 0),
     SERVER_SELF("/users/@me/guilds/%s", 0),
     SERVER_CHANNEL("/guilds/%s/channels", 0),
@@ -50,9 +50,9 @@ public enum RestEndpoint {
     STICKER_PACK("/sticker-packs"),
     SERVER_STICKER("/guilds/%s/stickers", 0),
     // interactions
-    INTERACTION_RESPONSE("/interactions/%s/%s/callback", 0),
-    ORIGINAL_INTERACTION_RESPONSE("/webhooks/%s/%s/messages/@original",0),
-    APPLICATION_COMMANDS("/applications/%s/commands", 0),
+    INTERACTION_RESPONSE("/interactions/%s/%s/callback"),
+    ORIGINAL_INTERACTION_RESPONSE("/webhooks/%s/%s/messages/@original"),
+    APPLICATION_COMMANDS("/applications/%s/commands"),
     SERVER_APPLICATION_COMMANDS("/applications/%s/guilds/%s/commands",0),
     SERVER_APPLICATION_COMMAND_PERMISSIONS("/applications/%s/guilds/%s/commands/permissions",0),
     APPLICATION_COMMAND_PERMISSIONS("/applications/%s/guilds/%s/commands/%s/permissions",0),
@@ -79,39 +79,22 @@ public enum RestEndpoint {
     private final int majorParameterPosition;
 
     /**
-     * Whether the endpoint is global or not.
-     */
-    private boolean global;
-
-    /**
      * The position of the major parameter starting with <code>0</code> or <code>-1</code> if no major parameter exists.
      */
     private final int hardcodedRatelimit;
 
-    RestEndpoint(String endpointUrl) {
-        this(endpointUrl, -1, false, -1);
-    }
 
-    RestEndpoint(String endpointUrl, boolean global) {
-        this(endpointUrl, -1, global, -1);
+    RestEndpoint(String endpointUrl) {
+        this(endpointUrl, -1, -1);
     }
 
     RestEndpoint(String endpointUrl, int majorParameterPosition) {
-        this(endpointUrl, majorParameterPosition, false, -1);
+        this(endpointUrl, majorParameterPosition, -1);
     }
 
     RestEndpoint(String endpointUrl, int majorParameterPosition, int hardcodedRatelimit) {
-        this(endpointUrl, majorParameterPosition, false, hardcodedRatelimit);
-    }
-
-    RestEndpoint(String endpointUrl, int majorParameterPosition, boolean global) {
-        this(endpointUrl, majorParameterPosition, false, -1);
-    }
-
-    RestEndpoint(String endpointUrl, int majorParameterPosition, boolean global, int hardcodedRatelimit) {
         this.endpointUrl = endpointUrl;
         this.majorParameterPosition = majorParameterPosition;
-        this.global = global;
         this.hardcodedRatelimit = hardcodedRatelimit;
     }
 
@@ -136,24 +119,6 @@ public enum RestEndpoint {
      */
     public String getEndpointUrl() {
         return endpointUrl;
-    }
-
-    /**
-     * Checks if the endpoint is global.
-     *
-     * @return Whether the endpoint is global or not.
-     */
-    public boolean isGlobal() {
-        return global;
-    }
-
-    /**
-     * Sets whether this endpoint is global or not.
-     *
-     * @param global If the endpoint is global.
-     */
-    public void setGlobal(boolean global) {
-        this.global = global;
     }
 
     /**


### PR DESCRIPTION
Also removed the global attribute with this PR as it's always set to false.
What the changes are based on what the current major parameters are see [Discord Docs](https://discord.com/developers/docs/topics/rate-limits#rate-limits)

Furthermore the hardcoded ratelimit for the `REACTIONS` endpoint has been removed (#578) because since gateway v8 Discord sends the X-RateLimit-Reset with milliseconds precision https://discord.com/developers/docs/change-log#september-24-2020