### PR TITLE
Remove deprecated methods

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/ApplicationInfo.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/ApplicationInfo.java
@@ -1,10 +1,8 @@
 package org.javacord.api.entity;
 
 import org.javacord.api.entity.team.Team;
-import org.javacord.api.entity.user.User;
 
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Represents the information of an application (aka. bot).
@@ -50,31 +48,6 @@ public interface ApplicationInfo extends Nameable {
     boolean botRequiresCodeGrant();
 
     /**
-     * Gets the name of the application owner.
-     *
-     * <p>If the application is owned by a user, this will be the username. If it
-     * is owned by a team, the return value will be empty.</p>
-     *
-     * @return The name of the application owner, if applicable.
-     * @deprecated This method is deprecated. Access {@link #getOwner()} instead. This method is scheduled for removal.
-     */
-    @Deprecated
-    default Optional<String> getOwnerName() {
-        return getOwner().map(ApplicationOwner::getName);
-    }
-
-    /**
-     * Gets the id of the application owner.
-     *
-     * @return The id of the application owner.
-     * @deprecated This method is deprecated. Access {@link #getOwner()} instead. This method is scheduled for removal.
-     */
-    @Deprecated
-    default Optional<Long> getOwnerId() {
-        return getOwner().isPresent() ? Optional.of(getOwner().get().getId()) : Optional.empty();
-    }
-
-    /**
      * Gets the owner of the Application.
      *
      * <p>An application might be owned by a user or team. If it is not owned
@@ -83,35 +56,6 @@ public interface ApplicationInfo extends Nameable {
      * @return The user owning this application, if applicable.
      */
     Optional<ApplicationOwner> getOwner();
-
-    /**
-     * Gets the discriminator of the application owner.
-     *
-     * <p>The contents of this are undefined if the owner is a team, but will
-     * likely always be "0000"</p>
-     *
-     * @return The discriminator of the application owner, if applicable.
-     * @deprecated This method is deprecated. Access {@link #getOwner()} instead. This method is scheduled for removal.
-     */
-    @Deprecated
-    default Optional<String> getOwnerDiscriminator() {
-        return getOwner().map(ApplicationOwner::getDiscriminator);
-    }
-
-    /**
-     * Requests the owner of the application.
-     *
-     * @return The owner of the application.
-     * @deprecated This method is deprecated. Access {@link #getOwner()} instead. This method is scheduled for removal.
-     */
-    @Deprecated
-    default CompletableFuture<Optional<User>> requestOwner() {
-        if (getOwner().isPresent()) {
-            return getOwner().get().requestUser().thenApply(Optional::of);
-        } else {
-            return CompletableFuture.completedFuture(Optional.empty());
-        }
-    }
 
     /**
      * Gets the team owning the application.

--- a/javacord-api/src/main/java/org/javacord/api/entity/Attachment.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/Attachment.java
@@ -84,41 +84,6 @@ public interface Attachment extends DiscordEntity {
      *
      * @return The attachment as an input stream.
      * @throws IOException If an IO error occurs.
-     * @deprecated Use {@link #asInputStream()} instead.
-     */
-    @Deprecated
-    default InputStream downloadAsInputStream() throws IOException {
-        return asInputStream();
-    }
-
-    /**
-     * Downloads the attachment as a byte array.
-     *
-     * @return The attachment as a byte array.
-     * @deprecated Use {@link #asByteArray()} instead.
-     */
-    @Deprecated
-    default CompletableFuture<byte[]> downloadAsByteArray() {
-        return asByteArray();
-    }
-
-    /**
-     * Downloads the attachment as an image.
-     *
-     * @return The attachment as an image. Only present, if the attachment is an image.
-     * @throws IllegalStateException If the attachment is not an image.
-     * @deprecated Use {@link #asImage()} instead.
-     */
-    @Deprecated
-    default CompletableFuture<BufferedImage> downloadAsImage() {
-        return asImage();
-    }
-
-    /**
-     * Downloads the attachment as an input stream.
-     *
-     * @return The attachment as an input stream.
-     * @throws IOException If an IO error occurs.
      */
     InputStream asInputStream() throws IOException;
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/VoiceChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/VoiceChannel.java
@@ -1,7 +1,5 @@
 package org.javacord.api.entity.channel;
 
-import org.javacord.api.entity.permission.PermissionType;
-import org.javacord.api.entity.user.User;
 import org.javacord.api.listener.channel.VoiceChannelAttachableListenerManager;
 
 import java.util.NoSuchElementException;
@@ -12,70 +10,6 @@ import java.util.concurrent.CompletableFuture;
  * This class represents a voice channel.
  */
 public interface VoiceChannel extends Channel, VoiceChannelAttachableListenerManager {
-
-    /**
-     * Checks if the given user can connect to the voice channel.
-     * In private channels this always returns <code>true</code> if the user is part of the chat.
-     *
-     * @param user The user to check.
-     * @return Whether the given user can connect or not.
-     * @deprecated Use {@link ServerVoiceChannel#canConnect(User)} instead.
-     */
-    @Deprecated
-    default boolean canConnect(User user) {
-        if (!canSee(user)) {
-            return false;
-        }
-        Optional<ServerVoiceChannel> severVoiceChannel = asServerVoiceChannel();
-        return !severVoiceChannel.isPresent()
-                || severVoiceChannel.get().hasAnyPermission(user,
-                PermissionType.ADMINISTRATOR,
-                PermissionType.CONNECT);
-    }
-
-    /**
-     * Checks if the user of the connected account can connect to the voice channel.
-     * In private channels this always returns {@code true} if the user is part of the chat.
-     *
-     * @return Whether the user of the connected account can connect or not.
-     * @deprecated Use {@link ServerVoiceChannel#canYouConnect()} instead.
-     */
-    @Deprecated
-    default boolean canYouConnect() {
-        return canConnect(getApi().getYourself());
-    }
-
-    /**
-     * Checks if the given user can mute other users in this voice channel.
-     * In private channels this always returns <code>false</code>.
-     *
-     * @param user The user to check.
-     * @return Whether the given user can mute other users or not.
-     * @deprecated Use {@link ServerVoiceChannel#canMuteUsers(User)} instead.
-     */
-    @Deprecated
-    default boolean canMuteUsers(User user) {
-        if (!canConnect(user) || getType() == ChannelType.PRIVATE_CHANNEL) {
-            return false;
-        }
-        Optional<ServerVoiceChannel> serverVoiceChannel = asServerVoiceChannel();
-        return !serverVoiceChannel.isPresent()
-                || serverVoiceChannel.get().hasAnyPermission(user,
-                PermissionType.ADMINISTRATOR,
-                PermissionType.MUTE_MEMBERS);
-    }
-
-    /**
-     * Checks if the user of the connected account can mute other users in this voice channel.
-     * In private channels this always returns {@code false}.
-     *
-     * @return Whether the user of the connected account can mute other users or not.
-     * @deprecated Use {@link ServerVoiceChannel#canYouMuteUsers()} instead.
-     */
-    @Deprecated
-    default boolean canYouMuteUsers() {
-        return canMuteUsers(getApi().getYourself());
-    }
 
     @Override
     default Optional<? extends VoiceChannel> getCurrentCachedInstance() {

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageAuthor.java
@@ -531,40 +531,6 @@ public interface MessageAuthor extends DiscordEntity, Nameable {
     }
 
     /**
-     * Checks if the author can connect to the voice channel where the message was sent.
-     * In private channels this always returns {@code true} if the user is part of the chat.
-     * Always returns {@code false} if the author is not a user or if the channel is not a voice channel.
-     *
-     * @return Whether the author can connect to the voice channel or not.
-     * @deprecated Use {@link ServerVoiceChannel#canConnect(User)} instead.
-     */
-    @Deprecated
-    default boolean canConnectToVoiceChannel() {
-        return getMessage()
-            .getChannel()
-            .asVoiceChannel()
-            .flatMap(voiceChannel -> asUser().map(voiceChannel::canConnect))
-            .orElse(false);
-    }
-
-    /**
-     * Checks if the author can mute other users in the voice channel where the message was sent.
-     * In private channels this always returns @{code false}.
-     * Always returns {@code false} if the author is not a user or if the channel is not a voice channel.
-     *
-     * @return Whether the author can mute other users in the voice channel or not.
-     * @deprecated Use {@link ServerVoiceChannel#canMuteUsers(User)} instead.
-     */
-    @Deprecated
-    default boolean canMuteUsersInVoiceChannel() {
-        return getMessage()
-                .getChannel()
-                .asVoiceChannel()
-                .flatMap(voiceChannel -> asUser().map(voiceChannel::canMuteUsers))
-                .orElse(false);
-    }
-
-    /**
      * Checks if the author is allowed to add <b>new</b> reactions to the message.
      * Always returns {@code false} if the author is not a user.
      *

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedAuthor.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedAuthor.java
@@ -41,43 +41,6 @@ public interface EmbedAuthor extends Nameable {
      *
      * @param api The discord api instance used to download the author icon.
      * @return The thumbnail as a {@code BufferedImage}.
-     * @deprecated Use {@link #iconAsBufferedImage(DiscordApi)} instead.
-     */
-    @Deprecated
-    default Optional<CompletableFuture<BufferedImage>> downloadIconAsBufferedImage(DiscordApi api) {
-        return iconAsBufferedImage(api);
-    }
-
-    /**
-     * Downloads the author icon as a byte array.
-     *
-     * @param api The discord api instance used to download the author icon.
-     * @return The thumbnail as a byte array.
-     * @deprecated Use {@link #iconAsByteArray(DiscordApi)} instead.
-     */
-    @Deprecated
-    default Optional<CompletableFuture<byte[]>> downloadIconAsByteArray(DiscordApi api) {
-        return iconAsByteArray(api);
-    }
-
-    /**
-     * Downloads the author icon as an input stream.
-     *
-     * @param api The discord api instance used to download the author icon.
-     * @return The thumbnail as an input stream.
-     * @throws IOException If an IO error occurs.
-     * @deprecated Use {@link #iconAsInputStream(DiscordApi)} instead.
-     */
-    @Deprecated
-    default Optional<InputStream> downloadIconAsInputStream(DiscordApi api) throws IOException {
-        return iconAsInputStream(api);
-    }
-
-    /**
-     * Downloads the author icon as a {@code BufferedImage}.
-     *
-     * @param api The discord api instance used to download the author icon.
-     * @return The thumbnail as a {@code BufferedImage}.
      */
     Optional<CompletableFuture<BufferedImage>> iconAsBufferedImage(DiscordApi api);
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedImage.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedImage.java
@@ -46,43 +46,6 @@ public interface EmbedImage {
      *
      * @param api The discord api instance used to download the image.
      * @return The thumbnail as a {@code BufferedImage}.
-     * @deprecated Use {@link #asBufferedImage(DiscordApi)} instead.
-     */
-    @Deprecated
-    default CompletableFuture<BufferedImage> downloadAsBufferedImage(DiscordApi api) {
-        return asBufferedImage(api);
-    }
-
-    /**
-     * Downloads the image as a byte array.
-     *
-     * @param api The discord api instance used to download the image.
-     * @return The thumbnail as a byte array.
-     * @deprecated Use {@link #asByteArray(DiscordApi)} instead.
-     */
-    @Deprecated
-    default CompletableFuture<byte[]> downloadAsByteArray(DiscordApi api) {
-        return asByteArray(api);
-    }
-
-    /**
-     * Downloads the image as an input stream.
-     *
-     * @param api The discord api instance used to download the image.
-     * @return The thumbnail as an input stream.
-     * @throws IOException If an IO error occurs.
-     * @deprecated Use {@link #asInputStream(DiscordApi)} instead.
-     */
-    @Deprecated
-    default InputStream downloadAsInputStream(DiscordApi api) throws IOException {
-        return asInputStream(api);
-    }
-
-    /**
-     * Downloads the image as a {@code BufferedImage}.
-     *
-     * @param api The discord api instance used to download the image.
-     * @return The thumbnail as a {@code BufferedImage}.
      */
     CompletableFuture<BufferedImage> asBufferedImage(DiscordApi api);
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedThumbnail.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedThumbnail.java
@@ -46,43 +46,6 @@ public interface EmbedThumbnail {
      *
      * @param api The discord api instance used to download the thumbnail.
      * @return The thumbnail as a {@code BufferedImage}.
-     * @deprecated Use {@link #asBufferedImage(DiscordApi)} instead.
-     */
-    @Deprecated
-    default CompletableFuture<BufferedImage> downloadAsBufferedImage(DiscordApi api) {
-        return asBufferedImage(api);
-    }
-
-    /**
-     * Downloads the thumbnail as a byte array.
-     *
-     * @param api The discord api instance used to download the thumbnail.
-     * @return The thumbnail as a byte array.
-     * @deprecated Use {@link #asByteArray(DiscordApi)} instead.
-     */
-    @Deprecated
-    default CompletableFuture<byte[]> downloadAsByteArray(DiscordApi api) {
-        return asByteArray(api);
-    }
-
-    /**
-     * Downloads the thumbnail as an input stream.
-     *
-     * @param api The discord api instance used to download the thumbnail.
-     * @return The thumbnail as an input stream.
-     * @throws IOException If an IO error occurs.
-     * @deprecated Use {@link #asInputStream(DiscordApi)} instead.
-     */
-    @Deprecated
-    default InputStream downloadAsInputStream(DiscordApi api) throws IOException {
-        return asInputStream(api);
-    }
-
-    /**
-     * Downloads the thumbnail as a {@code BufferedImage}.
-     *
-     * @param api The discord api instance used to download the thumbnail.
-     * @return The thumbnail as a {@code BufferedImage}.
      */
     CompletableFuture<BufferedImage> asBufferedImage(DiscordApi api);
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2010,33 +2010,6 @@ public interface Server extends DiscordEntity, Nameable, Deletable, UpdatableFro
     /**
      * Bans the given user from the server.
      *
-     * @param user              The user to ban.
-     * @param deleteMessageDays The number of days to delete messages for (0-7).
-     * @return A future to check if the ban was successful.
-     * @deprecated Use {@link #banUser(User, long, TimeUnit, String)} instead.
-     */
-    @Deprecated
-    default CompletableFuture<Void> banUser(User user, int deleteMessageDays) {
-        return banUser(user.getId(), deleteMessageDays);
-    }
-
-    /**
-     * Bans the given user from the server.
-     *
-     * @param user              The user to ban.
-     * @param deleteMessageDays The number of days to delete messages for (0-7).
-     * @param reason            The reason for the ban.
-     * @return A future to check if the ban was successful.
-     * @deprecated Use {@link #banUser(User, long, TimeUnit, String)} instead.
-     */
-    @Deprecated
-    default CompletableFuture<Void> banUser(User user, int deleteMessageDays, String reason) {
-        return banUser(user.getId(), deleteMessageDays, reason);
-    }
-
-    /**
-     * Bans the given user from the server.
-     *
      * @param user                  The user to ban.
      * @param deleteMessageDuration The number of messages to delete within the duration.
      *                              (Between 0 and 604800 seconds (7 days))
@@ -2107,32 +2080,6 @@ public interface Server extends DiscordEntity, Nameable, Deletable, UpdatableFro
     /**
      * Bans the given user from the server.
      *
-     * @param userId            The id of the user to ban.
-     * @param deleteMessageDays The number of days to delete messages for (0-7).
-     * @return A future to check if the ban was successful.
-     * @deprecated Use {@link #banUser(String, long, TimeUnit)} instead.
-     */
-    @Deprecated
-    default CompletableFuture<Void> banUser(String userId, int deleteMessageDays) {
-        return banUser(userId, deleteMessageDays, TimeUnit.DAYS);
-    }
-
-    /**
-     * Bans the given user from the server.
-     *
-     * @param userId            The id of the user to ban.
-     * @param deleteMessageDays The number of days to delete messages for (0-7).
-     * @return A future to check if the ban was successful.
-     * @deprecated Use {@link #banUser(String, long, TimeUnit)} instead.
-     */
-    @Deprecated
-    default CompletableFuture<Void> banUser(long userId, int deleteMessageDays) {
-        return banUser(Long.toUnsignedString(userId), deleteMessageDays);
-    }
-
-    /**
-     * Bans the given user from the server.
-     *
      * @param userId                The id of the user to ban.
      * @param deleteMessageDuration The number of messages to delete within the duration.
      *                              (Between 0 and 604800 seconds (7 days))
@@ -2176,34 +2123,6 @@ public interface Server extends DiscordEntity, Nameable, Deletable, UpdatableFro
      */
     default CompletableFuture<Void> banUser(long userId, Duration duration) {
         return banUser(Long.toUnsignedString(userId), duration);
-    }
-
-    /**
-     * Bans the given user from the server.
-     *
-     * @param userId            The id of the user to ban.
-     * @param deleteMessageDays The number of days to delete messages for (0-7).
-     * @param reason            The reason for the ban.
-     * @return A future to check if the ban was successful.
-     * @deprecated Use {@link #banUser(String, long, TimeUnit)} instead.
-     */
-    @Deprecated
-    default CompletableFuture<Void> banUser(String userId, int deleteMessageDays, String reason) {
-        return banUser(userId, deleteMessageDays, TimeUnit.DAYS, reason);
-    }
-
-    /**
-     * Bans the given user from the server.
-     *
-     * @param userId            The id of the user to ban.
-     * @param deleteMessageDays The number of days to delete messages for (0-7).
-     * @param reason            The reason for the ban.
-     * @return A future to check if the ban was successful.
-     * @deprecated Use {@link #banUser(String, long, TimeUnit)} instead.
-     */
-    @Deprecated
-    default CompletableFuture<Void> banUser(long userId, int deleteMessageDays, String reason) {
-        return banUser(Long.toUnsignedString(userId), deleteMessageDays, reason);
     }
 
     /**


### PR DESCRIPTION
## Checklist
- [X] I have tested this PR[^1].
- [X] I have read the [contributing guidelines](./CONTRIBUTING.md).


## Changelog
*no functional changes*

### Breaking Changes
Removes methods that have been deprecated in favor of others in prior releases:
 - Obsolete application owner methods
 - Banning server members
 - Renamed `downloadAsXY` methods
 - Methods moved from `VoiceChannel` to `ServerVoiceChannel`


## Description
To be merged after 3.6.0 release

Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.