### PR TITLE
Have git ignore OS X system files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 *.iml
 *.ipr
 *.iws
+
+# System files
+.DS_Store
+


### PR DESCRIPTION
.DS_Store is added to .gitignore because .DS_Store files are automatically generated on OS X and should not be checked in.
https://en.wikipedia.org/wiki/.DS_Store