### PR TITLE
Bring the Server object and its fields up to date

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -32,6 +32,7 @@ import org.javacord.api.entity.permission.PermissionsBuilder;
 import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.permission.RoleBuilder;
 import org.javacord.api.entity.server.invite.RichInvite;
+import org.javacord.api.entity.server.invite.WelcomeScreen;
 import org.javacord.api.entity.sticker.Sticker;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.webhook.IncomingWebhook;
@@ -50,6 +51,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -69,20 +71,6 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
      * @return The audio connection in this server.
      */
     Optional<AudioConnection> getAudioConnection();
-
-    /**
-     * Checks if the server has boost messages enabled.
-     *
-     * @return Whether the server has boost messages enabled or not.
-     */
-    boolean hasBoostMessagesEnabled();
-
-    /**
-     * Checks if the server has join messages enabled.
-     *
-     * @return Whether the server has join messages enabled or not.
-     */
-    boolean hasJoinMessagesEnabled();
 
     /**
      * Gets the features of the server.
@@ -3436,4 +3424,70 @@ public interface Server extends DiscordEntity, Nameable, UpdatableFromCache<Serv
             throw new IllegalArgumentException("The ID must be a number.");
         }
     }
+
+    /**
+     * True if the server widget is enabled.
+     * 
+     * @return true if the server widget is enabled.
+     */
+    boolean isWidgetEnabled();
+
+    /**
+     * Gets the channel id that the widget will generate an invite to, or null if set to no invite.
+     * 
+     * @return the channel id that the widget will generate an invite to, or null if set to no invite.
+     */
+    Optional<Long> getWidgetChannelId();
+
+    /**
+     * Gets the maximum number of presences for the guild
+     * (null is always returned, apart from the largest of guilds).
+     * 
+     * @return the maximum number of presences for the guild.
+     */
+    Optional<Integer> getMaxPresences();
+
+    /**
+     * Gets the maximum number of members for the guild.
+     * 
+     * @return the maximum number of members for the guild.
+     */
+    Optional<Integer> getMaxMembers();
+
+    /**
+     * Gets the maximum amount of users in a video channel.
+     * 
+     * @return the maximum amount of users in a video channel.
+     */
+    Optional<Integer> getMaxVideoChannelUsers();
+
+    /**
+     * Gets the welcome screen of a Community server shown to new members.
+     * 
+     * @return the welcome screen of a Community server shown to new members.
+     */
+    Optional<WelcomeScreen> getWelcomeScreen();
+
+    /**
+     * True if the server's boost progress bar is enabled.
+     * 
+     * @return whether the server's boost progress bar is enabled or not.
+     */
+    boolean isPremiumProgressBarEnabled();
+
+    /**
+     * Gets regular server channel for widget.
+     * 
+     * @return the regular server channel for widget.
+     */
+    default Optional<RegularServerChannel> getWidgetChannel() {
+        return getWidgetChannelId().flatMap(this::getRegularChannelById);
+    }
+
+    /**
+     * Gets system channel flags for this server.
+     * 
+     * @return The system channel flags for this server.
+     */
+    public EnumSet<SystemChannelFlag> getSystemChannelFlags();
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/ServerFeature.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/ServerFeature.java
@@ -14,10 +14,6 @@ public enum ServerFeature {
      */
     BANNER,
     /**
-     * Server has access to use commerce features (i.e. create store channels).
-     */
-    COMMERCE,
-    /**
      * Server is a community server.
      */
     COMMUNITY,
@@ -78,19 +74,15 @@ public enum ServerFeature {
      */
     MORE_STICKERS,
     /**
-     * Server has access to the three day archive time for threads.
-     */
-    THREE_DAY_THREAD_ARCHIVE,
-    /**
-     * Server has access to the seven day archive time for threads.
-     */
-    SEVEN_DAY_THREAD_ARCHIVE,
-    /**
      * Server has access to create private threads.
      */
     PRIVATE_THREADS,
     /**
-     * Server was able to be discovered in the directory before.
+     * Server has access to set an animated guild banner image.
      */
-    ENABLED_DISCOVERABLE_BEFORE
+    ANIMATED_BANNER,
+    /**
+     * Server has set up auto moderation rules.
+     */
+    AUTO_MODERATION,
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/SystemChannelFlag.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/SystemChannelFlag.java
@@ -1,0 +1,44 @@
+package org.javacord.api.entity.server;
+
+/**
+ * System channel flags for various server notifications.
+ */
+public enum SystemChannelFlag {
+
+    /**
+     * Suppress member join notifications.
+     */
+    SUPPRESS_JOIN_NOTIFICATIONS(1 << 0),
+    /**
+     * Suppress server boost notifications.
+     */
+    SUPPRESS_PREMIUM_SUBSCRIPTIONS(1 << 1),
+    /**
+     * Suppress server setup tips.
+     */
+    SUPPRESS_GUILD_REMINDER_NOTIFICATIONS(1 << 2),
+    /**
+     * Hide member join sticker reply buttons.
+     */
+    SUPPRESS_JOIN_NOTIFICATION_REPLIES(1 << 3);
+
+    private final int flag;
+
+    /**
+     * Class constructor.
+     *
+     * @param flag The bitmask of the flag.
+     */
+    SystemChannelFlag(int flag) {
+        this.flag = flag;
+    }
+
+    /**
+     * Gets the integer value of the flag.
+     *
+     * @return The integer value of the flag.
+     */
+    public int asInt() {
+        return flag;
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/invite/WelcomeScreen.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/invite/WelcomeScreen.java
@@ -1,0 +1,24 @@
+package org.javacord.api.entity.server.invite;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * This class represents a Welcome Screen.
+ */
+public interface WelcomeScreen {
+
+    /**
+     * Gets the server description shown in the welcome screen.
+     * 
+     * @return the server description shown in the welcome screen.
+     */
+    Optional<String>  getDescription();
+
+    /**
+     * Gets the channels shown in the welcome screen.
+     * 
+     * @return the channels shown in the welcome screen.
+     */
+    List<WelcomeScreenChannel> getWelcomeScreenChannels();
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/invite/WelcomeScreenChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/invite/WelcomeScreenChannel.java
@@ -1,0 +1,37 @@
+package org.javacord.api.entity.server.invite;
+
+import java.util.Optional;
+
+/**
+ * This class represents a Welcome Screen Channel.
+ */
+public interface WelcomeScreenChannel {
+
+    /**
+     * Gets the channel's id.
+     * 
+     * @return the channel's id
+     */
+    long getChannelId();
+
+    /**
+     * Gets the description shown for the channel.
+     * 
+     * @return the description shown for the channel.
+     */
+    String getDescription();
+
+    /**
+     * Gets the emoji id, if the emoji is custom.
+     * 
+     * @return the emoji id, if the emoji is custom.
+     */
+    Optional<Long> getEmojiId();
+
+    /**
+     * Gets the emoji name if custom or the unicode character.
+     * 
+     * @return the emoji name if custom or the unicode character.
+     */
+    Optional<String> getEmojiName();
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -40,8 +40,10 @@ import org.javacord.api.entity.server.MultiFactorAuthenticationLevel;
 import org.javacord.api.entity.server.NsfwLevel;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.server.ServerFeature;
+import org.javacord.api.entity.server.SystemChannelFlag;
 import org.javacord.api.entity.server.VerificationLevel;
 import org.javacord.api.entity.server.invite.RichInvite;
+import org.javacord.api.entity.server.invite.WelcomeScreen;
 import org.javacord.api.entity.sticker.Sticker;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.entity.user.UserStatus;
@@ -65,6 +67,7 @@ import org.javacord.core.entity.channel.UnknownRegularServerChannelImpl;
 import org.javacord.core.entity.channel.UnknownServerChannelImpl;
 import org.javacord.core.entity.permission.RoleImpl;
 import org.javacord.core.entity.server.invite.InviteImpl;
+import org.javacord.core.entity.server.invite.WelcomeScreenImpl;
 import org.javacord.core.entity.sticker.StickerImpl;
 import org.javacord.core.entity.user.Member;
 import org.javacord.core.entity.user.MemberImpl;
@@ -87,6 +90,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -277,15 +281,47 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     private volatile String discoverySplash;
 
     /**
-     * Whether the server has join messages enabled.
+     * True if the server widget is enabled.
      */
-    private volatile boolean hasJoinMessagesEnabled = true;
+    private volatile boolean widgetEnabled;
+    
+    /**
+     * The channel id that the widget will generate an invite to, or null if set to no invite.
+     */
+    private volatile long widgetChannelId;
+    
+    /**
+     * The maximum number of presences for the guild (null is always returned, apart from the largest of guilds).
+     */
+    private volatile int maxPresences;
+    
+    /**
+     * The maximum number of members for the guild.
+     */
+    private volatile int maxMembers;
+    
+    /**
+     * The maximum amount of users in a video channel.
+     */
+    private volatile int maxVideoChannelUsers;
+    
+    /**
+     * The welcome screen of a community server, shown to new members.
+     */
+    private volatile WelcomeScreen welcomeScreen;
+    
+    /**
+     * Whether the server's boost progress bar is enabled or not.
+     */
+    private volatile boolean premiumProgressBarEnabled;
 
     /**
-     * Whether the server has boost messages enabled.
+     * The enum set of all server system channel flags.
      */
-    private volatile boolean hasBoostMessagesEnabled = true;
-
+    private final EnumSet<SystemChannelFlag> systemChannelFlags = 
+            EnumSet.noneOf(SystemChannelFlag.class);
+    
+    
     /**
      * Creates a new server object.
      *
@@ -350,7 +386,8 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
             vanityUrlCode = new VanityUrlCodeImpl(data.get("vanity_url_code").asText());
         }
         if (data.hasNonNull("system_channel_flags")) {
-            setSystemChannelFlag(data.get("system_channel_flags").asInt());
+            int systemChannelFlag = data.get("system_channel_flags").asInt();
+            setSystemChannelFlag(systemChannelFlag);
         }
 
         if (data.has("channels")) {
@@ -512,6 +549,22 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
             }
         }
 
+        if (data.has("welcome_screen")) {
+            this.welcomeScreen = new WelcomeScreenImpl(data.get("welcome_screen"));
+        } else {
+            this.welcomeScreen = null;
+        }
+        this.widgetEnabled = data.path("widget_enabled").asBoolean(false);
+        this.widgetChannelId = data.hasNonNull("widget_channel_id") 
+                            ? data.get("widget_channel_id").asLong() : null;
+        this.maxPresences = data.hasNonNull("max_presences") 
+                            ? data.get("max_presences").asInt() : null;
+        this.maxMembers = data.hasNonNull("max_members") 
+                            ? data.get("max_members").asInt() : null;
+        this.maxVideoChannelUsers = data.hasNonNull("max_video_channel_users") 
+                            ? data.get("max_video_channel_users").asInt() : null;
+        this.premiumProgressBarEnabled = data.path("premium_progress_bar_enabled").asBoolean(false);
+        
         api.addServerToCache(this);
     }
 
@@ -524,11 +577,14 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     /**
      * Sets the system channel flags.
      *
-     * @param value The system channel flag.
+     * @param systemChannelFlag The system channel flag.
      */
-    public void setSystemChannelFlag(int value) {
-        hasJoinMessagesEnabled = (value & (1)) != (1);
-        hasBoostMessagesEnabled = (value & (1 << 1)) != (1 << 1);
+    public void setSystemChannelFlag(int systemChannelFlag) {
+        for (SystemChannelFlag flag : SystemChannelFlag.values()) {
+            if ((flag.asInt() & systemChannelFlag) == flag.asInt()) {
+                systemChannelFlags.add(flag);
+            }
+        }
     }
 
     /**
@@ -1142,16 +1198,6 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     }
 
     @Override
-    public boolean hasBoostMessagesEnabled() {
-        return hasBoostMessagesEnabled;
-    }
-
-    @Override
-    public boolean hasJoinMessagesEnabled() {
-        return hasJoinMessagesEnabled;
-    }
-
-    @Override
     public Set<ServerFeature> getFeatures() {
         return Collections.unmodifiableSet(new HashSet<>(serverFeatures));
     }
@@ -1472,6 +1518,41 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
                 .orElseGet(() ->
                         getRealMemberById(user.getId())
                                 .map(Member::getRoles).orElseGet(Collections::emptyList));
+    }
+
+    @Override
+    public boolean isWidgetEnabled() {
+        return widgetEnabled;
+    }
+
+    @Override
+    public Optional<Long> getWidgetChannelId() {
+        return Optional.ofNullable(widgetChannelId);
+    }
+
+    @Override
+    public Optional<Integer> getMaxPresences() {
+        return Optional.ofNullable(maxPresences);
+    }
+
+    @Override
+    public Optional<Integer> getMaxMembers() {
+        return Optional.ofNullable(maxMembers);
+    }
+
+    @Override
+    public Optional<Integer> getMaxVideoChannelUsers() {
+        return Optional.ofNullable(maxVideoChannelUsers);
+    }
+
+    @Override
+    public Optional<WelcomeScreen> getWelcomeScreen() {
+        return Optional.ofNullable(welcomeScreen);
+    }
+
+    @Override
+    public boolean isPremiumProgressBarEnabled() {
+        return premiumProgressBarEnabled;
     }
 
     @Override
@@ -1961,5 +2042,9 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
     public String toString() {
         return String.format("Server (id: %s, name: %s)", getIdAsString(), getName());
     }
-
+    
+    @Override
+    public EnumSet<SystemChannelFlag> getSystemChannelFlags() {
+        return EnumSet.copyOf(systemChannelFlags);
+    }
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/invite/WelcomeScreenChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/invite/WelcomeScreenChannelImpl.java
@@ -1,0 +1,64 @@
+package org.javacord.core.entity.server.invite;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.entity.server.invite.WelcomeScreenChannel;
+
+import java.util.Optional;
+
+/**
+ * The implementation of {@link WelcomeScreenChannel}.
+ */
+public class WelcomeScreenChannelImpl implements WelcomeScreenChannel {
+
+    /**
+     * The channel's id.
+     */
+    private final long channelId;
+    
+    /**
+     * The description shown for the channel.
+     */
+    private final String description;
+
+    /**
+     * The emoji id, if the emoji is custom.
+     */
+    private final Long emojiId;
+
+    /**
+     * The emoji name if custom, the unicode character if standard, or null if no emoji is set.
+     */
+    private final String emojiName;
+
+    /**
+     * Creates an instance of Welcome Screen Channel Object.
+     * 
+     * @param data JSON data for welcome screen channel.
+     */
+    public WelcomeScreenChannelImpl(JsonNode data) {
+        this.channelId = data.get("channel_id").asLong();
+        this.description = data.get("description").asText();
+        this.emojiId = data.hasNonNull("emoji_id") ? data.get("emoji_id").asLong() : null;
+        this.emojiName = data.hasNonNull("emoji_name") ? data.get("emoji_name").asText() : null;
+    }
+
+    @Override
+    public long getChannelId() {
+        return channelId;
+    }
+    
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public Optional<Long> getEmojiId() {
+        return Optional.ofNullable(emojiId);
+    }
+
+    @Override
+    public Optional<String> getEmojiName() {
+        return Optional.ofNullable(emojiName);
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/invite/WelcomeScreenImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/invite/WelcomeScreenImpl.java
@@ -1,0 +1,49 @@
+package org.javacord.core.entity.server.invite;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.javacord.api.entity.server.invite.WelcomeScreen;
+import org.javacord.api.entity.server.invite.WelcomeScreenChannel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The implementation of {@link WelcomeScreen}.
+ */
+public class WelcomeScreenImpl implements WelcomeScreen {
+
+    /**
+     * The server description shown in the welcome screen.
+     */
+    private final String description;
+
+    /**
+     * The channels shown in the welcome screen, up to 5.
+     */
+    private final List<WelcomeScreenChannel> welcomeScreenChannels = new ArrayList<>();
+
+    /**
+     * Creates a new Welcome Screen Object.
+     *
+     * @param data The json data of the welcome screen.
+     */
+    public WelcomeScreenImpl(JsonNode data) {
+        this.description = data.get("description").asText();
+        for (JsonNode welcomeChannel : data.get("welcome_channels")) {
+            this.welcomeScreenChannels.add(new WelcomeScreenChannelImpl(welcomeChannel));
+        }
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(description);
+    }
+
+    @Override
+    public List<WelcomeScreenChannel> getWelcomeScreenChannels() {
+        return Collections.unmodifiableList(welcomeScreenChannels);
+    }
+}


### PR DESCRIPTION
Update ServerFeature ENUM Class
Add WelcomeScreen and WelcomeScreenChannel
Add Missing fields in ServerImpl
Add Missing System Channel Flags

Issue Link : https://github.com/Javacord/Javacord/issues/1087
Issue Description :

> Missing fields:
> 
> premium_progress_bar_enabled
> welcome_screen
> max_video_channel_users
> max_members
> max_presences
> widget_channel_id
> widget_enabled
>
> ServerFeatures enum is outdated:
> https://discord.com/developers/docs/resources/guild#guild-object-guild-features
> 
> Add missing System Channel Flags
> https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags
> 
> 

### Changes
- Add server welcome screen
- Add support for other missing fields: premium_progress_bar_enabled,  welcome_screen, max_video_channel_users, max_members, max_presences, widget_channel_id, widget_enabled

### Breaking
- SeaverFeature enum has been adjusted to the current existing values
- `hasBoostMessagesEnabled` and `hasJoinMessagesEnabled` have been removed and a new SystemChannelFlags Enum has been introduced