### PR TITLE
Handle user update gateway packets

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/handler/user/UserUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/user/UserUpdateHandler.java
@@ -2,6 +2,8 @@ package org.javacord.core.util.handler.user;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.javacord.api.DiscordApi;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
 import org.javacord.core.util.gateway.PacketHandler;
 
 /**
@@ -20,7 +22,7 @@ public class UserUpdateHandler extends PacketHandler {
 
     @Override
     public void handle(JsonNode packet) {
-        // NOP
+        api.setYourself(new UserImpl(api, packet.get("user"), (MemberImpl) null, null));
     }
 
 }


### PR DESCRIPTION
`USER_UPDATE` is dispatched when the current user (i.e. the bot) is updated, e.g. to update the username or avatar. Previously the packet would just be ignored, meaning `DiscordApi#getYourself()` would return stale data, as the underlying field was only ever set once, in the `READY` handler (with the same line of code I used here).

Now, the question remains - should this also emit a fully fledged Javacord event? You can already receive `GUILD_MEMBER_UPDATE` events when a user changes, so technically you can aready listen to self-updates; just `getYourself()` would be outdated.