### PR TITLE
MessageUpdateHandler should now fire an event every time it receives an event

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelBuilder.java
@@ -14,12 +14,11 @@ public class ServerChannelBuilder<T> {
      */
     protected final ServerChannelBuilderDelegate delegate;
 
-
     /**
      * Creates a new server channel builder.
      *
-     * @param myClass The class this builder is for.
-     * @param delegate A subtype of a ServerChannelBuilderDelegate.
+     * @param myClass  The class of the channel to create.
+     * @param delegate The server channel delegate used by this instance.
      */
     protected ServerChannelBuilder(Class<T> myClass, ServerChannelBuilderDelegate delegate) {
         this.myClass = myClass;

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannelUpdater.java
@@ -17,7 +17,7 @@ public class ServerChannelUpdater<T extends ServerChannelUpdater<T>> {
     /**
      * Creates a new server channel updater.
      *
-     * @param serverChannelUpdaterDelegate A subtype of a ServerChannelUpdaterDelegate.
+     * @param serverChannelUpdaterDelegate The server channel delegate used by this instance.
      */
     protected ServerChannelUpdater(ServerChannelUpdaterDelegate serverChannelUpdaterDelegate) {
         this.serverChannelUpdaterDelegate = serverChannelUpdaterDelegate;

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -31,6 +31,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -812,6 +813,13 @@ public interface Message extends DiscordEntity, Comparable<Message>, UpdatableFr
      * @return The activity of the message.
      */
     Optional<MessageActivity> getActivity();
+
+    /**
+     * Gets the flags of the message.
+     *
+     * @return The flags of the message.
+     */
+    EnumSet<MessageFlag> getFlags();
 
     /**
      * Checks if the message is pinned.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
@@ -22,6 +22,13 @@ import java.util.concurrent.CompletableFuture;
 public interface MessageAuthor extends DiscordEntity, Nameable {
 
     /**
+     * Gets the webhook id of this author if the message was sent by a webhook.
+     *
+     * @return The webhook id of this author if the message was sent by a webhook.
+     */
+    Optional<Long> getWebhookId();
+
+    /**
      * Gets the message.
      *
      * @return The message.

--- a/javacord-api/src/main/java/org/javacord/api/event/message/MessageEditEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/message/MessageEditEvent.java
@@ -1,41 +1,34 @@
 package org.javacord.api.event.message;
 
-import org.javacord.api.entity.message.embed.Embed;
-
-import java.util.List;
+import org.javacord.api.entity.message.Message;
 import java.util.Optional;
 
 /**
  * A message delete event.
  */
-public interface MessageEditEvent extends RequestableMessageEvent {
+public interface MessageEditEvent extends CertainMessageEvent {
 
     /**
-     * Gets the new content of the message.
+     * Gets the updated message.
      *
-     * @return The new content of the message.
+     * @return The updated message.
      */
-    String getNewContent();
+    @Override
+    Message getMessage();
 
     /**
-     * Gets the old content of the message. It will only be present, if the message is in the cache.
+     * Gets the old message with its old content. It will only be present if the message
+     * was in the cache before this event.
      *
-     * @return The old content of the message.
+     * @return The old message.
      */
-    Optional<String> getOldContent();
+    Optional<Message> getOldMessage();
 
     /**
-     * Gets the new embeds of the message.
+     * Whether this event represents a real change of the contents of this message.
      *
-     * @return The new embeds of the message.
+     * @return true if the original author updated the contents of this message; false otherwise
      */
-    List<Embed> getNewEmbeds();
-
-    /**
-     * Gets the old embeds of the message. It will only be present, if the message is in the cache.
-     *
-     * @return The old embeds of the message.
-     */
-    Optional<List<Embed>> getOldEmbeds();
+    boolean isActualEdit();
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageAuthorImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageAuthorImpl.java
@@ -77,6 +77,11 @@ public class MessageAuthorImpl implements MessageAuthor {
     }
 
     @Override
+    public Optional<Long> getWebhookId() {
+        return Optional.ofNullable(webhookId);
+    }
+
+    @Override
     public Message getMessage() {
         return message;
     }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
@@ -10,6 +10,7 @@ import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.MessageActivity;
 import org.javacord.api.entity.message.MessageAttachment;
 import org.javacord.api.entity.message.MessageAuthor;
+import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.entity.message.MessageReference;
 import org.javacord.api.entity.message.MessageType;
 import org.javacord.api.entity.message.Reaction;
@@ -35,6 +36,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -78,6 +80,11 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
     private final MessageType type;
 
     /**
+     * The flags of the message.
+     */
+    private final EnumSet<MessageFlag> flags = EnumSet.noneOf(MessageFlag.class);
+
+    /**
      * The pinned flag of the message.
      */
     private volatile boolean pinned;
@@ -100,7 +107,7 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
     /**
      * The author of the message.
      */
-    private final MessageAuthor author;
+    private MessageAuthor author;
 
     /**
      * The activity of the message.
@@ -160,41 +167,164 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
     /**
      * Creates a new message object.
      *
-     * @param api The discord api instance.
+     * @param api     The discord api instance.
      * @param channel The channel of the message.
-     * @param data The json data of the message.
+     * @param data    The json data of the message.
      */
     public MessageImpl(DiscordApiImpl api, TextChannel channel, JsonNode data) {
         this.api = api;
         this.channel = channel;
 
         id = data.get("id").asLong();
-        content = data.get("content").asText();
-
-        pinned = data.get("pinned").asBoolean(false);
-        tts = data.get("tts").asBoolean(false);
-        mentionsEveryone = data.get("mention_everyone").asBoolean(false);
-
-        lastEditTime = data.has("edited_timestamp") && !data.get("edited_timestamp").isNull()
-                ? OffsetDateTime.parse(data.get("edited_timestamp").asText()).toInstant()
-                : null;
 
         type = MessageType.byType(data.get("type").asInt(), data.has("webhook_id"));
 
         Long webhookId = data.has("webhook_id") ? data.get("webhook_id").asLong() : null;
         author = new MessageAuthorImpl(this, webhookId, data);
 
+        activity = data.hasNonNull("activity")
+                ? new MessageActivityImpl(this, data.get("activity"))
+                : null;
+
+        nonce = data.hasNonNull("nonce")
+                ? data.path("nonce").asText()
+                : null;
+
+        referencedMessage = data.hasNonNull("referenced_message")
+                ? api.getOrCreateMessage(channel, data.get("referenced_message"))
+                : null;
+
+        messageReference = data.hasNonNull("message_reference")
+                ? new MessageReferenceImpl(api, referencedMessage, data.get("message_reference"))
+                : null;
+
+        setUpdatableFields(data);
+
         MessageCacheImpl cache = (MessageCacheImpl) channel.getMessageCache();
         cache.addMessage(this);
+    }
+
+    /**
+     * Create a new message with the given data.
+     *
+     * @param api               The discord api instance.
+     * @param channel           The channel of the message.
+     * @param id                The id of the message.
+     * @param type              The type of the message.
+     * @param author            The author of the message.
+     * @param activity          The activity of the message.
+     * @param content           The content of the message.
+     * @param nonce             The nonce of the message.
+     * @param referencedMessage The message referenced via message reply.
+     * @param messageReference  The message reference.
+     * @param pinned            The pinned flag of the message.
+     * @param tts               The text-to-speech flag of the message.
+     * @param mentionsEveryone  If the message mentions everyone or not.
+     * @param lastEditTime      The last edit time.
+     * @param components        The components of the message.
+     * @param embeds            The embeds of the message.
+     * @param reactions         The reactions of the message.
+     * @param attachments       The attachments of the message.
+     * @param mentions          The users mentioned in this message.
+     * @param roleMentions      The roles mentioned in this message.
+     * @param stickerItems      The sticker items in this message.
+     */
+    private MessageImpl(DiscordApiImpl api, TextChannel channel, long id, MessageType type,
+                        MessageAuthor author, MessageActivityImpl activity, String content,
+                        String nonce, Message referencedMessage, MessageReference messageReference,
+                        boolean pinned, boolean tts, boolean mentionsEveryone,
+                        Instant lastEditTime, List<HighLevelComponent> components,
+                        List<Embed> embeds, List<Reaction> reactions,
+                        List<MessageAttachment> attachments, List<User> mentions,
+                        List<Role> roleMentions, Set<StickerItem> stickerItems) {
+        this.api = api;
+        this.channel = channel;
+        this.id = id;
+        this.type = type;
+        this.author = author;
+        this.activity = activity;
+        this.content = content;
+        this.nonce = nonce;
+        this.referencedMessage = referencedMessage;
+        this.messageReference = messageReference;
+        this.pinned = pinned;
+        this.tts = tts;
+        this.mentionsEveryone = mentionsEveryone;
+        this.lastEditTime = lastEditTime;
+        this.components.addAll(components);
+        this.embeds.addAll(embeds);
+        this.reactions.addAll(reactions);
+        this.attachments.addAll(attachments);
+        this.mentions.addAll(mentions);
+        this.roleMentions.addAll(roleMentions);
+        this.stickerItems.addAll(stickerItems);
+    }
+
+    /**
+     * Copy the message.
+     *
+     * @return The message.
+     */
+    public MessageImpl copyMessage() {
+        return new MessageImpl(api, channel, id, type, author, activity, content, nonce, referencedMessage,
+                messageReference, pinned, tts, mentionsEveryone, lastEditTime, components,
+                embeds, reactions, attachments, mentions, roleMentions, stickerItems);
+    }
+
+    /**
+     * Sets the updatable fields of the message.
+     *
+     * @param data The json data of the message.
+     */
+    public void setUpdatableFields(JsonNode data) {
+        if (data.has("content")) {
+            content = data.get("content").asText("");
+        }
+
+        if (data.has("pinned")) {
+            pinned = data.path("pinned").asBoolean(false);
+        }
+
+        if (data.has("tts")) {
+            tts = data.path("tts").asBoolean(false);
+        }
+
+        if (data.has("mention_everyone")) {
+            mentionsEveryone = data.path("mention_everyone").asBoolean(false);
+        }
+
+        if (data.has("edited_timestamp")) {
+            if (data.get("edited_timestamp").isNull()) {
+                lastEditTime = null;
+            } else {
+                lastEditTime = OffsetDateTime.parse(data.get("edited_timestamp").asText()).toInstant();
+            }
+        }
 
         if (data.has("embeds")) {
+            embeds.clear();
             for (JsonNode embedJson : data.get("embeds")) {
                 Embed embed = new EmbedImpl(embedJson);
                 embeds.add(embed);
             }
         }
 
+        if (data.has("flags")) {
+            flags.clear();
+            int flag = data.get("flags").asInt();
+            for (MessageFlag value : MessageFlag.values()) {
+                if ((flag & value.getId()) == value.getId()) {
+                    flags.add(value);
+                }
+            }
+        }
+
+        if (data.has("author")) {
+            author = new MessageAuthorImpl(this, author.getWebhookId().orElse(null), data);
+        }
+
         if (data.has("components")) {
+            components.clear();
             for (JsonNode componentJson : data.get("components")) {
                 ActionRowImpl actionRow = new ActionRowImpl(componentJson);
                 components.add(actionRow);
@@ -202,6 +332,7 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
         }
 
         if (data.has("reactions")) {
+            reactions.clear();
             for (JsonNode reactionJson : data.get("reactions")) {
                 Reaction reaction = new ReactionImpl(this, reactionJson);
                 reactions.add(reaction);
@@ -209,6 +340,7 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
         }
 
         if (data.has("attachments")) {
+            attachments.clear();
             for (JsonNode attachmentJson : data.get("attachments")) {
                 MessageAttachment attachment = new MessageAttachmentImpl(this, attachmentJson);
                 attachments.add(attachment);
@@ -216,6 +348,7 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
         }
 
         if (data.has("mentions")) {
+            mentions.clear();
             for (JsonNode mentionJson : data.get("mentions")) {
                 User user = new UserImpl(api, mentionJson, (MemberImpl) null,
                         getServer().map(ServerImpl.class::cast).orElse(null));
@@ -223,7 +356,8 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
             }
         }
 
-        if (data.hasNonNull("mention_roles")) {
+        if (data.has("mention_roles")) {
+            roleMentions.clear();
             getServer().ifPresent(server -> {
                 for (JsonNode roleMentionJson : data.get("mention_roles")) {
                     server.getRoleById(roleMentionJson.asText()).ifPresent(roleMentions::add);
@@ -231,97 +365,19 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
             });
         }
 
-        if (data.hasNonNull("activity")) {
-            activity = new MessageActivityImpl(this, data.get("activity"));
-        } else {
-            activity = null;
-        }
-
-        if (data.hasNonNull("nonce")) {
-            nonce = data.get("nonce").asText();
-        } else {
-            nonce = null;
-        }
-
-        if (data.hasNonNull("sticker_items")) {
+        if (data.has("sticker_items")) {
+            stickerItems.clear();
             for (JsonNode stickerItemJson : data.get("sticker_items")) {
                 stickerItems.add(new StickerItemImpl(api, stickerItemJson));
             }
         }
-
-        if (data.hasNonNull("referenced_message")) {
-            referencedMessage = api.getOrCreateMessage(channel, data.get("referenced_message"));
-        } else {
-            referencedMessage = null;
-        }
-
-        if (data.hasNonNull("message_reference")) {
-            messageReference = new MessageReferenceImpl(api, referencedMessage, data.get("message_reference"));
-        } else {
-            messageReference = null;
-        }
-    }
-
-    /**
-     * Sets the content of the message.
-     *
-     * @param content The content to set.
-     */
-    public void setContent(String content) {
-        this.content = content;
-    }
-
-    /**
-     * Sets the pinned flag if the message.
-     *
-     * @param pinned The pinned flag to set.
-     */
-    public void setPinned(boolean pinned) {
-        this.pinned = pinned;
-    }
-
-    /**
-     * Sets the mentions everyone flag.
-     *
-     * @param mentionsEveryone The mentions everyone flag to set.
-     */
-    public void setMentionsEveryone(boolean mentionsEveryone) {
-        this.mentionsEveryone = mentionsEveryone;
-    }
-
-    /**
-     * Sets the last edit time of the message.
-     *
-     * @param lastEditTime The last edit time of the message.
-     */
-    public void setLastEditTime(Instant lastEditTime) {
-        this.lastEditTime = lastEditTime;
-    }
-
-    /**
-     * Sets the embeds of the message.
-     *
-     * @param embeds The embeds to set.
-     */
-    public void setEmbeds(List<Embed> embeds) {
-        this.embeds.clear();
-        this.embeds.addAll(embeds);
-    }
-
-    /**
-     * Set the tts flag for the message.
-     *
-     * @param tts The new flag.
-     */
-    public void setTts(boolean tts) {
-        this.tts = tts;
     }
 
     /**
      * Adds an emoji to the list of reactions.
      *
      * @param emoji The emoji.
-     * @param you Whether this reaction is used by you or not.
+     * @param you   Whether this reaction is used by you or not.
      */
     public void addReaction(Emoji emoji, boolean you) {
         Optional<Reaction> reaction = reactions.stream().filter(r -> emoji.equalsEmoji(r.getEmoji())).findAny();
@@ -335,7 +391,7 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
      * Removes an emoji from the list of reactions.
      *
      * @param emoji The emoji.
-     * @param you Whether this reaction is used by you or not.
+     * @param you   Whether this reaction is used by you or not.
      */
     public void removeReaction(Emoji emoji, boolean you) {
         Optional<Reaction> reaction = reactions.stream().filter(r -> emoji.equalsEmoji(r.getEmoji())).findAny();
@@ -404,6 +460,11 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
     @Override
     public Optional<MessageActivity> getActivity() {
         return Optional.ofNullable(activity);
+    }
+
+    @Override
+    public EnumSet<MessageFlag> getFlags() {
+        return EnumSet.copyOf(flags);
     }
 
     @Override
@@ -539,9 +600,9 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
     @Override
     public boolean equals(Object o) {
         return (this == o)
-               || !((o == null)
-                    || (getClass() != o.getClass())
-                    || (getId() != ((DiscordEntity) o).getId()));
+                || !((o == null)
+                || (getClass() != o.getClass())
+                || (getId() != ((DiscordEntity) o).getId()));
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/event/message/MessageEditEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/message/MessageEditEventImpl.java
@@ -2,77 +2,48 @@ package org.javacord.core.event.message;
 
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.TextChannel;
-import org.javacord.api.entity.message.embed.Embed;
+import org.javacord.api.entity.message.Message;
 import org.javacord.api.event.message.MessageEditEvent;
-
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 /**
  * The implementation of {@link MessageEditEvent}.
  */
-public class MessageEditEventImpl extends RequestableMessageEventImpl implements MessageEditEvent {
+public class MessageEditEventImpl extends CertainMessageEventImpl implements MessageEditEvent {
+    /**
+     * The old message. May be <code>null</code>!
+     */
+    private final Message oldMessage;
 
     /**
-     * The new content of the message.
+     * Whether this event represents a real change of the contents of this message.
      */
-    private final String newContent;
-
-    /**
-     * The old content of the message. May be <code>null</code>!
-     */
-    private final String oldContent;
-
-    /**
-     * The new embeds of the message.
-     */
-    private final List<Embed> newEmbeds;
-
-    /**
-     * The old embeds of the message. May be <code>null</code>!
-     */
-    private final List<Embed> oldEmbeds;
+    private final boolean isActualEdit;
 
     /**
      * Creates a new message edit event.
      *
-     * @param api The discord api instance.
-     * @param messageId The id of the message.
-     * @param channel The text channel in which the message was sent.
-     * @param newContent The new content of the message.
-     * @param newEmbeds The new embeds of the message.
-     * @param oldContent The old content of the message.
-     * @param oldEmbeds The old embeds of the message.
+     * @param api            The discord api instance.
+     * @param messageId      The id of the message.
+     * @param channel        The text channel in which the message was sent.
+     * @param updatedMessage The updated message.
+     * @param oldMessage     The old message.
+     * @param isActualEdit   Whether this event represents a real change of the contents of this message.
      */
-    public MessageEditEventImpl(
-            DiscordApi api, long messageId, TextChannel channel, String newContent, List<Embed> newEmbeds,
-            String oldContent, List<Embed> oldEmbeds) {
-        super(api, messageId, channel);
-        this.newContent = newContent;
-        this.newEmbeds = newEmbeds;
-        this.oldContent = oldContent;
-        this.oldEmbeds = oldEmbeds;
+    public MessageEditEventImpl(DiscordApi api, long messageId, TextChannel channel, Message updatedMessage,
+                                Message oldMessage, boolean isActualEdit) {
+        super(updatedMessage);
+        this.oldMessage = oldMessage;
+        this.isActualEdit = isActualEdit;
     }
 
     @Override
-    public String getNewContent() {
-        return newContent == null ? "" : newContent;
+    public Optional<Message> getOldMessage() {
+        return Optional.ofNullable(oldMessage);
     }
 
     @Override
-    public Optional<String> getOldContent() {
-        return Optional.ofNullable(oldContent);
+    public boolean isActualEdit() {
+        return isActualEdit;
     }
-
-    @Override
-    public List<Embed> getNewEmbeds() {
-        return newEmbeds == null ? Collections.emptyList() : newEmbeds;
-    }
-
-    @Override
-    public Optional<List<Embed>> getOldEmbeds() {
-        return Optional.ofNullable(oldEmbeds);
-    }
-
 }

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/message/MessageUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/message/MessageUpdateHandler.java
@@ -5,15 +5,11 @@ import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.TextChannel;
-import org.javacord.api.entity.message.Message;
-import org.javacord.api.entity.message.embed.Embed;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.event.message.CachedMessagePinEvent;
 import org.javacord.api.event.message.CachedMessageUnpinEvent;
 import org.javacord.api.event.message.MessageEditEvent;
 import org.javacord.core.entity.message.MessageImpl;
-import org.javacord.core.entity.message.embed.EmbedBuilderDelegateImpl;
-import org.javacord.core.entity.message.embed.EmbedImpl;
 import org.javacord.core.event.message.CachedMessagePinEventImpl;
 import org.javacord.core.event.message.CachedMessageUnpinEventImpl;
 import org.javacord.core.event.message.MessageEditEventImpl;
@@ -22,8 +18,6 @@ import org.javacord.core.util.gateway.PacketHandler;
 import org.javacord.core.util.logging.LoggerUtil;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -32,6 +26,7 @@ import java.util.concurrent.TimeUnit;
  * Handles the message update packet.
  */
 public class MessageUpdateHandler extends PacketHandler {
+    private static final int MAX_EDIT_TIMEOUT = 30000;
 
     /**
      * The logger of this class.
@@ -54,7 +49,7 @@ public class MessageUpdateHandler extends PacketHandler {
         api.getThreadPool().getScheduler().scheduleAtFixedRate(() -> {
             try {
                 lastKnownEditTimestamps.entrySet().removeIf(
-                        entry -> System.currentTimeMillis() + offset - entry.getValue() > 5000);
+                        entry -> System.currentTimeMillis() + offset - entry.getValue() > MAX_EDIT_TIMEOUT);
             } catch (Throwable t) {
                 logger.error("Failed to clean last known edit timestamps cache!", t);
             }
@@ -73,109 +68,71 @@ public class MessageUpdateHandler extends PacketHandler {
         }
 
         TextChannel channel = optionalChannel.get();
-        Optional<MessageImpl> message = api.getCachedMessageById(messageId).map(msg -> (MessageImpl) msg);
+        Optional<MessageImpl> cachedMessage = api.getCachedMessageById(messageId).map(msg -> (MessageImpl) msg);
 
-        message.ifPresent(msg -> {
-            boolean newPinnedFlag = packet.hasNonNull("pinned") ? packet.get("pinned").asBoolean() : msg.isPinned();
-            boolean oldPinnedFlag = msg.isPinned();
-            if (newPinnedFlag != oldPinnedFlag) {
-                msg.setPinned(newPinnedFlag);
+        // We need a message to dispatch any event so we either need a cached message to update
+        // or else we must be able to construct a new message from this event
+        if (!cachedMessage.isPresent() && !isCompleteMessagePacket(packet)) {
+            logger.debug("Received a message update event for an uncached message that contains not enough "
+                    + "data to construct a new message in channel {}. Packet: {}", channelId, packet);
+            return;
+        }
 
-                if (newPinnedFlag) {
-                    CachedMessagePinEvent event = new CachedMessagePinEventImpl(msg);
+        MessageImpl oldMessage = cachedMessage.map(MessageImpl::copyMessage).orElse(null);
+        MessageImpl newMessage = cachedMessage.orElseGet(() -> (MessageImpl) api.getOrCreateMessage(channel, packet));
 
-                    Optional<Server> optionalServer =
-                            msg.getChannel().asServerChannel().map(ServerChannel::getServer);
-                    api.getEventDispatcher().dispatchCachedMessagePinEvent(
-                            optionalServer.map(DispatchQueueSelector.class::cast).orElse(api),
-                            msg,
-                            optionalServer.orElse(null),
-                            msg.getChannel(),
-                            event);
-                } else {
-                    CachedMessageUnpinEvent event = new CachedMessageUnpinEventImpl(msg);
-
-                    Optional<Server> optionalServer =
-                            msg.getChannel().asServerChannel().map(ServerChannel::getServer);
-                    api.getEventDispatcher().dispatchCachedMessageUnpinEvent(
-                            optionalServer.map(DispatchQueueSelector.class::cast).orElse(api),
-                            msg,
-                            optionalServer.orElse(null),
-                            msg.getChannel(),
-                            event);
-                }
-            }
-        });
-
-        MessageEditEvent editEvent = null;
-        if (packet.has("edited_timestamp") && !packet.get("edited_timestamp").isNull()) {
-            message.ifPresent(msg -> {
-                msg.setLastEditTime(OffsetDateTime.parse(packet.get("edited_timestamp").asText()).toInstant());
-                msg.setMentionsEveryone(packet.get("mention_everyone").asBoolean());
-            });
-
+        // Figure out whether this was an intentional content edit by a user
+        boolean isMostLikelyAnEdit = packet.has("edited_timestamp") && !packet.get("edited_timestamp").isNull();
+        if (isMostLikelyAnEdit) {
             long editTimestamp =
                     OffsetDateTime.parse(packet.get("edited_timestamp").asText()).toInstant().toEpochMilli();
             long lastKnownEditTimestamp = lastKnownEditTimestamps.getOrDefault(messageId, 0L);
             lastKnownEditTimestamps.put(messageId, editTimestamp);
 
-            boolean isMostLikelyAnEdit = true;
             long offset = api.getTimeOffset() == null ? 0 : api.getTimeOffset();
             if (editTimestamp == lastKnownEditTimestamp) {
                 isMostLikelyAnEdit = false;
-            } else if (System.currentTimeMillis() + offset - editTimestamp > 5000) {
+            } else if (System.currentTimeMillis() + offset - editTimestamp > MAX_EDIT_TIMEOUT) {
                 isMostLikelyAnEdit = false;
             }
+        }
 
-            String oldContent = message.map(Message::getContent).orElse(null);
-            List<Embed> oldEmbeds = message.map(Message::getEmbeds).orElse(null);
+        newMessage.setUpdatableFields(packet);
 
-            String newContent = null;
-            if (packet.has("content")) {
-                newContent = packet.get("content").asText();
-                String finalNewContent = newContent;
-                message.ifPresent(msg -> msg.setContent(finalNewContent));
-            }
-            List<Embed> newEmbeds = null;
-            if (packet.has("embeds")) {
-                newEmbeds = new ArrayList<>();
-                for (JsonNode embedJson : packet.get("embeds")) {
-                    Embed embed = new EmbedImpl(embedJson);
-                    newEmbeds.add(embed);
-                }
-                List<Embed> finalNewEmbeds = newEmbeds;
-                message.ifPresent(msg -> msg.setEmbeds(finalNewEmbeds));
-            }
+        if (cachedMessage.isPresent() && packet.hasNonNull("pinned")) {
+            boolean newPinnedFlag = newMessage.isPinned();
+            boolean oldPinnedFlag = oldMessage.isPinned();
 
-            if (oldContent != null && newContent != null && !oldContent.equals(newContent)) {
-                // If the old content doesn't match the new content it's for sure an edit
-                isMostLikelyAnEdit = true;
-            }
+            if (newPinnedFlag != oldPinnedFlag) {
+                if (newPinnedFlag) {
+                    CachedMessagePinEvent event = new CachedMessagePinEventImpl(newMessage);
 
-            if (oldEmbeds != null && newEmbeds != null) {
-                if (newEmbeds.size() != oldEmbeds.size()) {
-                    isMostLikelyAnEdit = true;
+                    Optional<Server> optionalServer =
+                            newMessage.getChannel().asServerChannel().map(ServerChannel::getServer);
+                    api.getEventDispatcher().dispatchCachedMessagePinEvent(
+                            optionalServer.map(DispatchQueueSelector.class::cast).orElse(api),
+                            newMessage,
+                            optionalServer.orElse(null),
+                            newMessage.getChannel(),
+                            event);
                 } else {
-                    for (int i = 0; i < newEmbeds.size(); i++) {
-                        if (!((EmbedBuilderDelegateImpl) newEmbeds.get(i)
-                                .toBuilder().getDelegate()).toJsonNode().toString()
-                                .equals(((EmbedBuilderDelegateImpl) oldEmbeds.get(i)
-                                        .toBuilder().getDelegate()).toJsonNode().toString())) {
-                            isMostLikelyAnEdit = true;
-                        }
-                    }
+                    CachedMessageUnpinEvent event = new CachedMessageUnpinEventImpl(newMessage);
+
+                    Optional<Server> optionalServer =
+                            newMessage.getChannel().asServerChannel().map(ServerChannel::getServer);
+                    api.getEventDispatcher().dispatchCachedMessageUnpinEvent(
+                            optionalServer.map(DispatchQueueSelector.class::cast).orElse(api),
+                            newMessage,
+                            optionalServer.orElse(null),
+                            newMessage.getChannel(),
+                            event);
                 }
             }
-
-            if (isMostLikelyAnEdit) {
-                editEvent = new MessageEditEventImpl(
-                        api, messageId, channel, newContent, newEmbeds, oldContent, oldEmbeds);
-            }
         }
 
-        if (editEvent != null) {
-            dispatchEditEvent(editEvent);
-        }
+        MessageEditEventImpl editEvent = new MessageEditEventImpl(api, messageId, channel, newMessage,
+                oldMessage, isMostLikelyAnEdit);
+        dispatchEditEvent(editEvent);
     }
 
     /**
@@ -192,6 +149,21 @@ public class MessageUpdateHandler extends PacketHandler {
                 optionalServer.orElse(null),
                 event.getChannel(),
                 event);
+    }
+
+    /**
+     * Check the message update packet for some core fields whose presence indicates
+     * that this packet contains the entire message.
+     *
+     * @param packet the message update event
+     * @return true if this event contains a full message; false otherwise
+     */
+    private static boolean isCompleteMessagePacket(JsonNode packet) {
+        return packet.hasNonNull("type")
+                && packet.hasNonNull("author")
+                && packet.hasNonNull("content")
+                && packet.hasNonNull("timestamp")
+                && packet.hasNonNull("embeds");
     }
 
 }


### PR DESCRIPTION
### Change
MessageUpdateHandler now dispatches an event every time it receives an update

### Breaking change
Removes get(new/old)Content and embeds from the `MessageEditEvent`. Instead `getOldMessage` and `getMessage` should be used to compare the fields you want