### PR TITLE
Add support for creating, updating, deleting and bulk overwriting slash commands without Server instance.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -295,8 +295,25 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
      *                                      which should be used to perform the bulk overwrite.
      * @return A list containing all application commands.
      */
-    CompletableFuture<List<ApplicationCommand>> bulkOverwriteServerApplicationCommands(
+    default CompletableFuture<List<ApplicationCommand>> bulkOverwriteServerApplicationCommands(
             Server server,
+            List<? extends ApplicationCommandBuilder<?, ?, ?>> applicationCommandBuilderList) {
+        return bulkOverwriteServerApplicationCommands(server.getId(), applicationCommandBuilderList);
+    }
+
+    /**
+     * Bulk overwrites the servers application commands.
+     * This should be preferably used when updating and/or creating multiple
+     * application commands at once instead of {@link ApplicationCommandUpdater#updateForServer(Server)}
+     * and {@link ApplicationCommandBuilder#createForServer(Server)}
+     *
+     * @param server                        The server where the bulk overwrite should be performed on
+     *                                      which should be used to perform the bulk overwrite.
+     * @param applicationCommandBuilderList A list containing the ApplicationCommandBuilders.
+     * @return A list containing all application commands.
+     */
+    CompletableFuture<List<ApplicationCommand>> bulkOverwriteServerApplicationCommands(
+            long server,
             List<? extends ApplicationCommandBuilder<?, ?, ?>> applicationCommandBuilderList);
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
@@ -67,6 +67,13 @@ public interface ApplicationCommand extends DiscordEntity, Specializable<Applica
     boolean getDefaultPermission();
 
     /**
+     * Gets the server id of this command if it is not global.
+     *
+     * @return The server of this command.
+     */
+    Optional<Long> getServerId();
+
+    /**
      * Gets the server of this command if it is not global.
      *
      * @return The server of this command.
@@ -93,10 +100,20 @@ public interface ApplicationCommand extends DiscordEntity, Specializable<Applica
     CompletableFuture<Void> deleteGlobal();
 
     /**
-     * Deletes this application command globally.
+     * Deletes this application command for a server.
      *
      * @param server The server where the command should be deleted from.
      * @return A future to check if the deletion was successful.
      */
-    CompletableFuture<Void> deleteForServer(Server server);
+    default CompletableFuture<Void> deleteForServer(Server server) {
+        return deleteForServer(server.getId());
+    }
+
+    /**
+     * Deletes this application command for a server.
+     *
+     * @param server The server where the command should be deleted from.
+     * @return A future to check if the deletion was successful.
+     */
+    CompletableFuture<Void> deleteForServer(long server);
 }

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandBuilder.java
@@ -103,7 +103,21 @@ public abstract class ApplicationCommandBuilder<R extends ApplicationCommand,
      * @return The built application command.
      */
     public CompletableFuture<R> createForServer(Server server) {
-        return delegate.createForServer(server);
+        return delegate.createForServer(server.getApi(), server.getId());
+    }
+
+
+    /**
+     * Creates an application command for a specific server.
+     * When used to create multiple server application commands at once
+     * {@link DiscordApi#bulkOverwriteServerApplicationCommands(Server, List)} should be used instead.
+     *
+     * @param api The discord api instance.
+     * @param server The server.
+     * @return The built application command.
+     */
+    public CompletableFuture<R> createForServer(DiscordApi api, long server) {
+        return delegate.createForServer(api, server);
     }
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
@@ -96,7 +96,20 @@ public abstract class ApplicationCommandUpdater<T extends ApplicationCommand,
      * @return The updated application command.
      */
     public CompletableFuture<T> updateForServer(Server server) {
-        return delegate.updateForServer(server);
+        return delegate.updateForServer(server.getApi(), server.getId());
+    }
+
+    /**
+     * Updates an application command on the given server.
+     * When used to update multiple server application commands at once
+     * {@link DiscordApi#bulkOverwriteServerApplicationCommands(Server, List)} should be used instead.
+     *
+     * @param api The DiscordApi instance.
+     * @param server The server where the command should be updated.
+     * @return The updated application command.
+     */
+    public CompletableFuture<T> updateForServer(DiscordApi api, long server) {
+        return delegate.updateForServer(api, server);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandBuilderDelegate.java
@@ -1,7 +1,6 @@
 package org.javacord.api.interaction.internal;
 
 import org.javacord.api.DiscordApi;
-import org.javacord.api.entity.server.Server;
 import org.javacord.api.interaction.ApplicationCommand;
 import org.javacord.api.interaction.DiscordLocale;
 
@@ -58,9 +57,10 @@ public interface ApplicationCommandBuilderDelegate<T extends ApplicationCommand>
     /**
      * Creates an application command for a specific server.
      *
+     * @param api The discord api instance.
      * @param server The server.
      * @return The built application command.
      */
-    CompletableFuture<T> createForServer(Server server);
+    CompletableFuture<T> createForServer(DiscordApi api, long server);
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandUpdaterDelegate.java
@@ -59,5 +59,16 @@ public interface ApplicationCommandUpdaterDelegate<T extends ApplicationCommand>
      * @param server The server where the command should be updated.
      * @return A future with the updated application command to check if the update was successful.
      */
-    CompletableFuture<T> updateForServer(Server server);
+    default CompletableFuture<T> updateForServer(Server server) {
+        return updateForServer(server.getApi(), server.getId());
+    }
+
+    /**
+     * Performs the queued update.
+     *
+     * @param api The DiscordApi.
+     * @param server The server where the command should be updated.
+     * @return A future with the updated application command to check if the update was successful.
+     */
+    CompletableFuture<T> updateForServer(DiscordApi api, long server);
 }

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -1581,9 +1581,9 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
 
     @Override
     public CompletableFuture<List<ApplicationCommand>> bulkOverwriteServerApplicationCommands(
-            Server server, List<? extends ApplicationCommandBuilder<?, ?, ?>> applicationCommandBuilderList) {
+            long server, List<? extends ApplicationCommandBuilder<?, ?, ?>> applicationCommandBuilderList) {
         return new RestRequest<List<ApplicationCommand>>(this, RestMethod.PUT, RestEndpoint.SERVER_APPLICATION_COMMANDS)
-                .setUrlParameters(String.valueOf(clientId), server.getIdAsString())
+                .setUrlParameters(String.valueOf(clientId), String.valueOf(server))
                 .setBody(applicationCommandBuildersToArrayNode(applicationCommandBuilderList))
                 .execute(result -> jsonToApplicationCommandList(result.getJsonBody()));
     }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandBuilderDelegateImpl.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.DiscordApi;
-import org.javacord.api.entity.server.Server;
 import org.javacord.api.interaction.ApplicationCommand;
 import org.javacord.api.interaction.DiscordLocale;
 import org.javacord.api.interaction.internal.ApplicationCommandBuilderDelegate;
@@ -61,12 +60,12 @@ public abstract class ApplicationCommandBuilderDelegateImpl<T extends Applicatio
     }
 
     @Override
-    public CompletableFuture<T> createForServer(Server server) {
+    public CompletableFuture<T> createForServer(DiscordApi api, long server) {
         return new RestRequest<T>(
-                server.getApi(), RestMethod.POST, RestEndpoint.SERVER_APPLICATION_COMMANDS)
-                .setUrlParameters(String.valueOf(server.getApi().getClientId()), server.getIdAsString())
+                api, RestMethod.POST, RestEndpoint.SERVER_APPLICATION_COMMANDS)
+                .setUrlParameters(String.valueOf(api.getClientId()), String.valueOf(server))
                 .setBody(getJsonBodyForApplicationCommand())
-                .execute(result -> createInstance((DiscordApiImpl) server.getApi(), result.getJsonBody()));
+                .execute(result -> createInstance((DiscordApiImpl) api, result.getJsonBody()));
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/interaction/MessageContextMenuUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/MessageContextMenuUpdaterDelegateImpl.java
@@ -3,7 +3,6 @@ package org.javacord.core.interaction;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.DiscordApi;
-import org.javacord.api.entity.server.Server;
 import org.javacord.api.interaction.MessageContextMenu;
 import org.javacord.api.interaction.internal.MessageContextMenuUpdaterDelegate;
 import org.javacord.core.DiscordApiImpl;
@@ -47,15 +46,15 @@ public class MessageContextMenuUpdaterDelegateImpl extends ApplicationCommandUpd
     }
 
     @Override
-    public CompletableFuture<MessageContextMenu> updateForServer(Server server) {
+    public CompletableFuture<MessageContextMenu> updateForServer(DiscordApi api, long server) {
         ObjectNode body = JsonNodeFactory.instance.objectNode();
         prepareBody(body);
 
-        return new RestRequest<MessageContextMenu>(server.getApi(), RestMethod.PATCH,
+        return new RestRequest<MessageContextMenu>(api, RestMethod.PATCH,
                 RestEndpoint.SERVER_APPLICATION_COMMANDS)
-                .setUrlParameters(String.valueOf(server.getApi().getClientId()),
-                        server.getIdAsString(), String.valueOf(commandId))
+                .setUrlParameters(String.valueOf(api.getClientId()),
+                        String.valueOf(server), String.valueOf(commandId))
                 .setBody(body)
-                .execute(result -> new MessageContextMenuImpl((DiscordApiImpl) server.getApi(), result.getJsonBody()));
+                .execute(result -> new MessageContextMenuImpl((DiscordApiImpl) api, result.getJsonBody()));
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandUpdaterDelegateImpl.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.DiscordApi;
-import org.javacord.api.entity.server.Server;
 import org.javacord.api.interaction.SlashCommand;
 import org.javacord.api.interaction.SlashCommandOption;
 import org.javacord.api.interaction.internal.SlashCommandUpdaterDelegate;
@@ -65,15 +64,15 @@ public class SlashCommandUpdaterDelegateImpl extends ApplicationCommandUpdaterDe
     }
 
     @Override
-    public CompletableFuture<SlashCommand> updateForServer(Server server) {
+    public CompletableFuture<SlashCommand> updateForServer(DiscordApi api, long server) {
         ObjectNode body = JsonNodeFactory.instance.objectNode();
         prepareBody(body);
 
-        return new RestRequest<SlashCommand>(server.getApi(), RestMethod.PATCH,
+        return new RestRequest<SlashCommand>(api, RestMethod.PATCH,
                 RestEndpoint.SERVER_APPLICATION_COMMANDS)
-                .setUrlParameters(String.valueOf(server.getApi().getClientId()),
-                        server.getIdAsString(), String.valueOf(commandId))
+                .setUrlParameters(String.valueOf(api.getClientId()),
+                        String.valueOf(server), String.valueOf(commandId))
                 .setBody(body)
-                .execute(result -> new SlashCommandImpl((DiscordApiImpl) server.getApi(), result.getJsonBody()));
+                .execute(result -> new SlashCommandImpl((DiscordApiImpl) api, result.getJsonBody()));
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/UserContextMenuUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/UserContextMenuUpdaterDelegateImpl.java
@@ -3,7 +3,6 @@ package org.javacord.core.interaction;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.DiscordApi;
-import org.javacord.api.entity.server.Server;
 import org.javacord.api.interaction.UserContextMenu;
 import org.javacord.api.interaction.internal.UserContextMenuUpdaterDelegate;
 import org.javacord.core.DiscordApiImpl;
@@ -37,15 +36,15 @@ public class UserContextMenuUpdaterDelegateImpl extends ApplicationCommandUpdate
     }
 
     @Override
-    public CompletableFuture<UserContextMenu> updateForServer(Server server) {
+    public CompletableFuture<UserContextMenu> updateForServer(DiscordApi api, long server) {
         ObjectNode body = JsonNodeFactory.instance.objectNode();
         prepareBody(body);
 
-        return new RestRequest<UserContextMenu>(server.getApi(), RestMethod.PATCH,
+        return new RestRequest<UserContextMenu>(api, RestMethod.PATCH,
                 RestEndpoint.SERVER_APPLICATION_COMMANDS)
-                .setUrlParameters(String.valueOf(server.getApi().getClientId()),
-                        server.getIdAsString(), String.valueOf(commandId))
+                .setUrlParameters(String.valueOf(api.getClientId()),
+                        String.valueOf(server), String.valueOf(commandId))
                 .setBody(body)
-                .execute(result -> new UserContextMenuImpl((DiscordApiImpl) server.getApi(), result.getJsonBody()));
+                .execute(result -> new UserContextMenuImpl((DiscordApiImpl) api, result.getJsonBody()));
     }
 }


### PR DESCRIPTION
This adds methods that enable creating, updating, and deleting slash commands without the need for a Server instance. The primary motivation for this is to allow the ability to perform those actions regardless of the shard and cluster, in our case, we only needed the first shard to perform the necessary actions to keep the commands up-to-date.

- `bulkOverwriteServerApplicationCommands(long server, List<? extends ApplicationCommandBuilder<?, ?, ?>> applicationCommandBuilderList)`
- `deleteForServer(long server);`
- `createForServer(DiscordApi api, long server)`
- `updateForServer(DiscordApi api, long server)`

This also modifies the behavior of `ApplicationCommand` to store the server id instead of the Server instance but keeps the same Optional behavior for when the command isn't of a server slash command. (I'd be happy to get some notes if this does any bad side effect).

✅ The PR is tested to work for quite some time, although still unsure of the side effects of modifying the behavior of `ApplicationCommand`.