### PR TITLE
Allow scheduled / delayed deletes

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/Deletable.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/Deletable.java
@@ -1,11 +1,22 @@
 package org.javacord.api.entity;
 
+import org.javacord.api.DiscordApi;
+
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * An entity that can be deleted.
  */
 public interface Deletable {
+
+    /**
+     * Gets the DiscordApi managing this entity.
+     *
+     * @return The api instance.
+     */
+    DiscordApi getApi();
 
     /**
      * Deletes the entity.
@@ -23,5 +34,57 @@ public interface Deletable {
      * @return A future to tell if the deletion was successful.
      */
     CompletableFuture<Void> delete(String reason);
+
+    /**
+     * Deletes the entity after the given time.
+     *
+     * <p><b>Caution:</b> If the bot shuts down before the scheduled time, the entity will not be deleted.</p>
+     *
+     * @param duration The duration.
+     * @param unit The unit for the duration.
+     * @return A future that completes when the entity has been deleted.
+     */
+    default CompletableFuture<Void> deleteAfter(long duration, TimeUnit unit) {
+        return deleteAfter(duration, unit, "Scheduled deletion");
+    }
+
+    /**
+     * Deletes the entity after the given time.
+     *
+     * <p><b>Caution:</b> If the bot shuts down before the scheduled time, the entity will not be deleted.</p>
+     *
+     * @param duration The duration.
+     * @param unit The unit for the duration.
+     * @param auditLogReason The reason to log for the audit log.
+     * @return A future that completes when the entity has been deleted.
+     */
+    default CompletableFuture<Void> deleteAfter(long duration, TimeUnit unit, String auditLogReason) {
+        return getApi().getThreadPool().runAfter(() -> this.delete(auditLogReason), duration, unit);
+    }
+
+    /**
+     * Deletes the entity after the given time.
+     *
+     * <p><b>Caution:</b> If the bot shuts down before the scheduled time, the entity will not be deleted.</p>
+     *
+     * @param duration The duration.
+     * @return A future that completes when the entity has been deleted.
+     */
+    default CompletableFuture<Void> deleteAfter(Duration duration) {
+        return deleteAfter(duration.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Deletes the entity after the given time.
+     *
+     * <p><b>Caution:</b> If the bot shuts down before the scheduled time, the entity will not be deleted.</p>
+     *
+     * @param duration The duration.
+     * @param auditLogReason The reason to log for the audit log.
+     * @return A future that completes when the entity has been deleted.
+     */
+    default CompletableFuture<Void> deleteAfter(Duration duration, String auditLogReason) {
+        return deleteAfter(duration.toMillis(), TimeUnit.MILLISECONDS, auditLogReason);
+    }
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/Deletable.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/Deletable.java
@@ -1,0 +1,27 @@
+package org.javacord.api.entity;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An entity that can be deleted.
+ */
+public interface Deletable {
+
+    /**
+     * Deletes the entity.
+     *
+     * @return A future to tell if the deletion was successful.
+     */
+    default CompletableFuture<Void> delete() {
+        return delete(null);
+    }
+
+    /**
+     * Deletes the entity.
+     *
+     * @param reason The audit log reason for the deletion.
+     * @return A future to tell if the deletion was successful.
+     */
+    CompletableFuture<Void> delete(String reason);
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.Deletable;
 import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.server.invite.InviteBuilder;
@@ -13,7 +14,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class represents a server channel.
  */
-public interface ServerChannel extends Channel, Nameable, ServerChannelAttachableListenerManager {
+public interface
+ServerChannel extends Channel, Nameable, Deletable, ServerChannelAttachableListenerManager {
 
     /**
      * Gets the server of the channel.
@@ -59,23 +61,6 @@ public interface ServerChannel extends Channel, Nameable, ServerChannelAttachabl
     default CompletableFuture<Void> updateName(String name) {
         return createUpdater().setName(name).update();
     }
-
-    /**
-     * Deletes the channel.
-     *
-     * @return A future to tell us if the deletion was successful.
-     */
-    default CompletableFuture<Void> delete() {
-        return delete(null);
-    }
-
-    /**
-     * Deletes the channel.
-     *
-     * @param reason The audit log reason for the deletion.
-     * @return A future to tell us if the deletion was successful.
-     */
-    CompletableFuture<Void> delete(String reason);
 
     @Override
     default Optional<? extends ServerChannel> getCurrentCachedInstance() {

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
@@ -14,8 +14,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class represents a server channel.
  */
-public interface
-ServerChannel extends Channel, Nameable, Deletable, ServerChannelAttachableListenerManager {
+public interface ServerChannel extends Channel, Nameable, Deletable, ServerChannelAttachableListenerManager {
 
     /**
      * Gets the server of the channel.

--- a/javacord-api/src/main/java/org/javacord/api/entity/emoji/KnownCustomEmoji.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/emoji/KnownCustomEmoji.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.emoji;
 
+import org.javacord.api.entity.Deletable;
 import org.javacord.api.entity.UpdatableFromCache;
 import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.server.Server;
@@ -14,7 +15,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class represents a known custom emoji.
  */
-public interface KnownCustomEmoji extends CustomEmoji, UpdatableFromCache<KnownCustomEmoji>,
+public interface KnownCustomEmoji extends CustomEmoji, Deletable, UpdatableFromCache<KnownCustomEmoji>,
                                           KnownCustomEmojiAttachableListenerManager {
 
     /**
@@ -23,23 +24,6 @@ public interface KnownCustomEmoji extends CustomEmoji, UpdatableFromCache<KnownC
      * @return The server of the emoji.
      */
     Server getServer();
-
-    /**
-     * Deletes the emoji.
-     *
-     * @return A future to tell us if the deletion was successful.
-     */
-    default CompletableFuture<Void> delete() {
-        return delete(null);
-    }
-
-    /**
-     * Deletes the emoji.
-     *
-     * @param reason The reason for the deletion.
-     * @return A future to tell us if the deletion was successful.
-     */
-    CompletableFuture<Void> delete(String reason);
 
     /**
      * Creates an updater for this emoji.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -2,6 +2,7 @@ package org.javacord.api.entity.message;
 
 import org.javacord.api.DiscordApi;
 import org.javacord.api.Javacord;
+import org.javacord.api.entity.Deletable;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.UpdatableFromCache;
 import org.javacord.api.entity.channel.AutoArchiveDuration;
@@ -44,7 +45,7 @@ import java.util.stream.Stream;
 /**
  * This class represents a Discord message.
  */
-public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFromCache<Message>,
+public interface Message extends DiscordEntity, Deletable, Comparable<Message>, UpdatableFromCache<Message>,
         MessageAttachableListenerManager {
 
     /**
@@ -141,18 +142,10 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
     /**
      * Deletes the message.
      *
-     * @return A future to tell us if the deletion was successful.
-     */
-    default CompletableFuture<Void> delete() {
-        return delete(null);
-    }
-
-    /**
-     * Deletes the message.
-     *
      * @param reason The audit log reason for the deletion.
      * @return A future to tell us if the deletion was successful.
      */
+    @Override
     default CompletableFuture<Void> delete(String reason) {
         return Message.delete(getApi(), getChannel().getId(), getId(), reason);
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.permission;
 
+import org.javacord.api.entity.Deletable;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.Mentionable;
@@ -19,8 +20,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * This class represents a Discord role, e.g. "moderator".
  */
-public interface Role extends DiscordEntity, Mentionable, Nameable, Permissionable, Comparable<Role>,
-        UpdatableFromCache<Role>, RoleAttachableListenerManager {
+public interface Role extends DiscordEntity, Mentionable, Nameable, Deletable, Permissionable,
+        Comparable<Role>, UpdatableFromCache<Role>, RoleAttachableListenerManager {
 
     /**
      * Gets the server of the role.
@@ -276,13 +277,6 @@ public interface Role extends DiscordEntity, Mentionable, Nameable, Permissionab
     default CompletableFuture<Void> removeUser(User user, String reason) {
         return getServer().removeRoleFromUser(user, this, reason);
     }
-
-    /**
-     * Deletes the role.
-     *
-     * @return A future to check if the deletion was successful.
-     */
-    CompletableFuture<Void> delete();
 
     /**
      * Gets the allowed permissions of the role.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -1,6 +1,7 @@
 package org.javacord.api.entity.server;
 
 import org.javacord.api.audio.AudioConnection;
+import org.javacord.api.entity.Deletable;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.Nameable;
@@ -65,7 +66,8 @@ import java.util.stream.Collectors;
 /**
  * The class represents a Discord server, sometimes also called guild.
  */
-public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Server>, ServerAttachableListenerManager {
+public interface Server extends DiscordEntity, Nameable, Deletable, UpdatableFromCache<Server>,
+        ServerAttachableListenerManager {
 
     /**
      * Gets the audio connection in this server.
@@ -1640,13 +1642,6 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     default CompletableFuture<Void> removeUserTimeout(User user, String reason) {
         return createUpdater().setUserTimeout(user, Instant.MIN).setAuditLogReason(reason).update();
     }
-
-    /**
-     * Deletes the server.
-     *
-     * @return A future to check if the deletion was successful.
-     */
-    CompletableFuture<Void> delete();
 
     /**
      * Leaves the server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/invite/Invite.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/invite/Invite.java
@@ -10,7 +10,6 @@ import org.javacord.api.entity.user.User;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * This class represents an invite object.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/invite/Invite.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/invite/Invite.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.server.invite;
 
+import org.javacord.api.entity.Deletable;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.api.entity.channel.ServerChannel;
@@ -15,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
  * This class represents an invite object.
  * Invite objects won't receive any updates!
  */
-public interface Invite {
+public interface Invite extends Deletable {
 
     /**
      * Gets the code of the invite.
@@ -100,23 +101,6 @@ public interface Invite {
      * @return The type of the channel.
      */
     ChannelType getChannelType();
-
-    /**
-     * Deletes the invite.
-     *
-     * @return A future to check if the deletion was successful.
-     */
-    default CompletableFuture<Void> delete() {
-        return delete(null);
-    }
-
-    /**
-     * Deletes the invite.
-     *
-     * @param reason The audit log reason for the deletion.
-     * @return A future to check if the deletion was successful.
-     */
-    CompletableFuture<Void> delete(String reason);
 
     /**
      * Gets the approximate number of members for the target server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/sticker/Sticker.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/sticker/Sticker.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.sticker;
 
+import org.javacord.api.entity.Deletable;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Nameable;
 import org.javacord.api.entity.server.Server;
@@ -15,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * @see <a href="https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-structure">Discord Docs</a>
  */
-public interface Sticker extends DiscordEntity, Nameable, StickerAttachableListenerManager {
+public interface Sticker extends DiscordEntity, Nameable, Deletable, StickerAttachableListenerManager {
 
     /**
      * Gets the ID of the sticker pack.
@@ -195,23 +196,6 @@ public interface Sticker extends DiscordEntity, Nameable, StickerAttachableListe
      * @return A new sticker updater for the sticker.
      */
     StickerUpdater createUpdater();
-
-    /**
-     * Deletes the sticker.
-     *
-     * @return A future.
-     */
-    default CompletableFuture<Void> delete() {
-        return delete(null);
-    }
-
-    /**
-     * Deletes the sticker.
-     *
-     * @param reason The reason for the audit log.
-     * @return A future.
-     */
-    CompletableFuture<Void> delete(String reason);
 
     /**
      * Creates a new sticker with the given values.

--- a/javacord-api/src/main/java/org/javacord/api/entity/webhook/Webhook.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/webhook/Webhook.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.webhook;
 
+import org.javacord.api.entity.Deletable;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.Updatable;
@@ -20,7 +21,7 @@ import java.util.concurrent.CompletableFuture;
  * This class represents a webhook.
  * Webhook objects won't receive any updates!
  */
-public interface Webhook extends DiscordEntity, Updatable<Webhook>, WebhookAttachableListenerManager {
+public interface Webhook extends DiscordEntity, Deletable, Updatable<Webhook>, WebhookAttachableListenerManager {
 
     /**
      * Gets the server id of the webhook.
@@ -102,23 +103,6 @@ public interface Webhook extends DiscordEntity, Updatable<Webhook>, WebhookAttac
      * @return The webhook as incoming webhook.
      */
     Optional<IncomingWebhook> asIncomingWebhook();
-
-    /**
-     * Deletes the webhook.
-     *
-     * @return A future to tell us if the deletion was successful.
-     */
-    default CompletableFuture<Void> delete() {
-        return delete(null);
-    }
-
-    /**
-     * Deletes the webhook.
-     *
-     * @param reason The audit log reason for the deletion.
-     * @return A future to tell us if the deletion was successful.
-     */
-    CompletableFuture<Void> delete(String reason);
 
     /**
      * Gets the updater for this webhook.

--- a/javacord-api/src/main/java/org/javacord/api/util/concurrent/ThreadPool.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/concurrent/ThreadPool.java
@@ -1,8 +1,11 @@
 package org.javacord.api.util.concurrent;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * This class creates and contains thread pools which are used by Javacord.
@@ -58,4 +61,19 @@ public interface ThreadPool {
      * @return The removed and shutdown executor service with the given thread name.
      */
     Optional<ExecutorService> removeAndShutdownSingleThreadExecutorService(String threadName);
+
+    /**
+     * Executes code after a given duration.
+     *
+     * <p>Tasks will be scheduled on the daemon executor, allowing the bot to shutdown without
+     * all tasks being executed. This method is not meant to persist scheduled task over
+     * multiple bot life cycles.</p>
+     *
+     * @param task The code to run.
+     * @param duration The duration to run the code after.
+     * @param unit The unit of the duration given.
+     * @return A future that completes when the scheduled task is finished.
+     * @param <T> The return type of the future.
+     */
+    <T> CompletableFuture<T> runAfter(Supplier<CompletableFuture<T>> task, long duration, TimeUnit unit);
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/permission/RoleImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/permission/RoleImpl.java
@@ -305,8 +305,9 @@ public class RoleImpl implements Role, InternalRoleAttachableListenerManager {
     }
 
     @Override
-    public CompletableFuture<Void> delete() {
+    public CompletableFuture<Void> delete(String reason) {
         return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.ROLE)
+                .setAuditLogReason(reason)
                 .setUrlParameters(getServer().getIdAsString(), getIdAsString())
                 .execute(result -> null);
     }

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1574,10 +1574,12 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
         return Optional.ofNullable(roles.get(id));
     }
 
+
     @Override
-    public CompletableFuture<Void> delete() {
+    public CompletableFuture<Void> delete(String reason) {
         return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.SERVER)
                 .setUrlParameters(getIdAsString())
+                .setAuditLogReason(reason)
                 .execute(result -> null);
     }
 


### PR DESCRIPTION
This PR introduces a `Deletable` interface which takes over the existing deletion methods and introduces new ones for the scheduled deletion. Basically this is a do-over of the PR made by @cap5lut, incorporating the ideas from the discussion in #630.

I suggest either one of this and #630 to be merged and the other closed.