### PR TITLE
Reinstate javadoc options lost in rework

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,16 +152,32 @@ publishing {
 }
 
 subprojects {
-    tasks.register("configureJavadoc") {
-        doLast {
-            tasks.javadoc {
-                options.windowTitle = "Javacord $version (${project.ext.get("shortName")})"
-                title = options.windowTitle
+    tasks.withType<Javadoc>().configureEach {
+        options {
+            this as StandardJavadocDocletOptions
+            locale = "en"
+            encoding = "UTF-8"
+            docTitle = "Javacord ${project.version} (${project.property("shortName")})"
+            windowTitle = "$docTitle Documentation"
+            links("https://docs.oracle.com/javase/8/docs/api/")
+            isUse = true
+            isVersion = true
+            isAuthor = true
+            isSplitIndex = true
+
+            val toolchain = javadocTool
+                .map { JavaVersion.toVersion(it.metadata.languageVersion) }
+                .orElse(provider { JavaVersion.current() })
+                .get()
+            if (toolchain.isJava9Compatible) {
+                addBooleanOption("html5", true)
+                addStringOption("-release", java.targetCompatibility.majorVersion)
+                if (toolchain.isJava11Compatible) {
+                    addBooleanOption("-no-module-directories", true)
+                }
+            } else {
+                source = java.sourceCompatibility.toString()
             }
         }
-    }
-
-    tasks.javadoc {
-        dependsOn("configureJavadoc")
     }
 }

--- a/javacord-api/build.gradle.kts
+++ b/javacord-api/build.gradle.kts
@@ -48,3 +48,36 @@ tasks.jar {
         )
     }
 }
+
+tasks.javadoc {
+    options {
+        this as StandardJavadocDocletOptions
+        group("Public API", "*")
+        group(
+            "Internal Helpers",
+            this@javadoc
+                .source
+                .files
+                .asSequence()
+                .map { "${it.toURI()}" }
+                .filter { it.contains("/internal/") }
+                .map { uri ->
+                    sourceSets
+                        .main
+                        .get()
+                        .java
+                        .srcDirs
+                        .joinToString(
+                            separator = "|",
+                            prefix = "^(?:",
+                            postfix = """)(?:(?<!/)/)?|/[^/]*\.java$"""
+                        ) { """\Q${it.toURI()}\E""" }
+                        .toRegex()
+                        .replace(uri, "")
+                }
+                .map { it.replace("/", ".") }
+                .distinct()
+                .toList()
+        )
+    }
+}

--- a/javacord-core/build.gradle.kts
+++ b/javacord-core/build.gradle.kts
@@ -72,3 +72,14 @@ tasks.jar {
         )
     }
 }
+
+tasks.javadoc {
+    dependsOn(project(":javacord-api").tasks.javadoc)
+    options {
+        this as StandardJavadocDocletOptions
+        val releaseVersion: Boolean by rootProject.extra
+        val apiJavadocs = "${project(":javacord-api").tasks.javadoc.get().destinationDir!!.toURI()}"
+        val releasedApiJavadocs = "https://docs.javacord.org/api/v/$version"
+        linksOffline(if (releaseVersion) releasedApiJavadocs else apiJavadocs, apiJavadocs)
+    }
+}


### PR DESCRIPTION
Re-adds some of the missing javadoc build options, in particular the `-no-module-directories` option which fixes the `/unknown/` redirect

I'm not too familiar with Gradle/Kotlin DSL so any input on code styling welcome.
I have missed out the section which split the docs into "Public API" and "Internal helpers" as I'm not sure if we wanted to keep that
And lastly there are a few function calls in the previous javadoc task which I'm not sure of their use and I cannot find documentation for, in particular `delegate.use()`


As a side note our compatibility in the `build.gradle.kts` still seems to be at 1.8, should this be upgraded? 