### PR TITLE
Fix AssertionError for ServerThreadChannels

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2392,6 +2392,13 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     List<ServerChannel> getChannels();
 
     /**
+     * Gets an unordered collection with all channels in the server.
+     *
+     * @return An unordered collection with all channels in the server.
+     */
+    Set<ServerChannel> getUnorderedChannels();
+
+    /**
      * Gets a sorted list (by position) with all regular channels of the server.
      *
      * @return A sorted list (by position) with all regular channels of the server.

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerThreadChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerThreadChannelImpl.java
@@ -8,6 +8,7 @@ import org.javacord.api.util.cache.MessageCache;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.entity.server.ServerImpl;
 import org.javacord.core.listener.channel.server.text.InternalServerTextChannelAttachableListenerManager;
+import org.javacord.core.util.Cleanupable;
 import org.javacord.core.util.cache.MessageCacheImpl;
 import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
@@ -22,8 +23,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * The implementation of {@link ServerThreadChannel}.
  */
-public class ServerThreadChannelImpl extends ServerChannelImpl implements ServerThreadChannel, InternalTextChannel,
-        InternalServerTextChannelAttachableListenerManager {
+public class ServerThreadChannelImpl extends ServerChannelImpl implements ServerThreadChannel, Cleanupable,
+        InternalTextChannel, InternalServerTextChannelAttachableListenerManager {
 
     /**
      * The message cache of the server text channel.
@@ -213,5 +214,15 @@ public class ServerThreadChannelImpl extends ServerChannelImpl implements Server
     @Override
     public String getMentionTag() {
         return "<#" + getIdAsString() + ">";
+    }
+
+    @Override
+    public void cleanup() {
+        messageCache.cleanup();
+
+        ((DiscordApiImpl) getApi()).forEachCachedMessageWhere(
+                msg -> msg.getChannel().getId() == getId(),
+                msg -> ((DiscordApiImpl) getApi()).removeMessageFromCache(msg.getId())
+        );
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1066,12 +1066,8 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
         this.serverFeatures.addAll(serverFeatures);
     }
 
-    /**
-     * Gets an unordered collection with all channels in the server.
-     *
-     * @return An unordered collection with all channels in the server.
-     */
-    public Collection<ServerChannel> getUnorderedChannels() {
+    @Override
+    public Set<ServerChannel> getUnorderedChannels() {
         return api.getEntityCache().get().getChannelCache().getChannelsOfServer(getId());
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelDeleteHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/ChannelDeleteHandler.java
@@ -168,13 +168,7 @@ public class ChannelDeleteHandler extends PacketHandler {
         long channelId = channelJson.get("id").asLong();
         api.getPossiblyUnreadyServerById(serverId)
                 .flatMap(server -> server.getForumChannelById(channelId))
-                .ifPresent(channel -> {
-                    dispatchServerChannelDeleteEvent(channel);
-                    api.forEachCachedMessageWhere(
-                            msg -> msg.getChannel().getId() == channelId,
-                            msg -> api.removeMessageFromCache(msg.getId())
-                    );
-                });
+                .ifPresent(this::dispatchServerChannelDeleteEvent);
         api.removeObjectListeners(ServerForumChannel.class, channelId);
         api.removeObjectListeners(RegularServerChannel.class, channelId);
         api.removeObjectListeners(ServerChannel.class, channelId);

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/thread/ThreadDeleteHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/thread/ThreadDeleteHandler.java
@@ -51,19 +51,13 @@ public class ThreadDeleteHandler extends PacketHandler {
         final long channelId = packet.get("id").asLong();
         api.getPossiblyUnreadyServerById(serverId)
                 .flatMap(server -> server.getThreadChannelById(channelId))
-                .ifPresent(channel -> {
-                    dispatchThreadDeleteEvent(channel);
-                    api.forEachCachedMessageWhere(
-                            msg -> msg.getChannel().getId() == channelId,
-                            msg -> api.removeMessageFromCache(msg.getId())
-                    );
-                });
+                .ifPresent(this::dispatchThreadDeleteEvent);
         api.removeObjectListeners(ServerThreadChannel.class, channelId);
         api.removeObjectListeners(ServerChannel.class, channelId);
         api.removeObjectListeners(TextChannel.class, channelId);
         api.removeObjectListeners(Channel.class, channelId);
 
-        api.removeChannelFromCache(packet.get("id").asLong());
+        api.removeChannelFromCache(channelId);
     }
 
     /**


### PR DESCRIPTION
There is now a check if there are any ServerThreadChannels for a ServerChannel when a ServerChannel will be removed from the cache to delete them is they have the ServerChannel as a parent. Furthermore the message removing logic has been moved to the  ServerThreadChannels cleanup method so it also gets triggered in case the Thread is not being deleted through a `THREAD_DELETE` event.
Fixes #1028 