### PR TITLE
Add a flag whether messages will save their JSON as a String

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -1199,6 +1199,21 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
     }
 
     /**
+     * Sets whether the JSON of a message should be saved as a String in a message.
+     * If set to true {@link Message#getMessageJsonString()} will always contain the JSON as a String.
+     *
+     * @param saveMessageJsonAsString Whether the message saves its JSON as a String.
+     */
+    void setSaveMessageJsonAsString(boolean saveMessageJsonAsString);
+
+    /**
+     * Gets whether the JSON of a message should be saved.
+     *
+     * @return Whether the message save its JSON as a String.
+     */
+    boolean getSaveMessageJsonAsString();
+
+    /**
      * Gets a message by its id, if it exists and belongs to the given channel.
      *
      * @param id The id of the message.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -1701,4 +1701,13 @@ public interface Message extends DiscordEntity, Deletable, Comparable<Message>, 
                 .orElseThrow(() -> new IllegalStateException(
                         "In order to create a thread the channel of this message must be a ServerTextChannel"));
     }
+
+    /**
+     * Gets the message as a JSON String.
+     * Has to be enabled first by setting {@link DiscordApi#setSaveMessageJsonAsString(boolean)} to true.
+     *
+     * @return The message as a JSON String.
+     */
+    Optional<String> getMessageJsonString();
+
 }

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -215,6 +215,11 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     private volatile Activity activity;
 
     /**
+     * A flag to control whether messages save its JSON as a String.
+     */
+    private volatile boolean saveMessageJsonAsString = false;
+
+    /**
      * The default message cache capacity which is applied for every newly created channel.
      */
     private volatile int defaultMessageCacheCapacity = 50;
@@ -2046,6 +2051,16 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
         } finally {
             messageCacheLock.unlock();
         }
+    }
+
+    @Override
+    public void setSaveMessageJsonAsString(boolean saveMessageJsonAsString) {
+        this.saveMessageJsonAsString = saveMessageJsonAsString;
+    }
+
+    @Override
+    public boolean getSaveMessageJsonAsString() {
+        return saveMessageJsonAsString;
     }
 
     @Override


### PR DESCRIPTION
The intention of this PR is to be able to access the JSON of a message because there are situations where you may want to save the whole message in a database or in general just processing it. 
An example use-case would be to parse the message if you have a dashboard without SSR an no access to Javacords environment.
Since this will also consume more memory and depending on the bots size this is an opt-in feature which you have to set first by setting `DiscordApi#setSaveMessageJsonAsString` to true. 

If this gets accepted it would also be possible to do a follow-up PR where we can overload methods like `getMessagesAsStream` with a boolean parameter to only save the JSON for specific method calls in addition to having it as a global state

### Memory comparison:
Without saving the string: 151.22 Mbyte
With saving the string: 354.13 Mbyte

So when saving the string, it uses ~ 2,3 more memory. This is the result of about 109'000 messages