### PR TITLE
Updated activity flags

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/activity/Activity.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/activity/Activity.java
@@ -4,6 +4,7 @@ import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.emoji.Emoji;
 
 import java.time.Instant;
+import java.util.EnumSet;
 import java.util.Optional;
 
 /**
@@ -81,4 +82,11 @@ public interface Activity extends Nameable {
      */
     Optional<Emoji> getEmoji();
 
+    /**
+     * Gets the activity flags of this activity.
+     * The flags describe what the payload includes.
+     *
+     * @return the activity flags.
+     */
+    EnumSet<ActivityFlag> getFlags();
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/activity/ActivityFlag.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/activity/ActivityFlag.java
@@ -1,0 +1,48 @@
+package org.javacord.api.entity.activity;
+
+public enum ActivityFlag {
+
+    INSTANCE(1 << 0),
+    JOIN(1 << 1),
+    SPECTATE(1 << 2),
+    JOIN_REQUEST(1 << 3),
+    SYNC(1 << 4),
+    PLAY(1 << 5),
+    PARTY_PRIVACY_FRIENDS(1 << 6),
+    PARTY_PRIVACY_VOICE_CHANNEL(1 << 7),
+    EMBEDDED(1 << 8),
+    UNKNOWN(-1);
+
+    private final int flag;
+
+    /**
+     * The class constructor.
+     * @param flag The bitmask of the flag.
+     */
+    ActivityFlag(int flag) {
+        this.flag = flag;
+    }
+
+    /**
+     * Gets the activity flag of the given integer value.
+     * @param flags The integer value of the flag.
+     * @return The activity flag of the given integer value.
+     */
+    public static ActivityFlag getActivityFlagById(int flags) {
+        for (ActivityFlag activityFlag : values()) {
+            if (activityFlag.flag == flags) {
+                return activityFlag;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * Gets the integer value of the activity flag.
+     * @return Gets the integer value of the activity flag.
+     */
+    public int asInt() {
+        return flag;
+    }
+}
+


### PR DESCRIPTION
This update introduces the Activity flags enum which includes
```
| Name                        | Value  |
|-----------------------------|--------|
| INSTANCE                    | 1 << 0 |
| JOIN                        | 1 << 1 |
| SPECTATE                    | 1 << 2 |
| JOIN_REQUEST                | 1 << 3 |
| SYNC                        | 1 << 4 |
| PLAY                        | 1 << 5 |
| PARTY_PRIVACY_FRIENDS       | 1 << 6 |
| PARTY_PRIVACY_VOICE_CHANNEL | 1 << 7 |
| EMBEDDED                    | 1 << 8 |
```

Also closes #915