### PR TITLE
Adds support for `min_length` and `max_length` for `String` in Slash Commands.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOption.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOption.java
@@ -117,6 +117,20 @@ public interface SlashCommandOption {
     Optional<Double> getDecimalMaxValue();
 
     /**
+     * If the option is an {@link SlashCommandOptionType#STRING} type, the minimum allowed length.
+     *
+     * @return The minimum allowed length.
+     */
+    Optional<Long> getMinLength();
+
+    /**
+     * If the option is an {@link SlashCommandOptionType#STRING} type, the maximum allowed length.
+     *
+     * @return The maximum allowed length.
+     */
+    Optional<Long> getMaxLength();
+
+    /**
      * Create a new slash command option to be used with a slash command builder.
      * This is a convenience method.
      *
@@ -441,6 +455,32 @@ public interface SlashCommandOption {
                 .setName(name)
                 .setDescription(description)
                 .setRequired(required)
+                .build();
+    }
+
+    /**
+     * Create a new {@link SlashCommandOptionType#STRING} slash command option to be used with a slash command builder.
+     * This is a convenience method.
+     *
+     * @param name        The name of the option.
+     * @param description The description of the option.
+     * @param required    Whether this option is required
+     * @param minLength   The minimum allowed length.
+     * @param maxLength   The maximum allowed length.
+     * @return The new slash command option builder.
+     */
+    static SlashCommandOption createStringOption(String name,
+                                                 String description,
+                                                 boolean required,
+                                                 long minLength,
+                                                 long maxLength) {
+        return new SlashCommandOptionBuilder()
+                .setType(SlashCommandOptionType.STRING)
+                .setName(name)
+                .setDescription(description)
+                .setRequired(required)
+                .setMinLength(minLength)
+                .setMaxLength(maxLength)
                 .build();
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandOptionBuilder.java
@@ -230,6 +230,29 @@ public class SlashCommandOptionBuilder {
     }
 
     /**
+     * Sets the {@link SlashCommandOptionType#STRING} min length for the slash command option.
+     *
+     * @param minLength The string min length.
+     * @return The current instance in order to chain call methods
+     */
+    public SlashCommandOptionBuilder setMinLength(long minLength) {
+        delegate.setMinLength(minLength);
+        return this;
+    }
+
+
+    /**
+     * Sets the {@link SlashCommandOptionType#STRING} max length for the slash command option.
+     *
+     * @param maxLength The string min length.
+     * @return The current instance in order to chain call methods
+     */
+    public SlashCommandOptionBuilder setMaxLength(long maxLength) {
+        delegate.setMaxLength(maxLength);
+        return this;
+    }
+
+    /**
      * Builds the slash command option.
      *
      * @return The built option.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandOptionBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/SlashCommandOptionBuilderDelegate.java
@@ -138,6 +138,20 @@ public interface SlashCommandOptionBuilderDelegate {
     void setDecimalMaxValue(double decimalMaxValue);
 
     /**
+     * Sets the {@link SlashCommandOptionType#STRING} min length for the slash command option.
+     *
+     * @param minLength The min length.
+     */
+    void setMinLength(long minLength);
+
+    /**
+     * Sets the {@link SlashCommandOptionType#STRING} max length for the slash command option.
+     *
+     * @param maxLength The max length.
+     */
+    void setMaxLength(long maxLength);
+
+    /**
      * Build the slash command option.
      *
      * @return The built option.

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionBuilderDelegateImpl.java
@@ -32,6 +32,9 @@ public class SlashCommandOptionBuilderDelegateImpl implements SlashCommandOption
     private Double decimalMinValue;
     private Double decimalMaxValue;
 
+    private Long minLength;
+    private Long maxLength;
+
     @Override
     public void setType(SlashCommandOptionType type) {
         this.type = type;
@@ -130,9 +133,19 @@ public class SlashCommandOptionBuilderDelegateImpl implements SlashCommandOption
     }
 
     @Override
+    public void setMinLength(long minLength) {
+        this.minLength = minLength;
+    }
+
+    @Override
+    public void setMaxLength(long maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    @Override
     public SlashCommandOption build() {
         return new SlashCommandOptionImpl(type, name, nameLocalizations, description, descriptionLocalizations,
                 required, autocompletable, choices, options, channelTypes, longMinValue, longMaxValue,
-                decimalMinValue, decimalMaxValue);
+                decimalMinValue, decimalMaxValue, minLength, maxLength);
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionImpl.java
@@ -34,6 +34,8 @@ public class SlashCommandOptionImpl implements SlashCommandOption {
     private final Long longMaxValue;
     private final Double decimalMinValue;
     private final Double decimalMaxValue;
+    private final Long maxLength;
+    private final Long minLength;
     private final boolean autocomplete;
 
     /**
@@ -79,12 +81,25 @@ public class SlashCommandOptionImpl implements SlashCommandOption {
             longMaxValue = data.has("max_value") ? data.get("max_value").asLong() : null;
             decimalMinValue = null;
             decimalMaxValue = null;
+            minLength = null;
+            maxLength = null;
         } else if (type == SlashCommandOptionType.DECIMAL) {
             decimalMinValue = data.has("min_value") ? data.get("min_value").asDouble() : null;
             decimalMaxValue = data.has("max_value") ? data.get("max_value").asDouble() : null;
             longMinValue = null;
             longMaxValue = null;
+            minLength = null;
+            maxLength = null;
+        } else if (type == SlashCommandOptionType.STRING) {
+            minLength = data.has("min_length") ? data.get("min_length").asLong() : null;
+            maxLength = data.has("max_length") ? data.get("max_length").asLong() : null;
+            longMinValue = null;
+            longMaxValue = null;
+            decimalMinValue = null;
+            decimalMaxValue = null;
         } else {
+            minLength = null;
+            maxLength = null;
             longMinValue = null;
             longMaxValue = null;
             decimalMinValue = null;
@@ -109,6 +124,8 @@ public class SlashCommandOptionImpl implements SlashCommandOption {
      * @param longMaxValue The {@link SlashCommandOptionType#LONG} max value
      * @param decimalMinValue The {@link SlashCommandOptionType#DECIMAL} min value
      * @param decimalMaxValue The {@link SlashCommandOptionType#DECIMAL} max value
+     * @param minLength The {@link SlashCommandOptionType#STRING} min length.
+     * @param maxLength The {@link SlashCommandOptionType#STRING} max length.
      */
     public SlashCommandOptionImpl(
             SlashCommandOptionType type,
@@ -124,7 +141,9 @@ public class SlashCommandOptionImpl implements SlashCommandOption {
             Long longMinValue,
             Long longMaxValue,
             Double decimalMinValue,
-            Double decimalMaxValue
+            Double decimalMaxValue,
+            Long minLength,
+            Long maxLength
     ) {
         this.type = type;
         this.name = name;
@@ -140,6 +159,8 @@ public class SlashCommandOptionImpl implements SlashCommandOption {
         this.longMaxValue = longMaxValue;
         this.decimalMinValue = decimalMinValue;
         this.decimalMaxValue = decimalMaxValue;
+        this.minLength = minLength;
+        this.maxLength = maxLength;
     }
 
     @Override
@@ -212,6 +233,16 @@ public class SlashCommandOptionImpl implements SlashCommandOption {
         return Optional.ofNullable(decimalMaxValue);
     }
 
+    @Override
+    public Optional<Long> getMinLength() {
+        return Optional.ofNullable(minLength);
+    }
+
+    @Override
+    public Optional<Long> getMaxLength() {
+        return Optional.ofNullable(maxLength);
+    }
+
     /**
      * Creates a json node with the option's data.
      *
@@ -249,6 +280,13 @@ public class SlashCommandOptionImpl implements SlashCommandOption {
             }
             if (decimalMaxValue != null) {
                 node.put("max_value", decimalMaxValue);
+            }
+        } else if (type == SlashCommandOptionType.STRING) {
+            if (minLength != null) {
+                node.put("min_length", minLength);
+            }
+            if (maxLength != null) {
+                node.put("max_length", maxLength);
             }
         }
         if (!nameLocalizations.isEmpty()) {


### PR DESCRIPTION
This PR adds the newly implemented `min_length` and `max_length` for String options in Slash Commands. The documentations states `integer` for the parameter (same as for `INTEGER`) but seeing that `INTEGER` uses the `long` type, I decided to use the `long` type as well since I remembered that Discord's integer is longer than Java's integer.

☑️ This PR has been tested and works as intended.
![image](https://user-images.githubusercontent.com/69381903/178148169-c8341e65-40f9-4a1a-b17f-66f1fdb3c25e.png)
