### PR TITLE
Fix event queue and sticker memory leaks

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -371,7 +371,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     /**
      * A map with all stickers.
      */
-    private static final ConcurrentHashMap<Long, Sticker> stickers = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, Sticker> stickers = new ConcurrentHashMap<>();
 
     /**
      * A map with all cached messages.


### PR DESCRIPTION
This fixes two memory leak sources I have noticed:

- When leaving a server, the corresponding `Server` instance isn't removed as an event target key from the `queuedListenerTasks` in the event dispatcher, causing it to stay there forever even though no events will ever be dispatched for it anymore. Fx this by processing all remaining events in the queue for that server and then removing the queue.

- The big one: `DiscordApiImpl.stickers` was static, leaking DiscordApi instances. This only happens when you replace DiscordApi instances at runtime, but when you do it's a severe issue: Since `stickers` is static, when an API instance is destroyed, all its stickers will remain saved there - and each sticker has a reference to that old API instance, keeping it as well as all its caches from getting GC'd, leaking ~150MB of memory per stray instance of a larger shard.
I did wonder why it was static in the first place, and it seems it initially wasn't but then was made static based on a review comment in #904 mentioning sharding support. However, `customEmojis` also aren't static, so I'm not sure why stickers should be - if the API instance owning those stickers goes away, so should the stickers since there is no guarantee they're up to date anymore. If you want a list of all stickers, you can just loop through your `DiscordApi` instances and collect them.

Those changes have been running fine in Beemo for the past ~3 months (though I didn't specifically check if the queue fix is working as intended, but it hasn't caused any issues so far, so, I guess). I feel like the dispatcher fix is a little hacky so lmk if I can improve it somehow.