### PR TITLE
Add a toggle to change if events can be dispatched or not

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -101,6 +101,20 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
     ThreadPool getThreadPool();
 
     /**
+     * Sets whether this API instance can dispatch events.
+     *
+     * @param dispatchEvents Whether events can be dispatched.
+     */
+    void setEventsDispatchable(boolean dispatchEvents);
+
+    /**
+     * Gets whether this API instance can dispatch events.
+     *
+     * @return Whether events can be dispatched.
+     */
+    boolean canDispatchEvents();
+
+    /**
      * Gets a list with all global commands for the application.
      *
      * @return A list with all global commands.

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
@@ -117,6 +117,17 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
     }
 
     /**
+     * Sets whether this API instance can dispatch events.
+     *
+     * @param dispatchEvents Whether events can be dispatched.
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder setEventsDispatchable(boolean dispatchEvents) {
+        delegate.setEventsDispatchable(dispatchEvents);
+        return this;
+    }
+
+    /**
      * Sets the proxy selector which should be used to determine the proxies that should be used to connect to the
      * Discord REST API and web socket.
      * If no explicit proxy is configured using {@link #setProxy(Proxy)} and no proxy selector is configured using this

--- a/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
@@ -30,6 +30,13 @@ public interface DiscordApiBuilderDelegate {
     void setGlobalRatelimiter(Ratelimiter ratelimiter);
 
     /**
+     * Sets whether this API instance can dispatch events.
+     *
+     * @param dispatchEvents Whether events can be dispatched.
+     */
+    void setEventsDispatchable(boolean dispatchEvents);
+
+    /**
      * Sets a ratelimiter that can be used to respect the 5-second gateway identify ratelimit.
      *
      * @param ratelimiter The ratelimiter used to respect the 5-second gateway identify ratelimit.

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiBuilderDelegateImpl.java
@@ -56,6 +56,11 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
     private volatile Ratelimiter globalRatelimiter;
 
     /**
+     * Whether events can be dispatched.
+     */
+    private volatile boolean dispatchEvents = true;
+
+    /**
      * A ratelimiter used to respect the 5 seconds gateway identify ratelimit.
      */
     private volatile Ratelimiter gatewayIdentifyRatelimiter;
@@ -193,7 +198,7 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
             new DiscordApiImpl(token, currentShard.get(), totalShards.get(), intents,
                     waitForServersOnStartup, waitForUsersOnStartup, registerShutdownHook, globalRatelimiter,
                     gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator, trustAllCertificates,
-                    future, null, preparedListeners, preparedUnspecifiedListeners, userCacheEnabled);
+                    future, null, preparedListeners, preparedUnspecifiedListeners, userCacheEnabled, dispatchEvents);
         }
         return future;
     }
@@ -274,6 +279,11 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
     @Override
     public void setGlobalRatelimiter(Ratelimiter ratelimiter) {
         globalRatelimiter = ratelimiter;
+    }
+
+    @Override
+    public void setEventsDispatchable(boolean dispatchEvents) {
+        this.dispatchEvents = dispatchEvents;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -251,6 +251,11 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     private final Set<Intent> intents;
 
     /**
+     * Whether events can be dispatched.
+     */
+    private boolean dispatchEvents = true;
+
+    /**
      * Whether Javacord should wait for all servers to become available on startup or not.
      */
     private final boolean waitForServersOnStartup;
@@ -476,7 +481,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     ) {
         this(token, currentShard, totalShards, intents, waitForServersOnStartup, waitForUsersOnStartup,
                 true, globalRatelimiter, gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator,
-                trustAllCertificates, ready, null, Collections.emptyMap(), Collections.emptyList(), false);
+                trustAllCertificates, ready, null, Collections.emptyMap(), Collections.emptyList(), false, true);
     }
 
     /**
@@ -521,7 +526,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             Dns dns) {
         this(token, currentShard, totalShards, intents, waitForServersOnStartup, waitForUsersOnStartup,
                 true, globalRatelimiter, gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator,
-                trustAllCertificates, ready, dns, Collections.emptyMap(), Collections.emptyList(), false);
+                trustAllCertificates, ready, dns, Collections.emptyMap(), Collections.emptyList(), false, true);
     }
 
     /**
@@ -552,6 +557,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * @param listenerSourceMap          The functions to create listeners for pre-registration.
      * @param unspecifiedListeners       The listeners of unspecified types to pre-register.
      * @param userCacheEnabled           Whether the user cache should be enabled.
+     * @param dispatchEvents             Whether events can be dispatched.
      */
     @SuppressWarnings("unchecked")
     public DiscordApiImpl(
@@ -574,7 +580,8 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
                     List<Function<DiscordApi, GloballyAttachableListener>>
                     > listenerSourceMap,
             List<Function<DiscordApi, GloballyAttachableListener>> unspecifiedListeners,
-            boolean userCacheEnabled
+            boolean userCacheEnabled,
+            boolean dispatchEvents
     ) {
         this.token = token;
         this.currentShard = currentShard;
@@ -588,6 +595,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
         this.proxyAuthenticator = proxyAuthenticator;
         this.trustAllCertificates = trustAllCertificates;
         this.userCacheEnabled = userCacheEnabled;
+        this.dispatchEvents = dispatchEvents;
         this.reconnectDelayProvider = x ->
                 (int) Math.round(Math.pow(x, 1.5) - (1 / (1 / (0.1 * x) + 1)) * Math.pow(x, 1.5));
         //Always add the GUILDS intent unless it is not required anymore for Javacord to be functional.
@@ -721,6 +729,16 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      */
     public boolean hasUserCacheEnabled() {
         return userCacheEnabled;
+    }
+
+    @Override
+    public void setEventsDispatchable(boolean dispatchEvents) {
+        this.dispatchEvents = dispatchEvents;
+    }
+
+    @Override
+    public boolean canDispatchEvents() {
+        return dispatchEvents;
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/util/event/EventDispatcherBase.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/event/EventDispatcherBase.java
@@ -191,6 +191,10 @@ public abstract class EventDispatcherBase {
      * @param <T>           The type of the listener.
      */
     protected <T> void dispatchEvent(DispatchQueueSelector queueSelector, List<T> listeners, Consumer<T> consumer) {
+        if (!api.canDispatchEvents()) {
+            return;
+        }
+
         api.getThreadPool().getSingleThreadExecutorService("Event Dispatch Queues Manager").submit(() -> {
             if (queueSelector != null) { // Object dependent listeners
                 // Don't allow adding of more events while there are unfinished object independent tasks


### PR DESCRIPTION
This PR suggests to add a toggle which allows the user to turn the dispatch for events on/off. 
The intention of this is to be able to get closer to a 100% uptime of a bot which is currently not (easily) posible with the time a bot takes to start. In addition to that it becomes even harder when events gets dispatched and they may be handled twice when having a second bot process running.
For example a CD workflow:
1. Start the 2nd process with dispatchEvents turned off
2. Wait until the bot is fully logged in
3. Switch the toggle dispatch on both running bot processes
4. Stop the old running process