### PR TITLE
Disable signing library when building snapshot version on i.e. JitPack

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,6 +126,11 @@ configure<PublishingExtension> {
         }
 
         signing {
+            val isRequired = releaseVersion && (tasks.withType<PublishToMavenRepository>().find {
+                gradle.taskGraph.hasTask(it)
+            } != null)
+            setRequired(isRequired)
+
             val signingKey = System.getenv("SIGNING_KEY")
             val signingPassword = System.getenv("SIGNING_PASSWORD")
             useInMemoryPgpKeys(signingKey, signingPassword)


### PR DESCRIPTION
In #769 the code was removed to check whether signing is required