### PR TITLE
Add Support for Description in Attachments

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/Attachment.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/Attachment.java
@@ -20,6 +20,13 @@ public interface Attachment extends DiscordEntity {
     String getFileName();
 
     /**
+     * Gets the description of the attachment.
+     *
+     * @return The description of the attachment.
+     */
+    String getDescription();
+
+    /**
      * Gets the size of the attachment in bytes.
      *
      * @return The size of the attachment in bytes.

--- a/javacord-api/src/main/java/org/javacord/api/entity/Attachment.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/Attachment.java
@@ -24,7 +24,7 @@ public interface Attachment extends DiscordEntity {
      *
      * @return The description of the attachment.
      */
-    String getDescription();
+    Optional<String> getDescription();
 
     /**
      * Gets the size of the attachment in bytes.

--- a/javacord-core/src/main/java/org/javacord/core/entity/AttachmentImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/AttachmentImpl.java
@@ -40,6 +40,11 @@ public class AttachmentImpl implements Attachment {
     private final String fileName;
 
     /**
+     * The description of the attachment.
+     */
+    private final String description;
+
+    /**
      * The size of the attachment in bytes.
      */
     private final int size;
@@ -79,6 +84,7 @@ public class AttachmentImpl implements Attachment {
         this.api = api;
         id = data.get("id").asLong();
         fileName = data.get("filename").asText();
+        description = data.hasNonNull("description") ? data.get("description").asText() : null;
         size = data.get("size").asInt();
         url = data.get("url").asText();
         proxyUrl = data.get("proxy_url").asText();
@@ -100,6 +106,11 @@ public class AttachmentImpl implements Attachment {
     @Override
     public String getFileName() {
         return fileName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/AttachmentImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/AttachmentImpl.java
@@ -109,8 +109,8 @@ public class AttachmentImpl implements Attachment {
     }
 
     @Override
-    public String getDescription() {
-        return description;
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(description);
     }
 
     @Override


### PR DESCRIPTION
Issue Link : https://github.com/Javacord/Javacord/issues/1069 
[Message Attachments](https://discord.com/developers/docs/resources/channel#attachment-object) may have a description attribute.