### PR TITLE
Add the ability to listen for replies to specific messages

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/event/message/MessageReplyEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/message/MessageReplyEvent.java
@@ -1,0 +1,17 @@
+package org.javacord.api.event.message;
+
+import org.javacord.api.entity.message.Message;
+
+/**
+ * A message reply event.
+ */
+public interface MessageReplyEvent extends CertainMessageEvent {
+
+    /**
+     * Gets the message referenced by the message of this event.
+     *
+     * @return The message which was referenced.
+     */
+    Message getReferencedMessage();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/message/MessageReplyListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/message/MessageReplyListener.java
@@ -1,0 +1,25 @@
+package org.javacord.api.listener.message;
+
+import org.javacord.api.event.message.MessageReplyEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.channel.TextChannelAttachableListener;
+import org.javacord.api.listener.server.ServerAttachableListener;
+import org.javacord.api.listener.user.UserAttachableListener;
+import org.javacord.api.listener.webhook.WebhookAttachableListener;
+
+/**
+ * This listener listens to message replies.
+ */
+@FunctionalInterface
+public interface MessageReplyListener extends ServerAttachableListener, UserAttachableListener,
+        WebhookAttachableListener, TextChannelAttachableListener, MessageAttachableListener,
+        GloballyAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called when a message is created which replies to another.
+     *
+     * @param event The event.
+     */
+    void onMessageReply(MessageReplyEvent event);
+}

--- a/javacord-core/src/main/java/org/javacord/core/event/message/MessageReplyEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/message/MessageReplyEventImpl.java
@@ -1,0 +1,29 @@
+package org.javacord.core.event.message;
+
+import org.javacord.api.entity.message.Message;
+import org.javacord.api.event.message.MessageReplyEvent;
+
+/**
+ * The implementation of {@link MessageReplyEvent}.
+ */
+public class MessageReplyEventImpl extends CertainMessageEventImpl implements MessageReplyEvent {
+
+    private final Message referencedMessage;
+
+    /**
+     * Creates a new event instance.
+     *
+     * @param message The created message.
+     * @param referencedMessage The message which is being replied to.
+     */
+    public MessageReplyEventImpl(Message message, Message referencedMessage) {
+        super(message);
+        this.referencedMessage = referencedMessage;
+    }
+
+    @Override
+    public Message getReferencedMessage() {
+        return referencedMessage;
+    }
+
+}


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md).


<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
-->
## Changelog
- Adds message reply listeners (via `Message#addMessageCreateListener`)

### Breaking Changes
N/A

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description

Adds the ability to attach message create listeners to messages, which will be fired when the message receives a reply 

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: #1114

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.