### PR TITLE
Add application command localization

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
@@ -4,6 +4,7 @@ import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.util.Specializable;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -38,11 +39,25 @@ public interface ApplicationCommand extends DiscordEntity, Specializable<Applica
     String getName();
 
     /**
+     * Gets the name localizations of this command.
+     *
+     * @return The name localizations of this command.
+     */
+    Map<DiscordLocale, String> getNameLocalizations();
+
+    /**
      * Gets the description of this command.
      *
      * @return The description of this command.
      */
     String getDescription();
+
+    /**
+     * Gets the description localizations of this command.
+     *
+     * @return The description localizations of this command.
+     */
+    Map<DiscordLocale, String> getDescriptionLocalizations();
 
     /**
      * Gets the default permission of this command.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandBuilder.java
@@ -27,6 +27,41 @@ public abstract class ApplicationCommandBuilder<R extends ApplicationCommand,
     }
 
     /**
+     * Adds a name localization for the given locale.
+     *
+     * @param locale The locale to add this localization for.
+     * @param localization The command name localization.
+     * @return The current instance in order to chain call methods.
+     */
+    public T addNameLocalization(DiscordLocale locale, String localization) {
+        delegate.addNameLocalization(locale, localization);
+        return (T) this;
+    }
+
+    /**
+     * Sets the description of the slash command.
+     *
+     * @param description The description.
+     * @return The current instance in order to chain call methods.
+     */
+    public T setDescription(String description) {
+        delegate.setDescription(description);
+        return (T) this;
+    }
+
+    /**
+     * Adds a description localization for the given locale.
+     *
+     * @param locale The locale to add a localization for.
+     * @param localization The command description localization.
+     * @return The current instance in order to chain call methods.
+     */
+    public T addDescriptionLocalization(DiscordLocale locale, String localization) {
+        delegate.addDescriptionLocalization(locale, localization);
+        return (T) this;
+    }
+
+    /**
      * Sets the default permission for the message context menu
      * whether the context menu is enabled by default when the app is added to a server.
      *

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
@@ -27,6 +27,41 @@ public abstract class ApplicationCommandUpdater<T extends ApplicationCommand,
     }
 
     /**
+     * Adds a name localization for the given locale.
+     *
+     * @param locale The locale to add a localization for.
+     * @param localization The localization.
+     * @return The current instance in order to chain call methods.
+     */
+    public B addNameLocalization(DiscordLocale locale, String localization) {
+        delegate.addNameLocalization(locale, localization);
+        return (B) this;
+    }
+
+    /**
+     * Sets the new description of the slash command.
+     *
+     * @param description The description to set.
+     * @return The current instance in order to chain call methods.
+     */
+    public B setDescription(String description) {
+        delegate.setDescription(description);
+        return (B) this;
+    }
+
+    /**
+     * Adds a description localization for the given locale.
+     *
+     * @param locale The locale to add this localization for.
+     * @param localization The command description localization.
+     * @return The current instance in order to chain call methods.
+     */
+    public B addDescriptionLocalization(DiscordLocale locale, String localization) {
+        delegate.addDescriptionLocalization(locale, localization);
+        return (B) this;
+    }
+
+    /**
      * Sets the new application command default permission. When set to `false` no one will be able to use this command
      * until you overwrite it.
      * Disallowing the usage of this command includes absolutely every user even Administrators, Server owners

--- a/javacord-api/src/main/java/org/javacord/api/interaction/DiscordLocale.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/DiscordLocale.java
@@ -1,0 +1,83 @@
+package org.javacord.api.interaction;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum DiscordLocale {
+
+    DANISH("da"),
+    GERMAN("de"),
+    ENGLISH_UK("en-GB"),
+    ENGLISH_US("en-US"),
+    SPANISH("es-ES"),
+    FRENCH("fr"),
+    CROATIAN("hr"),
+    ITALIAN("it"),
+    LITHUANIAN("lt"),
+    HUNGARIAN("hu"),
+    DUTCH("nl"),
+    NORWEGIAN("no"),
+    POLISH("pl"),
+    PORTUGUESE_BRAZILIAN("pt-BR"),
+    ROMANIAN_ROMANIA("ro"),
+    FINNISH("fi"),
+    SWEDISH("sv-SE"),
+    VIETNAMESE("vi"),
+    TURKISH("tr"),
+    CZECH("cs"),
+    GREEK("el"),
+    BULGARIAN("bg"),
+    RUSSIAN("ru"),
+    UKRAINIAN("uk"),
+    HINDI("hi"),
+    THAI("th"),
+    CHINESE_CHINA("zh-CN"),
+    JAPANESE("ja"),
+    CHINESE_TAIWAN("zh-TW"),
+    KOREAN("ko"),
+    UNKNOWN("");
+
+    /**
+     * A map for retrieving the enum instances by code.
+     */
+    private static final Map<String, DiscordLocale> instanceByCode;
+
+    static {
+        instanceByCode = Collections.unmodifiableMap(
+                Arrays.stream(values())
+                        .collect(Collectors.toMap(DiscordLocale::getLocaleCode, Function.identity())));
+    }
+
+    private final String localeCode;
+
+    /**
+     * Constructs a new DiscordLocale.
+     *
+     * @param localeCode The short form locale code (e.g. en-US, fr).
+     */
+    DiscordLocale(String localeCode) {
+        this.localeCode = localeCode;
+    }
+
+    /**
+     * Gets the short form locale code (e.g. en-US, fr)
+     * @return The locale code.
+     */
+    public String getLocaleCode() {
+        return localeCode;
+    }
+
+    /**
+     * Gets a DiscordLocale from its locale code.
+     *
+     * @param localeCode The locale code.
+     * @return A DiscordLocale or UNKNOWN if this code is unknown.
+     */
+    public static DiscordLocale fromLocaleCode(String localeCode) {
+        return instanceByCode.getOrDefault(localeCode, DiscordLocale.UNKNOWN);
+    }
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/interaction/InteractionBase.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/InteractionBase.java
@@ -133,13 +133,13 @@ public interface InteractionBase extends DiscordEntity {
      *
      * @return The user selected language.
      */
-    String getLocale();
+    DiscordLocale getLocale();
 
     /**
      * Gets the server's preferred locale, if invoked in a server.
      *
      * @return The server's preferred locale.
      */
-    Optional<String> getServerLocale();
+    Optional<DiscordLocale> getServerLocale();
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandBuilder.java
@@ -21,17 +21,6 @@ public class SlashCommandBuilder
     }
 
     /**
-     * Sets the description of the slash command.
-     *
-     * @param description The name.
-     * @return The current instance in order to chain call methods.
-     */
-    public SlashCommandBuilder setDescription(String description) {
-        delegate.setDescription(description);
-        return this;
-    }
-
-    /**
      * Adds a slash command option to the slash command.
      *
      * @param option The option.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOption.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOption.java
@@ -1,9 +1,11 @@
 package org.javacord.api.interaction;
 
 import org.javacord.api.entity.channel.ChannelType;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,11 +30,25 @@ public interface SlashCommandOption {
     String getName();
 
     /**
+     * Gets the name localizations for this option.
+     *
+     * @return The name localizations for this option.
+     */
+    Map<DiscordLocale, String> getNameLocalizations();
+
+    /**
      * Gets the description of this option.
      *
      * @return The description of this option.
      */
     String getDescription();
+
+    /**
+     * Gets the description localizations for this option.
+     *
+     * @return The description localizations for this option.
+     */
+    Map<DiscordLocale, String> getDescriptionLocalizations();
 
     /**
      * Checks whether this option is required.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionBuilder.java
@@ -39,6 +39,18 @@ public class SlashCommandOptionBuilder {
     }
 
     /**
+     * Adds a name localization for the given locale.
+     *
+     * @param locale The locale to add this localization for.
+     * @param localization The option name localization.
+     * @return The current instance in order to chain call methods.
+     */
+    public SlashCommandOptionBuilder addNameLocalization(DiscordLocale locale, String localization) {
+        delegate.addNameLocalization(locale, localization);
+        return this;
+    }
+
+    /**
      * Sets the description of the slash command option.
      *
      * @param description The description.
@@ -46,6 +58,18 @@ public class SlashCommandOptionBuilder {
      */
     public SlashCommandOptionBuilder setDescription(String description) {
         delegate.setDescription(description);
+        return this;
+    }
+
+    /**
+     * Adds a description localization for the given locale.
+     *
+     * @param locale The locale to add this localization for.
+     * @param localization The option description localization.
+     * @return The current instance in order to chain call methods.
+     */
+    public SlashCommandOptionBuilder addDescriptionLocalization(DiscordLocale locale, String localization) {
+        delegate.addDescriptionLocalization(locale, localization);
         return this;
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionChoice.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionChoice.java
@@ -1,5 +1,6 @@
 package org.javacord.api.interaction;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -13,6 +14,13 @@ public interface SlashCommandOptionChoice {
      * @return The name of the choice.
      */
     String getName();
+
+    /**
+     * Gets the name localizations for this choice.
+     *
+     * @return The name localizations for this choice.
+     */
+    Map<DiscordLocale, String> getNameLocalizations();
 
     /**
      * Gets the string value of this choice.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionChoiceBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionChoiceBuilder.java
@@ -25,6 +25,18 @@ public class SlashCommandOptionChoiceBuilder {
     }
 
     /**
+     * Adds a name localization for the given locale.
+     *
+     * @param locale The locale to add this localization for.
+     * @param localization The choice name localization.
+     * @return The current instance in order to chain call methods.
+     */
+    public SlashCommandOptionChoiceBuilder addNameLocalization(DiscordLocale locale, String localization) {
+        delegate.addNameLocalization(locale, localization);
+        return this;
+    }
+
+    /**
      * Sets the string value of the slash command option choice.
      *
      * @param value The value.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandUpdater.java
@@ -23,17 +23,6 @@ public class SlashCommandUpdater
     }
 
     /**
-     * Sets the new description of the slash command.
-     *
-     * @param description The description to set.
-     * @return The current instance in order to chain call methods.
-     */
-    public SlashCommandUpdater setDescription(String description) {
-        delegate.setDescription(description);
-        return this;
-    }
-
-    /**
      * Sets the new slash command options.
      *
      * @param slashCommandOptions The slash command options to set.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandBuilderDelegate.java
@@ -3,6 +3,8 @@ package org.javacord.api.interaction.internal;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.interaction.ApplicationCommand;
+import org.javacord.api.interaction.DiscordLocale;
+
 import java.util.concurrent.CompletableFuture;
 
 public interface ApplicationCommandBuilderDelegate<T extends ApplicationCommand> {
@@ -13,6 +15,29 @@ public interface ApplicationCommandBuilderDelegate<T extends ApplicationCommand>
      * @param name The name.
      */
     void setName(String name);
+
+    /**
+     * Adds a name localization for the given locale.
+     *
+     * @param locale The locale to add a localization for.
+     * @param localization The command name localization.
+     */
+    void addNameLocalization(DiscordLocale locale, String localization);
+
+    /**
+     * Sets the description of the slash command.
+     *
+     * @param description The description.
+     */
+    void setDescription(String description);
+
+    /**
+     * Adds a description localization for the given locale.
+     *
+     * @param locale The locale to add a localization for.
+     * @param localization The command description localization.
+     */
+    void addDescriptionLocalization(DiscordLocale locale, String localization);
 
     /**
      * Sets the default permission for the application command

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandUpdaterDelegate.java
@@ -3,6 +3,7 @@ package org.javacord.api.interaction.internal;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.interaction.ApplicationCommand;
+import org.javacord.api.interaction.DiscordLocale;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -13,6 +14,29 @@ public interface ApplicationCommandUpdaterDelegate<T extends ApplicationCommand>
      * @param name The name to set.
      */
     void setName(String name);
+
+    /**
+     * Adds a name localization for the given locale.
+     *
+     * @param locale The locale to add a localization for.
+     * @param localization The command name localization.
+     */
+    void addNameLocalization(DiscordLocale locale, String localization);
+
+    /**
+     * Sets the new description of the slash command.
+     *
+     * @param description The description to set.
+     */
+    void setDescription(String description);
+
+    /**
+     * Adds a description localization for the given locale.
+     *
+     * @param locale The locale to add this localization for.
+     * @param localization The command description localization.
+     */
+    void addDescriptionLocalization(DiscordLocale locale, String localization);
 
     /**
      * Sets the new application command default permission.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandBuilderDelegate.java
@@ -13,13 +13,6 @@ import java.util.List;
 public interface SlashCommandBuilderDelegate extends ApplicationCommandBuilderDelegate<SlashCommand> {
 
     /**
-     * Sets the description of the slash command.
-     *
-     * @param description The name.
-     */
-    void setDescription(String description);
-
-    /**
      * Adds a slash command option to the slash command.
      *
      * @param option The option.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandOptionBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandOptionBuilderDelegate.java
@@ -1,6 +1,7 @@
 package org.javacord.api.interaction.internal;
 
 import org.javacord.api.entity.channel.ChannelType;
+import org.javacord.api.interaction.DiscordLocale;
 import org.javacord.api.interaction.SlashCommandOption;
 import org.javacord.api.interaction.SlashCommandOptionBuilder;
 import org.javacord.api.interaction.SlashCommandOptionChoice;
@@ -30,11 +31,27 @@ public interface SlashCommandOptionBuilderDelegate {
     void setName(String name);
 
     /**
+     * Adds a name localization for the given locale.
+     *
+     * @param locale The locale to add this localization for.
+     * @param localization The command name localization.
+     */
+    void addNameLocalization(DiscordLocale locale, String localization);
+
+    /**
      * Sets the description of the slash command option.
      *
      * @param description The description.
      */
     void setDescription(String description);
+
+    /**
+     * Adds a description localization for the given locale.
+     *
+     * @param locale The locale to add this localization for.
+     * @param localization The command description localization.
+     */
+    void addDescriptionLocalization(DiscordLocale locale, String localization);
 
     /**
      * Sets if the slash command option is required.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandOptionChoiceBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandOptionChoiceBuilderDelegate.java
@@ -1,5 +1,6 @@
 package org.javacord.api.interaction.internal;
 
+import org.javacord.api.interaction.DiscordLocale;
 import org.javacord.api.interaction.SlashCommandOptionChoice;
 import org.javacord.api.interaction.SlashCommandOptionChoiceBuilder;
 
@@ -15,6 +16,14 @@ public interface SlashCommandOptionChoiceBuilderDelegate {
      * @param name The name.
      */
     void setName(String name);
+
+    /**
+     * Adds a name localization for the given locale.
+     *
+     * @param locale The locale to add this localization for.
+     * @param localization The choice name localization.
+     */
+    void addNameLocalization(DiscordLocale locale, String localization);
 
     /**
      * Sets the string value of the slash command option choice.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandUpdaterDelegate.java
@@ -8,13 +8,6 @@ import java.util.List;
 public interface SlashCommandUpdaterDelegate extends ApplicationCommandUpdaterDelegate<SlashCommand> {
 
     /**
-     * Sets the new description of the slash command.
-     *
-     * @param description The description to set.
-     */
-    void setDescription(String description);
-
-    /**
      * Sets the new slash command options.
      *
      * @param slashCommandOptions The slash command options to set.

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandBuilderDelegateImpl.java
@@ -6,23 +6,45 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.interaction.ApplicationCommand;
+import org.javacord.api.interaction.DiscordLocale;
 import org.javacord.api.interaction.internal.ApplicationCommandBuilderDelegate;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
 import org.javacord.core.util.rest.RestRequest;
+
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class ApplicationCommandBuilderDelegateImpl<T extends ApplicationCommand>
         implements ApplicationCommandBuilderDelegate<T> {
 
     protected String name;
+    protected Map<DiscordLocale, String> nameLocalizations = new HashMap<>();
+    protected String description;
+    protected Map<DiscordLocale, String> descriptionLocalizations = new HashMap<>();
 
     protected Boolean defaultPermission;
 
     @Override
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public void addNameLocalization(DiscordLocale locale, String localization) {
+        nameLocalizations.put(locale, localization);
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public void addDescriptionLocalization(DiscordLocale locale, String localization) {
+        descriptionLocalizations.put(locale, localization);
     }
 
     @Override
@@ -55,6 +77,21 @@ public abstract class ApplicationCommandBuilderDelegateImpl<T extends Applicatio
     public ObjectNode getJsonBodyForApplicationCommand() {
         ObjectNode jsonBody = JsonNodeFactory.instance.objectNode()
                 .put("name", name);
+
+        if (!nameLocalizations.isEmpty()) {
+            ObjectNode nameLocalizationsJsonObject = jsonBody.putObject("name_localizations");
+            nameLocalizations.forEach(
+                    (locale, localization) -> nameLocalizationsJsonObject.put(locale.getLocaleCode(), localization));
+        }
+
+        jsonBody.put("description", description);
+
+        if (!descriptionLocalizations.isEmpty()) {
+            ObjectNode descriptionLocalizationsJsonObject = jsonBody.putObject("description_localizations");
+            descriptionLocalizations.forEach(
+                    (locale, localization) ->
+                            descriptionLocalizationsJsonObject.put(locale.getLocaleCode(), localization));
+        }
 
         if (defaultPermission != null) {
             jsonBody.put("default_permission", defaultPermission.booleanValue());

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
@@ -4,10 +4,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.interaction.ApplicationCommand;
+import org.javacord.api.interaction.DiscordLocale;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
 import org.javacord.core.util.rest.RestRequest;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -17,8 +22,10 @@ public abstract class ApplicationCommandImpl implements ApplicationCommand {
     private final long id;
     private final long applicationId;
     private final String name;
+    private final Map<DiscordLocale, String> nameLocalizations = new HashMap<>();
     private final boolean defaultPermission;
     private final String description;
+    private final Map<DiscordLocale, String> descriptionLocalizations = new HashMap<>();
 
     private final Server server;
 
@@ -33,7 +40,11 @@ public abstract class ApplicationCommandImpl implements ApplicationCommand {
         id = data.get("id").asLong();
         applicationId = data.get("application_id").asLong();
         name = data.get("name").asText();
+        data.path("name_localizations").fields().forEachRemaining(e ->
+                nameLocalizations.put(DiscordLocale.fromLocaleCode(e.getKey()), e.getValue().asText()));
         description = data.get("description").asText();
+        data.path("description_localizations").fields().forEachRemaining(e ->
+                descriptionLocalizations.put(DiscordLocale.fromLocaleCode(e.getKey()), e.getValue().asText()));
         defaultPermission = !data.hasNonNull("default_permission") || data.get("default_permission").asBoolean();
         server = data.has("guild_id")
                 ? api.getPossiblyUnreadyServerById(data.get("guild_id").asLong()).orElseThrow(AssertionError::new)
@@ -61,8 +72,18 @@ public abstract class ApplicationCommandImpl implements ApplicationCommand {
     }
 
     @Override
+    public Map<DiscordLocale, String> getNameLocalizations() {
+        return Collections.unmodifiableMap(nameLocalizations);
+    }
+
+    @Override
     public String getDescription() {
         return description;
+    }
+
+    @Override
+    public Map<DiscordLocale, String> getDescriptionLocalizations() {
+        return Collections.unmodifiableMap(descriptionLocalizations);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandUpdaterDelegateImpl.java
@@ -1,7 +1,11 @@
 package org.javacord.core.interaction;
 
 import org.javacord.api.interaction.ApplicationCommand;
+import org.javacord.api.interaction.DiscordLocale;
 import org.javacord.api.interaction.internal.ApplicationCommandUpdaterDelegate;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public abstract class ApplicationCommandUpdaterDelegateImpl<T extends ApplicationCommand>
         implements ApplicationCommandUpdaterDelegate<T> {
@@ -10,11 +14,32 @@ public abstract class ApplicationCommandUpdaterDelegateImpl<T extends Applicatio
 
     protected String name = null;
 
+    protected Map<DiscordLocale, String> nameLocalizations = new HashMap<>();
+
+    protected String description = null;
+
+    protected Map<DiscordLocale, String> descriptionLocalizations = new HashMap<>();
+
     protected boolean defaultPermission = true;
 
     @Override
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public void addNameLocalization(DiscordLocale locale, String localization) {
+        nameLocalizations.put(locale, localization);
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public void addDescriptionLocalization(DiscordLocale locale, String localization) {
+        descriptionLocalizations.put(locale, localization);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/interaction/InteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/InteractionImpl.java
@@ -13,6 +13,7 @@ import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.entity.message.component.HighLevelComponent;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
+import org.javacord.api.interaction.DiscordLocale;
 import org.javacord.api.interaction.Interaction;
 import org.javacord.api.interaction.InteractionType;
 import org.javacord.api.interaction.callback.InteractionFollowupMessageBuilder;
@@ -51,8 +52,8 @@ public abstract class InteractionImpl implements Interaction {
     private final UserImpl user;
     private final String token;
     private final int version;
-    private final String locale;
-    private final String serverLocale;
+    private final DiscordLocale locale;
+    private final DiscordLocale serverLocale;
 
     /**
      * Class constructor.
@@ -83,8 +84,9 @@ public abstract class InteractionImpl implements Interaction {
         }
         token = jsonData.get("token").asText();
         version = jsonData.get("version").asInt();
-        locale = jsonData.get("locale").asText();
-        serverLocale = jsonData.hasNonNull("guild_locale") ? jsonData.get("guild_locale").asText() : null;
+        locale = DiscordLocale.fromLocaleCode(jsonData.get("locale").asText());
+        serverLocale = jsonData.hasNonNull("guild_locale")
+                ? DiscordLocale.fromLocaleCode(jsonData.get("guild_locale").asText()) : null;
     }
 
     @Override
@@ -184,12 +186,12 @@ public abstract class InteractionImpl implements Interaction {
     }
 
     @Override
-    public String getLocale() {
+    public DiscordLocale getLocale() {
         return locale;
     }
 
     @Override
-    public Optional<String> getServerLocale() {
+    public Optional<DiscordLocale> getServerLocale() {
         return Optional.ofNullable(serverLocale);
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/MessageContextMenuUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/MessageContextMenuUpdaterDelegateImpl.java
@@ -40,6 +40,12 @@ public class MessageContextMenuUpdaterDelegateImpl extends ApplicationCommandUpd
             body.put("name", name);
         }
 
+        if (!nameLocalizations.isEmpty()) {
+            ObjectNode nameLocalizationsJsonObject = body.putObject("name_localizations");
+            nameLocalizations.forEach(
+                    (locale, localization) -> nameLocalizationsJsonObject.put(locale.getLocaleCode(), localization));
+        }
+
         body.put("default_permission", defaultPermission);
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandBuilderDelegateImpl.java
@@ -14,13 +14,7 @@ import java.util.List;
 public class SlashCommandBuilderDelegateImpl extends ApplicationCommandBuilderDelegateImpl<SlashCommand>
         implements SlashCommandBuilderDelegate {
 
-    private String description;
     private List<SlashCommandOption> options = new ArrayList<>();
-
-    @Override
-    public void setDescription(String description) {
-        this.description = description;
-    }
 
     @Override
     public void addOption(SlashCommandOption option) {
@@ -43,7 +37,6 @@ public class SlashCommandBuilderDelegateImpl extends ApplicationCommandBuilderDe
      */
     public ObjectNode getJsonBodyForApplicationCommand() {
         ObjectNode jsonBody = super.getJsonBodyForApplicationCommand();
-        jsonBody.put("description", description);
 
         if (!options.isEmpty()) {
             ArrayNode jsonOptions = jsonBody.putArray("options");

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionBuilderDelegateImpl.java
@@ -1,21 +1,27 @@
 package org.javacord.core.interaction;
 
 import org.javacord.api.entity.channel.ChannelType;
+import org.javacord.api.interaction.DiscordLocale;
 import org.javacord.api.interaction.SlashCommandOption;
 import org.javacord.api.interaction.SlashCommandOptionChoice;
 import org.javacord.api.interaction.SlashCommandOptionType;
 import org.javacord.api.interaction.internal.SlashCommandOptionBuilderDelegate;
+
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class SlashCommandOptionBuilderDelegateImpl implements SlashCommandOptionBuilderDelegate {
 
     private SlashCommandOptionType type;
     private String name;
+    private Map<DiscordLocale, String> nameLocalizations = new HashMap<>();
     private String description;
+    private Map<DiscordLocale, String> descriptionLocalizations = new HashMap<>();
     private boolean required = false;
     private boolean autocompletable = false;
     private List<SlashCommandOptionChoice> choices = new ArrayList<>();
@@ -37,8 +43,18 @@ public class SlashCommandOptionBuilderDelegateImpl implements SlashCommandOption
     }
 
     @Override
+    public void addNameLocalization(DiscordLocale locale, String localization) {
+        nameLocalizations.put(locale, localization);
+    }
+
+    @Override
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    @Override
+    public void addDescriptionLocalization(DiscordLocale locale, String localization) {
+        descriptionLocalizations.put(locale, localization);
     }
 
     @Override
@@ -115,7 +131,8 @@ public class SlashCommandOptionBuilderDelegateImpl implements SlashCommandOption
 
     @Override
     public SlashCommandOption build() {
-        return new SlashCommandOptionImpl(type, name, description, required, autocompletable, choices, options,
-                channelTypes, longMinValue, longMaxValue, decimalMinValue, decimalMaxValue);
+        return new SlashCommandOptionImpl(type, name, nameLocalizations, description, descriptionLocalizations,
+                required, autocompletable, choices, options, channelTypes, longMinValue, longMaxValue,
+                decimalMinValue, decimalMaxValue);
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionChoiceBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionChoiceBuilderDelegateImpl.java
@@ -1,17 +1,27 @@
 package org.javacord.core.interaction;
 
+import org.javacord.api.interaction.DiscordLocale;
 import org.javacord.api.interaction.SlashCommandOptionChoice;
 import org.javacord.api.interaction.internal.SlashCommandOptionChoiceBuilderDelegate;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class SlashCommandOptionChoiceBuilderDelegateImpl implements SlashCommandOptionChoiceBuilderDelegate {
 
     private String name;
+    private Map<DiscordLocale, String> nameLocalizations = new HashMap<>();
     private String stringValue;
     private Long longValue;
 
     @Override
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public void addNameLocalization(DiscordLocale locale, String localization) {
+        nameLocalizations.put(locale, localization);
     }
 
     @Override
@@ -28,6 +38,6 @@ public class SlashCommandOptionChoiceBuilderDelegateImpl implements SlashCommand
 
     @Override
     public SlashCommandOptionChoice build() {
-        return new SlashCommandOptionChoiceImpl(name, stringValue, longValue);
+        return new SlashCommandOptionChoiceImpl(name, nameLocalizations, stringValue, longValue);
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionChoiceImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionChoiceImpl.java
@@ -3,13 +3,18 @@ package org.javacord.core.interaction;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.api.interaction.DiscordLocale;
 import org.javacord.api.interaction.SlashCommandOptionChoice;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 public class SlashCommandOptionChoiceImpl implements SlashCommandOptionChoice {
 
     private final String name;
+    private final Map<DiscordLocale, String> nameLocalizations;
     private final String stringValue;
     private final Long longValue;
 
@@ -20,6 +25,9 @@ public class SlashCommandOptionChoiceImpl implements SlashCommandOptionChoice {
      */
     public SlashCommandOptionChoiceImpl(JsonNode data) {
         name = data.get("name").asText();
+        nameLocalizations = new HashMap<>();
+        data.path("name_localizations").fields().forEachRemaining(e ->
+                nameLocalizations.put(DiscordLocale.fromLocaleCode(e.getKey()), e.getValue().asText()));
         if (data.get("value").isTextual()) {
             stringValue = data.get("value").textValue();
         } else {
@@ -36,11 +44,14 @@ public class SlashCommandOptionChoiceImpl implements SlashCommandOptionChoice {
      * Class constructor.
      *
      * @param name The name of the choice.
+     * @param nameLocalizations The name localizations of this choice.
      * @param stringValue The string value of the choice or null if it is an int value.
      * @param longValue The long value of the choice or null if it is a string value.
      */
-    public SlashCommandOptionChoiceImpl(String name, String stringValue, Long longValue) {
+    public SlashCommandOptionChoiceImpl(String name, Map<DiscordLocale, String> nameLocalizations,
+                                        String stringValue, Long longValue) {
         this.name = name;
+        this.nameLocalizations = nameLocalizations;
         this.stringValue = stringValue;
         this.longValue = longValue;
     }
@@ -48,6 +59,11 @@ public class SlashCommandOptionChoiceImpl implements SlashCommandOptionChoice {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public Map<DiscordLocale, String> getNameLocalizations() {
+        return Collections.unmodifiableMap(nameLocalizations);
     }
 
     @Override
@@ -68,6 +84,11 @@ public class SlashCommandOptionChoiceImpl implements SlashCommandOptionChoice {
     public JsonNode toJsonNode() {
         ObjectNode node = JsonNodeFactory.instance.objectNode();
         node.put("name", name);
+        if (!nameLocalizations.isEmpty()) {
+            ObjectNode nameLocalizationsJsonObject = node.putObject("name_localizations");
+            nameLocalizations.forEach(
+                    (locale, localization) -> nameLocalizationsJsonObject.put(locale.getLocaleCode(), localization));
+        }
         getLongValue().ifPresent(value -> node.put("value", value));
         getStringValue().ifPresent(value -> node.put("value", value));
         return node;

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandUpdaterDelegateImpl.java
@@ -24,11 +24,6 @@ public class SlashCommandUpdaterDelegateImpl extends ApplicationCommandUpdaterDe
         implements SlashCommandUpdaterDelegate {
 
     /**
-     * The slash command description.
-     */
-    private String description = null;
-
-    /**
      * The slash command options.
      */
     private List<SlashCommandOption> slashCommandOptions = new ArrayList<>();
@@ -43,11 +38,6 @@ public class SlashCommandUpdaterDelegateImpl extends ApplicationCommandUpdaterDe
     }
 
     @Override
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    @Override
     public void setOptions(List<SlashCommandOption> slashCommandOptions) {
         this.slashCommandOptions = slashCommandOptions;
     }
@@ -57,8 +47,21 @@ public class SlashCommandUpdaterDelegateImpl extends ApplicationCommandUpdaterDe
             body.put("name", name);
         }
 
+        if (!nameLocalizations.isEmpty()) {
+            ObjectNode nameLocalizationsJsonObject = body.putObject("name_localizations");
+            nameLocalizations.forEach(
+                    (locale, localization) -> nameLocalizationsJsonObject.put(locale.getLocaleCode(), localization));
+        }
+
         if (description != null && !description.isEmpty()) {
             body.put("description", description);
+        }
+
+        if (!descriptionLocalizations.isEmpty()) {
+            ObjectNode descriptionLocalizationsJsonObject = body.putObject("description_localizations");
+            descriptionLocalizations.forEach(
+                    (locale, localization) ->
+                            descriptionLocalizationsJsonObject.put(locale.getLocaleCode(), localization));
         }
 
         if (!slashCommandOptions.isEmpty()) {

--- a/javacord-core/src/main/java/org/javacord/core/interaction/UserContextMenuUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/UserContextMenuUpdaterDelegateImpl.java
@@ -30,6 +30,12 @@ public class UserContextMenuUpdaterDelegateImpl extends ApplicationCommandUpdate
             body.put("name", name);
         }
 
+        if (!nameLocalizations.isEmpty()) {
+            ObjectNode nameLocalizationsJsonObject = body.putObject("name_localizations");
+            nameLocalizations.forEach(
+                    (locale, localization) -> nameLocalizationsJsonObject.put(locale.getLocaleCode(), localization));
+        }
+
         body.put("default_permission", defaultPermission);
     }
 


### PR DESCRIPTION
Adds localization to application commands, slash command options and option choices.
as documented here discord/discord-api-docs#4653

You will need to obtain the localization experiment from Discord Developers if you wish to test this yourself.