### PR TITLE
Add bans pagination

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2190,9 +2190,9 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      * This can be used to get a specific page of bans.
      * To get all pages / all bans at once, use {@link Server#getBans()}.
      *
+     * @param limit how many bans should be returned at most. Must be within [0, 1000]. If null, it will default to 1000
      * @param after should be a snowflake to only take bans of users with IDs higher
      *              than this parameter into account; can be null
-     * @param limit how many bans should be returned at most. Must be within [0, 1000]. If null, it will default to 1000
      * @return A collection with server bans on the given page with at most <code>limit</code> entries.
      */
     CompletableFuture<Collection<Ban>> getBans(Integer limit, Long after);

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2176,10 +2176,26 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
 
     /**
      * Gets a collection with all server bans.
+     * Note: This method fires <code>ceil((number of bans + 1) / 1000)</code> requests to Discord
+     * as the API returns the results in pages and Javacord collects all pages into one collection.
+     * If you want to control pagination yourself, use {@link Server#getBans(Integer, Long)}.
      *
      * @return A collection with all server bans.
      */
     CompletableFuture<Collection<Ban>> getBans();
+
+    /**
+     * Gets a collection with up to <code>limit</code> server bans, only taking users with an ID higher than
+     * <code>after</code> into account.
+     * This can be used to get a specific page of bans.
+     * To get all pages / all bans at once, use {@link Server#getBans()}.
+     *
+     * @param after should be a snowflake to only take bans of users with IDs higher
+     *              than this parameter into account; can be null
+     * @param limit how many bans should be returned at most. Must be within [0, 1000]. If null, it will default to 1000
+     * @return A collection with server bans on the given page with at most <code>limit</code> entries.
+     */
+    CompletableFuture<Collection<Ban>> getBans(Integer limit, Long after);
 
     /**
      * Gets a list of all webhooks in this server.

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -73,6 +73,7 @@ import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
 import org.javacord.core.util.rest.RestRequest;
 import org.javacord.core.util.rest.RestRequestResult;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Instant;
@@ -1556,15 +1557,49 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
 
     @Override
     public CompletableFuture<Collection<Ban>> getBans() {
-        return new RestRequest<Collection<Ban>>(getApi(), RestMethod.GET, RestEndpoint.BAN)
-                .setUrlParameters(getIdAsString())
-                .execute(result -> {
-                    Collection<Ban> bans = new ArrayList<>();
-                    for (JsonNode ban : result.getJsonBody()) {
-                        bans.add(new BanImpl(this, ban));
-                    }
-                    return Collections.unmodifiableCollection(bans);
-                });
+        CompletableFuture<Collection<Ban>> future = new CompletableFuture<>();
+        ArrayList<Ban> bans = new ArrayList<>();
+
+        fetchBansPageAndAddAllToCollection(null, bans, future);
+
+        return future;
+    }
+
+    private void fetchBansPageAndAddAllToCollection(Long after,
+                                                    ArrayList<Ban> banList,
+                                                    CompletableFuture<Collection<Ban>> futureToComplete) {
+        RestRequest<Object> request = new RestRequest<>(getApi(), RestMethod.GET, RestEndpoint.BAN)
+                .setUrlParameters(getIdAsString());
+
+        if (after != null) {
+            request.addQueryParameter("after", String.valueOf(after));
+        }
+
+        request.execute(result -> {
+            JsonNode body = result.getJsonBody();
+            for (JsonNode ban : body) {
+                banList.add(new BanImpl(this, ban));
+            }
+
+            // If the response was smaller than 1000 entries, this was the last page.
+            // Let's pass the full list to the future!
+            if (body.size() < 1000) {
+                futureToComplete.complete(Collections.unmodifiableCollection(banList));
+                return null;
+            }
+
+            // The response contained 1000 bans. There could be more, so let's request the next page
+            fetchBansPageAndAddAllToCollection(
+                    banList.get(banList.size() - 1).getUser().getId(),
+                    banList,
+                    futureToComplete
+            );
+
+            return null;
+        }).exceptionally(t -> {
+            futureToComplete.completeExceptionally(t);
+            return null;
+        });
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1557,8 +1557,11 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
 
     @Override
     public CompletableFuture<Collection<Ban>> getBans(Integer limit, Long after) {
-        RestRequest<Collection<Ban>> request = new RestRequest<Collection<Ban>>(getApi(), RestMethod.GET, RestEndpoint.BAN)
-                .setUrlParameters(getIdAsString());
+        RestRequest<Collection<Ban>> request = new RestRequest<Collection<Ban>>(
+                getApi(),
+                RestMethod.GET,
+                RestEndpoint.BAN
+        ).setUrlParameters(getIdAsString());
 
         if (limit != null) {
             request.addQueryParameter("limit", String.valueOf(limit));


### PR DESCRIPTION
Discord randomly added paging to the bans endpoint: https://discord.com/developers/docs/change-log#mar-31-2022

This is causing that Javacord doesn't return more than 1000 bans at the moment. This is only a problem for large guilds.

This PR fetches all bans again (not a breaking change) by just fetching all available pages. There are rarely usecases where you would only want to fetch like the first one- or two thousand of bans, so the method has been set up to always fetch all bans. Individual bans can still be fetched using ``requestBan()``.

I've successfully tested this patch on a server with about 2.5k bans. 