### PR TITLE
Fix ThreadListSyncHandler

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/thread/ThreadListSyncHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/thread/ThreadListSyncHandler.java
@@ -3,8 +3,7 @@ package org.javacord.core.util.handler.channel.thread;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
-import org.javacord.api.entity.channel.Channel;
-import org.javacord.api.entity.channel.ChannelType;
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.channel.ServerThreadChannel;
 import org.javacord.api.entity.channel.ThreadMember;
 import org.javacord.api.event.channel.thread.ThreadListSyncEvent;
@@ -42,13 +41,6 @@ public class ThreadListSyncHandler extends PacketHandler {
             return;
         }
 
-        final Set<Long> channelIds = new HashSet<>();
-        if (packet.has("channel_ids")) {
-            for (final JsonNode channelId : packet.get("channel_ids")) {
-                channelIds.add(channelId.asLong());
-            }
-        }
-
         final List<ServerThreadChannel> threads = new ArrayList<>();
         for (final JsonNode thread : packet.get("threads")) {
             threads.add(server.getOrCreateServerThreadChannel(thread));
@@ -59,18 +51,26 @@ public class ThreadListSyncHandler extends PacketHandler {
             threadIds.add(thread.getId());
         }
 
+        final Set<Long> channelIds = new HashSet<>();
+        if (packet.has("channel_ids")) {
+            for (final JsonNode channelId : packet.get("channel_ids")) {
+                channelIds.add(channelId.asLong());
+            }
+
+            server.getThreadChannels().stream()
+                    .filter(stc -> channelIds.contains(stc.getParent().getId()) && !threadIds.contains(stc.getId()))
+                    .map(DiscordEntity::getId)
+                    .forEach(api::removeChannelFromCache);
+        } else {
+            server.getThreadChannels().stream()
+                    .map(DiscordEntity::getId)
+                    .filter(id -> !threadIds.contains(id))
+                    .forEach(api::removeChannelFromCache);
+        }
+
         final Set<ThreadMember> members = new HashSet<>();
         for (final JsonNode member : packet.get("members")) {
             members.add(new ThreadMemberImpl(api, server, member));
-        }
-
-        //Removes lost threads from cache
-        for (final Channel channel : api.getChannels()) {
-            if (channel.getType() == ChannelType.SERVER_PRIVATE_THREAD
-                    || channel.getType() == ChannelType.SERVER_PUBLIC_THREAD
-                    && !threadIds.contains(channel.getId())) {
-                api.removeChannelFromCache(channel.getId());
-            }
         }
 
         final ThreadListSyncEvent event = new ThreadListSyncEventImpl(server, channelIds, threads, members);


### PR DESCRIPTION
Fix ThreadListSyncHandler removing always all thread channels even if they are not synced for the entire server