### PR TITLE
Expose `getServerBoostingSinceTimestamp` and `getServerAvatarHash`

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -177,6 +177,14 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     Optional<String> getNickname(User user);
 
     /**
+     * Gets the timestamp of when this member started boosting the server.
+     *
+     * @param user The user to check.
+     * @return The timestamp of when this member started boosting the server.
+     */
+    Optional<Instant> getServerBoostingSinceTimestamp(User user);
+
+    /**
      * Gets the timestamp of when the user's timeout will expire
      * and the user will be able to communicate in the server again.
      * The returned Instant may be in the past which indicates that the user is not timed out.
@@ -199,6 +207,14 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
     default Optional<Instant> getActiveTimeout(User user) {
         return getTimeout(user).filter(Instant.now()::isBefore);
     }
+
+    /**
+     * Gets the user's server specific avatar hash.
+     *
+     * @param user The user.
+     * @return The user's server specific avatar hash.
+     */
+    Optional<String> getUserServerAvatarHash(User user);
 
     /**
      * Gets the user's server specific avatar.

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -242,6 +242,14 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
     Icon getAvatar(int size);
 
     /**
+     * Gets the member's server avatar hash.
+     *
+     * @param server The server.
+     * @return The member's server avatar hash.
+     */
+    Optional<String> getServerAvatarHash(Server server);
+
+    /**
      * Gets the user's server-specific avatar in the given server.
      *
      * @param server The server.
@@ -374,6 +382,14 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
      * @return The nickname of the user.
      */
     Optional<String> getNickname(Server server);
+
+    /**
+     * Gets the timestamp of when this member started boosting the server.
+     *
+     * @param server The server.
+     * @return The timestamp of when this member started boosting the server.
+     */
+    Optional<Instant> getServerBoostingSinceTimestamp(Server server);
 
     /**
      * Timeouts the user on the given server.

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1271,9 +1271,21 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     }
 
     @Override
+    public Optional<Instant> getServerBoostingSinceTimestamp(User user) {
+        return getRealMemberById(user.getId())
+                .flatMap(Member::getServerBoostingSinceTimestamp);
+    }
+
+    @Override
     public Optional<Instant> getTimeout(User user) {
         return getRealMemberById(user.getId())
                 .flatMap(Member::getTimeout);
+    }
+
+    @Override
+    public Optional<String> getUserServerAvatarHash(User user) {
+        return getRealMemberById(user.getId())
+                .flatMap(Member::getServerAvatarHash);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/Member.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/Member.java
@@ -107,7 +107,7 @@ public interface Member extends DiscordEntity, Messageable, Mentionable, Permiss
     /**
      * Gets the timestamp of when this member started boosting the server.
      *
-     * @return The timestamp of when this member started boosting joined the server.
+     * @return The timestamp of when this member started boosting the server.
      */
     Optional<Instant> getServerBoostingSinceTimestamp();
 

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
@@ -289,6 +289,15 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
     }
 
     @Override
+    public Optional<Instant> getServerBoostingSinceTimestamp(Server server) {
+        if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
+            return server.getServerBoostingSinceTimestamp(this);
+        } else {
+            return member.getServerBoostingSinceTimestamp();
+        }
+    }
+
+    @Override
     public String getDisplayName(Server server) {
         if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
             return server.getNickname(this).orElseGet(this::getName);
@@ -366,6 +375,15 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
             return server.getRoleColor(this);
         } else {
             return member.getRoleColor();
+        }
+    }
+
+    @Override
+    public Optional<String> getServerAvatarHash(Server server) {
+        if (api.hasUserCacheEnabled() || member == null || member.getServer().getId() != server.getId()) {
+            return server.getUserServerAvatarHash(this);
+        } else {
+            return member.getServerAvatarHash();
         }
     }
 


### PR DESCRIPTION
Previously, one could only get a full avatar URL from a member, instead of just the hash like you can already do with a normal user avatar. The boosting timestamp wasn't even exposed at all, it was just internal to `Member`, which was probably an oversight (it was added in the member intent refactor and never touched again).
Since I don't see a reason to keep them private, let's expose them! From what I see these were the only missing member fields, so all Discord member fields should be exposed now.