### PR TITLE
Remove okhttp shutdown calls when disconnecting the api

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -1895,8 +1895,6 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
                     disconnectFuture.get().complete(null);
                 }, 1, TimeUnit.MINUTES);
             }
-            httpClient.dispatcher().executorService().shutdown();
-            httpClient.connectionPool().evictAll();
         }
         return disconnectFuture.get();
     }


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md).


<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
-->
## Changelog
- Internal: Remove OkHttp shutdown calls when disconnecting the DiscordApi

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description
Earlier versions of OkHttp used non-daemon threads which forced us to forcefully shutdown the OkHttpClient. In version 4.5.1 OkHttp switched to daemon threads.

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.