### PR TITLE
Change Message#edit and add editContent and editEmbed methods

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -221,8 +221,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param messageId The id of the message.
      * @param content   The new content of the message.
      * @return A future to check if the update was successful.
-     * @deprecated Use {@link #editContent(DiscordApi, long, long, String)} instead.
      * @see #editContent(DiscordApi, long, long, String)
+     * @deprecated Use {@link #editContent(DiscordApi, long, long, String)} instead.
      */
     @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, String content) {
@@ -237,8 +237,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param messageId The id of the message.
      * @param content   The new content of the message.
      * @return A future to check if the update was successful.
-     * @deprecated Use {@link #editContent(DiscordApi, String, String, String)} instead.
      * @see #editContent(DiscordApi, String, String, String)
+     * @deprecated Use {@link #editContent(DiscordApi, String, String, String)} instead.
      */
     @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, String content) {
@@ -253,8 +253,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param messageId The id of the message.
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
+     * @see #editEmbed(DiscordApi, long, long, EmbedBuilder...)
      * @deprecated Use {@link #editEmbed(DiscordApi, long, long, EmbedBuilder...)} instead.
-     * @see #editEmbed(DiscordApi, long, long, EmbedBuilder...) 
      */
     @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, EmbedBuilder... embeds) {
@@ -270,8 +270,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param messageId The id of the message.
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
+     * @see #editEmbed(DiscordApi, long, long, List)
      * @deprecated Use {@link #editEmbed(DiscordApi, long, long, List)} instead.
-     * @see #editEmbed(DiscordApi, long, long, List) 
      */
     @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, List<EmbedBuilder> embeds) {
@@ -286,8 +286,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param messageId The id of the message.
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
+     * @see #editEmbed(DiscordApi, String, String, EmbedBuilder...)
      * @deprecated Use {@link #editEmbed(DiscordApi, String, String, EmbedBuilder...)} instead.
-     * @see #editEmbed(DiscordApi, String, String, EmbedBuilder...) 
      */
     @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, EmbedBuilder... embeds) {
@@ -302,8 +302,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param messageId The id of the message.
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
-     * @deprecated Use {@link #editEmbed(DiscordApi, String, String, List)} instead.
      * @see #editEmbed(DiscordApi, String, String, List)
+     * @deprecated Use {@link #editEmbed(DiscordApi, String, String, List)} instead.
      */
     @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId,
@@ -384,7 +384,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, String content,
-                                             boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
+                                           boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, content, updateContent, embeds, updateEmbed);
     }
 
@@ -401,7 +401,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, String content,
-                                             boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
+                                           boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, content, updateContent, embeds, updateEmbed);
     }
 
@@ -410,8 +410,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      *
      * @param content The new content of the message.
      * @return A future to check if the update was successful.
-     * @deprecated Use {@link #editContent(String)} instead.
      * @see #editContent(String)
+     * @deprecated Use {@link #editContent(String)} instead.
      */
     @Deprecated
     default CompletableFuture<Message> edit(String content) {
@@ -423,8 +423,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      *
      * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.
-     * @deprecated Use {@link #editEmbed(EmbedBuilder...)} instead.
      * @see #editEmbed(EmbedBuilder...)
+     * @deprecated Use {@link #editEmbed(EmbedBuilder...)} instead.
      */
     @Deprecated
     default CompletableFuture<Message> edit(EmbedBuilder... embeds) {
@@ -436,8 +436,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      *
      * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.
-     * @deprecated Use {@link #editEmbed(List)} instead.
      * @see #editEmbed(List)
+     * @deprecated Use {@link #editEmbed(List)} instead.
      */
     @Deprecated
     default CompletableFuture<Message> edit(List<EmbedBuilder> embeds) {
@@ -511,7 +511,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> editEmbed(DiscordApi api, long channelId, long messageId, EmbedBuilder... embeds) {
+    static CompletableFuture<Message> editEmbed(DiscordApi api, long channelId, long messageId,
+                                                EmbedBuilder... embeds) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, null, false,
                 Arrays.asList(embeds), true);
     }
@@ -525,7 +526,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> editEmbed(DiscordApi api, long channelId, long messageId, List<EmbedBuilder> embeds) {
+    static CompletableFuture<Message> editEmbed(DiscordApi api, long channelId, long messageId,
+                                                List<EmbedBuilder> embeds) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
     }
 
@@ -538,7 +540,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> editEmbed(DiscordApi api, String channelId, String messageId, EmbedBuilder... embeds) {
+    static CompletableFuture<Message> editEmbed(DiscordApi api, String channelId, String messageId,
+                                                EmbedBuilder... embeds) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, Arrays.asList(embeds), true);
     }
 
@@ -552,7 +555,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> editEmbed(DiscordApi api, String channelId, String messageId,
-                                             List<EmbedBuilder> embeds) {
+                                                List<EmbedBuilder> embeds) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -214,83 +214,101 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Replaces content and clears embeds of the message.
+     * Updates the content of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param content   The new content of the message.
      * @return A future to check if the update was successful.
+     * @deprecated Use {@link #editContent(DiscordApi, long, long, String)} instead.
+     * @see #editContent(DiscordApi, long, long, String)
      */
+    @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, String content) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), true);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), false);
     }
 
     /**
-     * Replaces content and clears embeds of the message.
+     * Updates the content of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param content   The new content of the message.
      * @return A future to check if the update was successful.
+     * @deprecated Use {@link #editContent(DiscordApi, String, String, String)} instead.
+     * @see #editContent(DiscordApi, String, String, String)
      */
+    @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, String content) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), true);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), false);
     }
 
     /**
-     * Replaces embeds and clears content of the message.
+     * Updates the embed of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
+     * @deprecated Use {@link #editEmbed(DiscordApi, long, long, EmbedBuilder...)} instead.
+     * @see #editEmbed(DiscordApi, long, long, EmbedBuilder...) 
      */
+    @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, EmbedBuilder... embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true,
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false,
                 Arrays.asList(embeds), true);
     }
 
     /**
-     * Replaces embeds and clears content of the message.
+     * Updates the embed of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
+     * @deprecated Use {@link #editEmbed(DiscordApi, long, long, List)} instead.
+     * @see #editEmbed(DiscordApi, long, long, List) 
      */
+    @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, List<EmbedBuilder> embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, embeds, true);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
     }
 
     /**
-     * Replaces embeds and clears content of the message.
+     * Updates the embed of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
+     * @deprecated Use {@link #editEmbed(DiscordApi, String, String, EmbedBuilder...)} instead.
+     * @see #editEmbed(DiscordApi, String, String, EmbedBuilder...) 
      */
+    @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, EmbedBuilder... embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, Arrays.asList(embeds), true);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, Arrays.asList(embeds), true);
     }
 
     /**
-     * Replaces embeds and clears content of the message.
+     * Updates the embed of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
      * @param messageId The id of the message.
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
+     * @deprecated Use {@link #editEmbed(DiscordApi, String, String, List)} instead.
+     * @see #editEmbed(DiscordApi, String, String, List)
      */
+    @Deprecated
     static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId,
                                            List<EmbedBuilder> embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, embeds, true);
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
     }
 
     /**
@@ -388,33 +406,42 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Replaces content and clears embeds of the message.
+     * Updates the content of the message.
      *
      * @param content The new content of the message.
      * @return A future to check if the update was successful.
+     * @deprecated Use {@link #editContent(String)} instead.
+     * @see #editContent(String)
      */
+    @Deprecated
     default CompletableFuture<Message> edit(String content) {
-        return new MessageUpdater(this).setContent(content).removeAllEmbeds().applyChanges();
+        return new MessageUpdater(this).setContent(content).applyChanges();
     }
 
     /**
-     * Replaces embeds and clears content of the message.
+     * Updates the embed of the message.
      *
      * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.
+     * @deprecated Use {@link #editEmbed(EmbedBuilder...)} instead.
+     * @see #editEmbed(EmbedBuilder...)
      */
+    @Deprecated
     default CompletableFuture<Message> edit(EmbedBuilder... embeds) {
-        return new MessageUpdater(this).addEmbeds(Arrays.asList(embeds)).removeContent().applyChanges();
+        return new MessageUpdater(this).addEmbeds(Arrays.asList(embeds)).applyChanges();
     }
 
     /**
-     * Replaces embeds and clears content of the message.
+     * Updates the embed of the message.
      *
      * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.
+     * @deprecated Use {@link #editEmbed(List)} instead.
+     * @see #editEmbed(List)
      */
+    @Deprecated
     default CompletableFuture<Message> edit(List<EmbedBuilder> embeds) {
-        return new MessageUpdater(this).addEmbeds(embeds).removeContent().applyChanges();
+        return new MessageUpdater(this).addEmbeds(embeds).applyChanges();
     }
 
     /**
@@ -440,7 +467,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Updates the content of the message without modifying embeds.
+     * Updates the content of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -453,7 +480,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Updates the content of the message without modifying embeds.
+     * Updates the content of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -466,7 +493,17 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Updates the embed of the message without modifying content.
+     * Updates the content of the message.
+     *
+     * @param content The new content of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> editContent(String content) {
+        return new MessageUpdater(this).setContent(content).applyChanges();
+    }
+
+    /**
+     * Updates the embed of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -480,7 +517,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Updates the embed of the message without modifying content.
+     * Updates the embed of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -493,7 +530,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Updates the embed of the message without modifying content.
+     * Updates the embed of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -506,7 +543,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Updates the embed of the message without modifying content.
+     * Updates the embed of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -520,17 +557,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Updates the content of the message without modifying embeds.
-     *
-     * @param content The new content of the message.
-     * @return A future to check if the update was successful.
-     */
-    default CompletableFuture<Message> editContent(String content) {
-        return new MessageUpdater(this).setContent(content).applyChanges();
-    }
-
-    /**
-     * Updates the embed of the message without modifying content.
+     * Updates the embed of the message.
      *
      * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.
@@ -540,7 +567,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Updates the embed of the message without modifying content.
+     * Updates the embed of the message.
      *
      * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -214,6 +214,86 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
+     * Replaces content and clears embeds of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param content   The new content of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, String content) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), true);
+    }
+
+    /**
+     * Replaces content and clears embeds of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param content   The new content of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, String content) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), true);
+    }
+
+    /**
+     * Replaces embeds and clears content of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, EmbedBuilder... embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true,
+                Arrays.asList(embeds), true);
+    }
+
+    /**
+     * Replaces embeds and clears content of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, List<EmbedBuilder> embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, embeds, true);
+    }
+
+    /**
+     * Replaces embeds and clears content of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, EmbedBuilder... embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, Arrays.asList(embeds), true);
+    }
+
+    /**
+     * Replaces embeds and clears content of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId,
+                                           List<EmbedBuilder> embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, embeds, true);
+    }
+
+    /**
      * Updates the content and the embed of the message.
      *
      * @param api       The discord api instance.
@@ -308,108 +388,6 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Updates the content and the embed of the message.
-     *
-     * @param content The new content of the message.
-     * @param embeds  An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    default CompletableFuture<Message> edit(String content, EmbedBuilder... embeds) {
-        return new MessageUpdater(this).setContent(content).addEmbeds(embeds).applyChanges();
-    }
-
-    /**
-     * Updates the content and the embed of the message.
-     *
-     * @param content The new content of the message.
-     * @param embeds  An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    default CompletableFuture<Message> edit(String content, List<EmbedBuilder> embeds) {
-        return new MessageUpdater(this).setContent(content).addEmbeds(embeds).applyChanges();
-    }
-
-    /**
-     * Replaces content and clears embeds of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param content   The new content of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, String content) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), true);
-    }
-
-    /**
-     * Replaces content and clears embeds of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param content   The new content of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, String content) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), true);
-    }
-
-    /**
-     * Replaces embeds and clears content of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param embeds    An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, EmbedBuilder... embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true,
-                Arrays.asList(embeds), true);
-    }
-
-    /**
-     * Replaces embeds and clears content of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param embeds    An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, List<EmbedBuilder> embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, embeds, true);
-    }
-
-    /**
-     * Replaces embeds and clears content of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param embeds    An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, EmbedBuilder... embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, Arrays.asList(embeds), true);
-    }
-
-    /**
-     * Replaces embeds and clears content of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param embeds    An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId,
-                                           List<EmbedBuilder> embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, embeds, true);
-    }
-
-    /**
      * Replaces content and clears embeds of the message.
      *
      * @param content The new content of the message.
@@ -437,6 +415,28 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      */
     default CompletableFuture<Message> edit(List<EmbedBuilder> embeds) {
         return new MessageUpdater(this).addEmbeds(embeds).removeContent().applyChanges();
+    }
+
+    /**
+     * Updates the content and the embed of the message.
+     *
+     * @param content The new content of the message.
+     * @param embeds  An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(String content, EmbedBuilder... embeds) {
+        return new MessageUpdater(this).setContent(content).addEmbeds(embeds).applyChanges();
+    }
+
+    /**
+     * Updates the content and the embed of the message.
+     *
+     * @param content The new content of the message.
+     * @param embeds  An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(String content, List<EmbedBuilder> embeds) {
+        return new MessageUpdater(this).setContent(content).addEmbeds(embeds).applyChanges();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -213,85 +213,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
         return api.getUncachedMessageUtil().delete(messages);
     }
 
-    /**
-     * Updates the content of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param content   The new content of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, String content) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content);
-    }
-
-    /**
-     * Updates the content of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param content   The new content of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, String content) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), false);
-    }
-
-    /**
-     * Updates the embed of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param embeds    An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, EmbedBuilder... embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false,
-                Arrays.asList(embeds), true);
-    }
-
-    /**
-     * Updates the embed of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param embeds    An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, List<EmbedBuilder> embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
-    }
-
-    /**
-     * Updates the embed of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param embeds    An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, EmbedBuilder... embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, Arrays.asList(embeds), true);
-    }
-
-    /**
-     * Updates the embed of the message.
-     *
-     * @param api       The discord api instance.
-     * @param channelId The id of the message's channel.
-     * @param messageId The id of the message.
-     * @param embeds    An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId,
-                                           List<EmbedBuilder> embeds) {
-        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
-    }
+    
 
     /**
      * Updates the content and the embed of the message.
@@ -366,7 +288,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, String content,
-                                           boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
+                                             boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, content, updateContent, embeds, updateEmbed);
     }
 
@@ -383,38 +305,8 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return A future to check if the update was successful.
      */
     static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, String content,
-                                           boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
+                                             boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, content, updateContent, embeds, updateEmbed);
-    }
-
-    /**
-     * Updates the content of the message.
-     *
-     * @param content The new content of the message.
-     * @return A future to check if the update was successful.
-     */
-    default CompletableFuture<Message> edit(String content) {
-        return new MessageUpdater(this).setContent(content).applyChanges();
-    }
-
-    /**
-     * Updates the embed of the message.
-     *
-     * @param embeds An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    default CompletableFuture<Message> edit(EmbedBuilder... embeds) {
-        return new MessageUpdater(this).addEmbeds(Arrays.asList(embeds)).applyChanges();
-    }
-
-    /**
-     * Updates the embed of the message.
-     *
-     * @param embeds An array of the new embeds of the message.
-     * @return A future to check if the update was successful.
-     */
-    default CompletableFuture<Message> edit(List<EmbedBuilder> embeds) {
-        return new MessageUpdater(this).addEmbeds(embeds).applyChanges();
     }
 
     /**
@@ -437,6 +329,116 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      */
     default CompletableFuture<Message> edit(String content, List<EmbedBuilder> embeds) {
         return new MessageUpdater(this).setContent(content).addEmbeds(embeds).applyChanges();
+    }
+
+    /**
+     * Updates the content of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param content   The new content of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> update(DiscordApi api, long channelId, long messageId, String content) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content);
+    }
+
+    /**
+     * Updates the content of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param content   The new content of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> update(DiscordApi api, String channelId, String messageId, String content) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), false);
+    }
+
+    /**
+     * Updates the content of the message.
+     *
+     * @param content The new content of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> update(String content) {
+        return new MessageUpdater(this).setContent(content).applyChanges();
+    }
+
+    /**
+     * Updates the embed of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> update(DiscordApi api, long channelId, long messageId, EmbedBuilder... embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false,
+                Arrays.asList(embeds), true);
+    }
+
+    /**
+     * Updates the embed of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> update(DiscordApi api, long channelId, long messageId, List<EmbedBuilder> embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
+    }
+
+    /**
+     * Updates the embed of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> update(DiscordApi api, String channelId, String messageId, EmbedBuilder... embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, Arrays.asList(embeds), true);
+    }
+
+    /**
+     * Updates the embed of the message.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> update(DiscordApi api, String channelId, String messageId,
+                                             List<EmbedBuilder> embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
+    }
+
+    /**
+     * Updates the embed of the message.
+     *
+     * @param embeds An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> update(EmbedBuilder... embeds) {
+        return new MessageUpdater(this).addEmbeds(Arrays.asList(embeds)).applyChanges();
+    }
+
+    /**
+     * Updates the embed of the message.
+     *
+     * @param embeds An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> update(List<EmbedBuilder> embeds) {
+        return new MessageUpdater(this).addEmbeds(embeds).applyChanges();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -213,8 +213,6 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
         return api.getUncachedMessageUtil().delete(messages);
     }
 
-    
-
     /**
      * Updates the content and the embed of the message.
      *
@@ -332,6 +330,116 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
+     * Replaces content and embeds of the message with new content.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param content   The new content of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, String content) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), true);
+    }
+
+    /**
+     * Replaces content and embeds of the message with new content.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param content   The new content of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, String content) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), true);
+    }
+
+    /**
+     * Replaces content and embeds of the message with new embeds.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, EmbedBuilder... embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true,
+                Arrays.asList(embeds), true);
+    }
+
+    /**
+     * Replaces content and embeds of the message with new embeds.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, long channelId, long messageId, List<EmbedBuilder> embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, embeds, true);
+    }
+
+    /**
+     * Replaces content and embeds of the message with new embeds.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId, EmbedBuilder... embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, Arrays.asList(embeds), true);
+    }
+
+    /**
+     * Replaces content and embeds of the message with new embeds.
+     *
+     * @param api       The discord api instance.
+     * @param channelId The id of the message's channel.
+     * @param messageId The id of the message.
+     * @param embeds    An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    static CompletableFuture<Message> edit(DiscordApi api, String channelId, String messageId,
+                                           List<EmbedBuilder> embeds) {
+        return api.getUncachedMessageUtil().edit(channelId, messageId, null, true, embeds, true);
+    }
+
+    /**
+     * Replaces content and embeds of the message with new content.
+     *
+     * @param content The new content of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(String content) {
+        return new MessageUpdater(this).setContent(content).removeAllEmbeds().applyChanges();
+    }
+
+    /**
+     * Replaces content and embeds of the message with new embeds.
+     *
+     * @param embeds An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(EmbedBuilder... embeds) {
+        return new MessageUpdater(this).addEmbeds(Arrays.asList(embeds)).removeContent().applyChanges();
+    }
+
+    /**
+     * Replaces content and embeds of the message with new embeds.
+     *
+     * @param embeds An array of the new embeds of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(List<EmbedBuilder> embeds) {
+        return new MessageUpdater(this).addEmbeds(embeds).removeContent().applyChanges();
+    }
+
+    /**
      * Updates the content of the message.
      *
      * @param api       The discord api instance.
@@ -355,16 +463,6 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      */
     static CompletableFuture<Message> update(DiscordApi api, String channelId, String messageId, String content) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), false);
-    }
-
-    /**
-     * Updates the content of the message.
-     *
-     * @param content The new content of the message.
-     * @return A future to check if the update was successful.
-     */
-    default CompletableFuture<Message> update(String content) {
-        return new MessageUpdater(this).setContent(content).applyChanges();
     }
 
     /**
@@ -419,6 +517,16 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     static CompletableFuture<Message> update(DiscordApi api, String channelId, String messageId,
                                              List<EmbedBuilder> embeds) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
+    }
+
+    /**
+     * Updates the content of the message.
+     *
+     * @param content The new content of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> update(String content) {
+        return new MessageUpdater(this).setContent(content).applyChanges();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -330,7 +330,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Replaces content and embeds of the message with new content.
+     * Replaces content and clears embeds of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -343,7 +343,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Replaces content and embeds of the message with new content.
+     * Replaces content and clears embeds of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -356,7 +356,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Replaces content and embeds of the message with new embeds.
+     * Replaces embeds and clears content of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -370,7 +370,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Replaces content and embeds of the message with new embeds.
+     * Replaces embeds and clears content of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -383,7 +383,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Replaces content and embeds of the message with new embeds.
+     * Replaces embeds and clears content of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -396,7 +396,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Replaces content and embeds of the message with new embeds.
+     * Replaces embeds and clears content of the message.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -410,7 +410,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Replaces content and embeds of the message with new content.
+     * Replaces content and clears embeds of the message.
      *
      * @param content The new content of the message.
      * @return A future to check if the update was successful.
@@ -420,7 +420,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Replaces content and embeds of the message with new embeds.
+     * Replaces embeds and clears content of the message.
      *
      * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.
@@ -430,7 +430,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Replaces content and embeds of the message with new embeds.
+     * Replaces embeds and clears content of the message.
      *
      * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.
@@ -440,7 +440,7 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     }
 
     /**
-     * Updates the content of the message.
+     * Updates the content of the message without modifying embeds.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -448,12 +448,12 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param content   The new content of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> update(DiscordApi api, long channelId, long messageId, String content) {
+    static CompletableFuture<Message> editContent(DiscordApi api, long channelId, long messageId, String content) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, content);
     }
 
     /**
-     * Updates the content of the message.
+     * Updates the content of the message without modifying embeds.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -461,12 +461,12 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param content   The new content of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> update(DiscordApi api, String channelId, String messageId, String content) {
+    static CompletableFuture<Message> editContent(DiscordApi api, String channelId, String messageId, String content) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, content, true, Collections.emptyList(), false);
     }
 
     /**
-     * Updates the embed of the message.
+     * Updates the embed of the message without modifying content.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -474,13 +474,13 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> update(DiscordApi api, long channelId, long messageId, EmbedBuilder... embeds) {
+    static CompletableFuture<Message> editEmbed(DiscordApi api, long channelId, long messageId, EmbedBuilder... embeds) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, null, false,
                 Arrays.asList(embeds), true);
     }
 
     /**
-     * Updates the embed of the message.
+     * Updates the embed of the message without modifying content.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -488,12 +488,12 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> update(DiscordApi api, long channelId, long messageId, List<EmbedBuilder> embeds) {
+    static CompletableFuture<Message> editEmbed(DiscordApi api, long channelId, long messageId, List<EmbedBuilder> embeds) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
     }
 
     /**
-     * Updates the embed of the message.
+     * Updates the embed of the message without modifying content.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -501,12 +501,12 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> update(DiscordApi api, String channelId, String messageId, EmbedBuilder... embeds) {
+    static CompletableFuture<Message> editEmbed(DiscordApi api, String channelId, String messageId, EmbedBuilder... embeds) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, Arrays.asList(embeds), true);
     }
 
     /**
-     * Updates the embed of the message.
+     * Updates the embed of the message without modifying content.
      *
      * @param api       The discord api instance.
      * @param channelId The id of the message's channel.
@@ -514,38 +514,38 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @param embeds    An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    static CompletableFuture<Message> update(DiscordApi api, String channelId, String messageId,
+    static CompletableFuture<Message> editEmbed(DiscordApi api, String channelId, String messageId,
                                              List<EmbedBuilder> embeds) {
         return api.getUncachedMessageUtil().edit(channelId, messageId, null, false, embeds, true);
     }
 
     /**
-     * Updates the content of the message.
+     * Updates the content of the message without modifying embeds.
      *
      * @param content The new content of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> update(String content) {
+    default CompletableFuture<Message> editContent(String content) {
         return new MessageUpdater(this).setContent(content).applyChanges();
     }
 
     /**
-     * Updates the embed of the message.
+     * Updates the embed of the message without modifying content.
      *
      * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> update(EmbedBuilder... embeds) {
+    default CompletableFuture<Message> editEmbed(EmbedBuilder... embeds) {
         return new MessageUpdater(this).addEmbeds(Arrays.asList(embeds)).applyChanges();
     }
 
     /**
-     * Updates the embed of the message.
+     * Updates the embed of the message without modifying content.
      *
      * @param embeds An array of the new embeds of the message.
      * @return A future to check if the update was successful.
      */
-    default CompletableFuture<Message> update(List<EmbedBuilder> embeds) {
+    default CompletableFuture<Message> editEmbed(List<EmbedBuilder> embeds) {
         return new MessageUpdater(this).addEmbeds(embeds).applyChanges();
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
@@ -216,7 +216,8 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
     public CompletableFuture<Message> edit(String channelId, String messageId, String content,
                                            boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
         try {
-            return edit(Long.parseLong(channelId), Long.parseLong(messageId), content, updateContent, embeds, updateEmbed);
+            return edit(Long.parseLong(channelId), Long.parseLong(messageId), content, updateContent, embeds,
+                    updateEmbed);
         } catch (NumberFormatException e) {
             CompletableFuture<Message> future = new CompletableFuture<>();
             future.completeExceptionally(e);

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
@@ -216,7 +216,7 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
     public CompletableFuture<Message> edit(String channelId, String messageId, String content,
                                            boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
         try {
-            return edit(Long.parseLong(channelId), Long.parseLong(messageId), content, true, embeds, true);
+            return edit(Long.parseLong(channelId), Long.parseLong(messageId), content, updateContent, embeds, updateEmbed);
         } catch (NumberFormatException e) {
             CompletableFuture<Message> future = new CompletableFuture<>();
             future.completeExceptionally(e);


### PR DESCRIPTION
This PR addresses  #822 and changes `Message#edit` to replace the entire message with new content or embeds. It also adds methods `editContent` and `editEmbed` to only update content or embeds without changing other parts of the message.

Currently, `MessageEventImpl#editMessage` uses `Message#edit`. Should `editMessage` use the new `edit` method where the entire message is replaced, or should it only call `editContent` or `editEmbed`?

I also ran into a bug where methods that call `edit(String channelId, String messageId, String content, boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed)` in `UncachedMessageUtil` always change both the content and embeds even if the `updateContent` and `updateEmbed` arguments are false. Should I go ahead and fix this in this PR, or should I make this a separate issue?