### PR TITLE
Add support for Select Menus v2

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannel.java
@@ -15,6 +15,11 @@ import java.util.concurrent.CompletableFuture;
 public interface ServerTextChannel extends RegularServerChannel, TextChannel, Mentionable, Categorizable,
         ServerTextChannelAttachableListenerManager {
 
+    @Override
+    default String getMentionTag() {
+        return "<#" + getIdAsString() + ">";
+    }
+
     /**
      * Gets the default auto archive duration for threads that will be created in this channel.
      *

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/component/ComponentType.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/component/ComponentType.java
@@ -1,16 +1,28 @@
 package org.javacord.api.entity.message.component;
 
+import java.util.Arrays;
+
 public enum ComponentType {
-    UNKNOWN(-1),
-    ACTION_ROW(1),
-    BUTTON(2),
-    SELECT_MENU(3),
-    TEXT_INPUT(4);
+    UNKNOWN(-1, false),
+    ACTION_ROW(1, false),
+    BUTTON(2, false),
+    SELECT_MENU_STRING(3, true),
+    TEXT_INPUT(4, false),
+    SELECT_MENU_USER(5, true),
+    SELECT_MENU_ROLE(6, true),
+    SELECT_MENU_MENTIONABLE(7, true),
+    SELECT_MENU_CHANNEL(8, true);
+
+    private static final ComponentType[] selectMenuTypes = Arrays.stream(ComponentType.values())
+            .filter(ComponentType::isSelectMenuType)
+            .toArray(ComponentType[]::new);
 
     private final int value;
+    private final boolean selectMenu;
 
-    ComponentType(int i) {
+    ComponentType(final int i, final boolean selectMenu) {
         this.value = i;
+        this.selectMenu = selectMenu;
     }
 
     /**
@@ -20,6 +32,24 @@ public enum ComponentType {
      */
     public int value() {
         return this.value;
+    }
+
+    /**
+     * Whether this component is a type of select menu.
+     *
+     * @return True if it's a type of select menu.
+     */
+    public boolean isSelectMenuType() {
+        return this.selectMenu;
+    }
+
+    /**
+     * Gets an array with all types that are text channel types.
+     *
+     * @return All types that are text channel types.
+     */
+    public static ComponentType[] getSelectMenuTypes() {
+        return selectMenuTypes;
     }
 
     @Override

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/component/LowLevelComponent.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/component/LowLevelComponent.java
@@ -29,7 +29,7 @@ public interface LowLevelComponent extends Component, Specializable<LowLevelComp
      * @return True if it's of that type.
      */
     default boolean isSelectMenu() {
-        return getType() == ComponentType.SELECT_MENU;
+        return getType().isSelectMenuType();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/component/SelectMenu.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/component/SelectMenu.java
@@ -1,9 +1,18 @@
 package org.javacord.api.entity.message.component;
 
+import org.javacord.api.entity.channel.ChannelType;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
 public interface SelectMenu extends LowLevelComponent {
+
+    /**
+     * Get the channel types of this select menu if it's of type {@link ComponentType#SELECT_MENU_CHANNEL}.
+     *
+     * @return The channel types if this select menu is restricted to any.
+     */
+    EnumSet<ChannelType> getChannelTypes();
 
     /**
      * Get the select menu's placeholder id.
@@ -51,12 +60,13 @@ public interface SelectMenu extends LowLevelComponent {
      * Creates a new select menu with the given values.
      *
      * @param customId The custom ID for the select menu.
-     * @param options The select menu options.
+     * @param options  The select menu options.
      * @return The created select menu.
+     * @deprecated Use {@link SelectMenu#createStringMenu(String, List)} instead.
      */
+    @Deprecated
     static SelectMenu create(String customId, List<SelectMenuOption> options) {
-        return new SelectMenuBuilder()
-                .setCustomId(customId)
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
                 .addOptions(options)
                 .build();
     }
@@ -64,14 +74,15 @@ public interface SelectMenu extends LowLevelComponent {
     /**
      * Creates a new select menu with the given values.
      *
-     * @param customId The custom ID for the select menu.
-     * @param options The select menu options.
+     * @param customId   The custom ID for the select menu.
+     * @param options    The select menu options.
      * @param isDisabled Set if the menu should be disabled.
      * @return The created select menu.
+     * @deprecated Use {@link SelectMenu#createStringMenu(String, List, boolean)} instead.
      */
+    @Deprecated
     static SelectMenu create(String customId, List<SelectMenuOption> options, boolean isDisabled) {
-        return new SelectMenuBuilder()
-                .setCustomId(customId)
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
                 .addOptions(options)
                 .setDisabled(isDisabled)
                 .build();
@@ -80,14 +91,15 @@ public interface SelectMenu extends LowLevelComponent {
     /**
      * Creates a new select menu with the given values.
      *
-     * @param customId The custom ID for the select menu.
+     * @param customId    The custom ID for the select menu.
      * @param placeholder The placeholder for the select menu.
-     * @param options The select menu options.
+     * @param options     The select menu options.
      * @return The created select menu.
+     * @deprecated Use {@link SelectMenu#createStringMenu(String, String, List)} )} instead.
      */
+    @Deprecated
     static SelectMenu create(String customId, String placeholder, List<SelectMenuOption> options) {
-        return new SelectMenuBuilder()
-                .setCustomId(customId)
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
                 .setPlaceholder(placeholder)
                 .addOptions(options)
                 .build();
@@ -96,15 +108,16 @@ public interface SelectMenu extends LowLevelComponent {
     /**
      * Creates a new select menu with the given values.
      *
-     * @param customId The custom ID for the select menu.
+     * @param customId    The custom ID for the select menu.
      * @param placeholder The placeholder for the select menu.
-     * @param options The select menu options.
-     * @param isDisabled Set if the menu should be disabled.
+     * @param options     The select menu options.
+     * @param isDisabled  Set if the menu should be disabled.
      * @return The created select menu.
+     * @deprecated Use {@link SelectMenu#createStringMenu(String, String, List, boolean)} instead.
      */
+    @Deprecated
     static SelectMenu create(String customId, String placeholder, List<SelectMenuOption> options, boolean isDisabled) {
-        return new SelectMenuBuilder()
-                .setCustomId(customId)
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
                 .setPlaceholder(placeholder)
                 .addOptions(options)
                 .setDisabled(isDisabled)
@@ -114,17 +127,18 @@ public interface SelectMenu extends LowLevelComponent {
     /**
      * Creates a new select menu with the given values.
      *
-     * @param customId The custom ID for the select menu.
-     * @param placeholder The placeholder for the select menu
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
      * @param minimumValues The minimum amount of options which must be selected.
      * @param maximumValues The maximum amount of options which can be selected.
-     * @param options The select menu options.
+     * @param options       The select menu options.
      * @return The created select menu.
+     * @deprecated Use {@link SelectMenu#createStringMenu(String, String, int, int, List)} instead.
      */
+    @Deprecated
     static SelectMenu create(String customId, String placeholder, int minimumValues,
                              int maximumValues, List<SelectMenuOption> options) {
-        return new SelectMenuBuilder()
-                .setCustomId(customId)
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
                 .setPlaceholder(placeholder)
                 .setMinimumValues(minimumValues)
                 .setMaximumValues(maximumValues)
@@ -135,22 +149,503 @@ public interface SelectMenu extends LowLevelComponent {
     /**
      * Creates a new select menu with the given values.
      *
-     * @param customId The custom ID for the select menu.
-     * @param placeholder The placeholder for the select menu
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
      * @param minimumValues The minimum amount of options which must be selected.
      * @param maximumValues The maximum amount of options which can be selected.
-     * @param options The select menu options.
-     * @param isDisabled Set if the menu should be disabled.
+     * @param options       The select menu options.
+     * @param isDisabled    Set if the menu should be disabled.
      * @return The created select menu.
+     * @deprecated Use {@link SelectMenu#createStringMenu(String, String, int, int, List, boolean)} instead.
      */
+    @Deprecated
     static SelectMenu create(String customId, String placeholder, int minimumValues,
                              int maximumValues, List<SelectMenuOption> options, boolean isDisabled) {
-        return new SelectMenuBuilder()
-                .setCustomId(customId)
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
                 .setPlaceholder(placeholder)
                 .setMinimumValues(minimumValues)
                 .setMaximumValues(maximumValues)
                 .addOptions(options)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId The custom ID for the select menu.
+     * @param options  The select menu options.
+     * @return The created select menu.
+     */
+    static SelectMenu createStringMenu(String customId, List<SelectMenuOption> options) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
+                .addOptions(options)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId   The custom ID for the select menu.
+     * @param options    The select menu options.
+     * @param isDisabled Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createStringMenu(String customId, List<SelectMenuOption> options, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
+                .addOptions(options)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId    The custom ID for the select menu.
+     * @param placeholder The placeholder for the select menu.
+     * @param options     The select menu options.
+     * @return The created select menu.
+     */
+    static SelectMenu createStringMenu(String customId, String placeholder, List<SelectMenuOption> options) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
+                .setPlaceholder(placeholder)
+                .addOptions(options)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId    The custom ID for the select menu.
+     * @param placeholder The placeholder for the select menu.
+     * @param options     The select menu options.
+     * @param isDisabled  Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createStringMenu(String customId, String placeholder, List<SelectMenuOption> options,
+                                       boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
+                .setPlaceholder(placeholder)
+                .addOptions(options)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
+     * @param minimumValues The minimum amount of options which must be selected.
+     * @param maximumValues The maximum amount of options which can be selected.
+     * @param options       The select menu options.
+     * @return The created select menu.
+     */
+    static SelectMenu createStringMenu(String customId, String placeholder, int minimumValues,
+                                       int maximumValues, List<SelectMenuOption> options) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
+                .setPlaceholder(placeholder)
+                .setMinimumValues(minimumValues)
+                .setMaximumValues(maximumValues)
+                .addOptions(options)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
+     * @param minimumValues The minimum amount of options which must be selected.
+     * @param maximumValues The maximum amount of options which can be selected.
+     * @param options       The select menu options.
+     * @param isDisabled    Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createStringMenu(String customId, String placeholder, int minimumValues,
+                                       int maximumValues, List<SelectMenuOption> options, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_STRING, customId)
+                .setPlaceholder(placeholder)
+                .setMinimumValues(minimumValues)
+                .setMaximumValues(maximumValues)
+                .addOptions(options)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId     The custom ID for the select menu.
+     * @return The created select menu.
+     */
+    static SelectMenu createChannelMenu(String customId) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_CHANNEL, customId).build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId     The custom ID for the select menu.
+     * @param channelTypes The channel types which should be available in the select menu.
+     * @return The created select menu.
+     */
+    static SelectMenu createChannelMenu(String customId, Iterable<ChannelType> channelTypes) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_CHANNEL, customId)
+                .addChannelTypes(channelTypes)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId     The custom ID for the select menu.
+     * @param channelTypes The channel types which should be available in the select menu.
+     * @param isDisabled   Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createChannelMenu(String customId, Iterable<ChannelType> channelTypes, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_CHANNEL, customId)
+                .addChannelTypes(channelTypes)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId     The custom ID for the select menu.
+     * @param placeholder  The placeholder for the select menu.
+     * @param channelTypes The channel types which should be available in the select menu.
+     * @return The created select menu.
+     */
+    static SelectMenu createChannelMenu(String customId, String placeholder, Iterable<ChannelType> channelTypes) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_CHANNEL, customId)
+                .setPlaceholder(placeholder)
+                .addChannelTypes(channelTypes)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId     The custom ID for the select menu.
+     * @param placeholder  The placeholder for the select menu.
+     * @param channelTypes The channel types which should be available in the select menu.
+     * @param isDisabled   Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createChannelMenu(String customId, String placeholder, Iterable<ChannelType> channelTypes,
+                                        boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_CHANNEL, customId)
+                .setPlaceholder(placeholder)
+                .addChannelTypes(channelTypes)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
+     * @param minimumValues The minimum amount of options which must be selected.
+     * @param maximumValues The maximum amount of options which can be selected.
+     * @param channelTypes  The channel types which should be available in the select menu.
+     * @return The created select menu.
+     */
+    static SelectMenu createChannelMenu(String customId, String placeholder, int minimumValues,
+                                        int maximumValues, Iterable<ChannelType> channelTypes) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_CHANNEL, customId)
+                .setPlaceholder(placeholder)
+                .setMinimumValues(minimumValues)
+                .setMaximumValues(maximumValues)
+                .addChannelTypes(channelTypes)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
+     * @param minimumValues The minimum amount of options which must be selected.
+     * @param maximumValues The maximum amount of options which can be selected.
+     * @param channelTypes  The channel types which should be available in the select menu.
+     * @param isDisabled    Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createChannelMenu(String customId, String placeholder, int minimumValues,
+                                        int maximumValues, Iterable<ChannelType> channelTypes, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_CHANNEL, customId)
+                .setPlaceholder(placeholder)
+                .setMinimumValues(minimumValues)
+                .setMaximumValues(maximumValues)
+                .addChannelTypes(channelTypes)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId The custom ID for the select menu.
+     * @return The created select menu.
+     */
+    static SelectMenu createRoleMenu(String customId) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_ROLE, customId).build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId   The custom ID for the select menu.
+     * @param isDisabled Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createRoleMenu(String customId, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_ROLE, customId)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId    The custom ID for the select menu.
+     * @param placeholder The placeholder for the select menu.
+     * @return The created select menu.
+     */
+    static SelectMenu createRoleMenu(String customId, String placeholder) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_ROLE, customId)
+                .setPlaceholder(placeholder)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId    The custom ID for the select menu.
+     * @param placeholder The placeholder for the select menu.
+     * @param isDisabled  Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createRoleMenu(String customId, String placeholder, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_ROLE, customId)
+                .setPlaceholder(placeholder)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
+     * @param minimumValues The minimum amount of options which must be selected.
+     * @param maximumValues The maximum amount of options which can be selected.
+     * @return The created select menu.
+     */
+    static SelectMenu createRoleMenu(String customId, String placeholder, int minimumValues, int maximumValues) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_ROLE, customId)
+                .setPlaceholder(placeholder)
+                .setMinimumValues(minimumValues)
+                .setMaximumValues(maximumValues)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
+     * @param minimumValues The minimum amount of options which must be selected.
+     * @param maximumValues The maximum amount of options which can be selected.
+     * @param isDisabled    Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createRoleMenu(String customId, String placeholder, int minimumValues,
+                                     int maximumValues, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_ROLE, customId)
+                .setPlaceholder(placeholder)
+                .setMinimumValues(minimumValues)
+                .setMaximumValues(maximumValues)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId The custom ID for the select menu.
+     * @return The created select menu.
+     */
+    static SelectMenu createMentionableMenu(String customId) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_MENTIONABLE, customId).build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId   The custom ID for the select menu.
+     * @param isDisabled Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createMentionableMenu(String customId, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_MENTIONABLE, customId)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId    The custom ID for the select menu.
+     * @param placeholder The placeholder for the select menu.
+     * @return The created select menu.
+     */
+    static SelectMenu createMentionableMenu(String customId, String placeholder) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_MENTIONABLE, customId)
+                .setPlaceholder(placeholder)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId    The custom ID for the select menu.
+     * @param placeholder The placeholder for the select menu.
+     * @param isDisabled  Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createMentionableMenu(String customId, String placeholder, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_MENTIONABLE, customId)
+                .setPlaceholder(placeholder)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
+     * @param minimumValues The minimum amount of options which must be selected.
+     * @param maximumValues The maximum amount of options which can be selected.
+     * @return The created select menu.
+     */
+    static SelectMenu createMentionableMenu(String customId, String placeholder, int minimumValues, int maximumValues) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_MENTIONABLE, customId)
+                .setPlaceholder(placeholder)
+                .setMinimumValues(minimumValues)
+                .setMaximumValues(maximumValues)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
+     * @param minimumValues The minimum amount of options which must be selected.
+     * @param maximumValues The maximum amount of options which can be selected.
+     * @param isDisabled    Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createMentionableMenu(String customId, String placeholder, int minimumValues,
+                                     int maximumValues, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_MENTIONABLE, customId)
+                .setPlaceholder(placeholder)
+                .setMinimumValues(minimumValues)
+                .setMaximumValues(maximumValues)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId The custom ID for the select menu.
+     * @return The created select menu.
+     */
+    static SelectMenu createUserMenu(String customId) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_USER, customId).build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId   The custom ID for the select menu.
+     * @param isDisabled Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createUserMenu(String customId, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_USER, customId)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId    The custom ID for the select menu.
+     * @param placeholder The placeholder for the select menu.
+     * @return The created select menu.
+     */
+    static SelectMenu createUserMenu(String customId, String placeholder) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_USER, customId)
+                .setPlaceholder(placeholder)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId    The custom ID for the select menu.
+     * @param placeholder The placeholder for the select menu.
+     * @param isDisabled  Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createUserMenu(String customId, String placeholder, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_USER, customId)
+                .setPlaceholder(placeholder)
+                .setDisabled(isDisabled)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
+     * @param minimumValues The minimum amount of options which must be selected.
+     * @param maximumValues The maximum amount of options which can be selected.
+     * @return The created select menu.
+     */
+    static SelectMenu createUserMenu(String customId, String placeholder, int minimumValues, int maximumValues) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_USER, customId)
+                .setPlaceholder(placeholder)
+                .setMinimumValues(minimumValues)
+                .setMaximumValues(maximumValues)
+                .build();
+    }
+
+    /**
+     * Creates a new select menu with the given values.
+     *
+     * @param customId      The custom ID for the select menu.
+     * @param placeholder   The placeholder for the select menu
+     * @param minimumValues The minimum amount of options which must be selected.
+     * @param maximumValues The maximum amount of options which can be selected.
+     * @param isDisabled    Set if the menu should be disabled.
+     * @return The created select menu.
+     */
+    static SelectMenu createUserMenu(String customId, String placeholder, int minimumValues,
+                                            int maximumValues, boolean isDisabled) {
+        return new SelectMenuBuilder(ComponentType.SELECT_MENU_USER, customId)
+                .setPlaceholder(placeholder)
+                .setMinimumValues(minimumValues)
+                .setMaximumValues(maximumValues)
                 .setDisabled(isDisabled)
                 .build();
     }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/component/SelectMenuBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/component/SelectMenuBuilder.java
@@ -1,8 +1,8 @@
 package org.javacord.api.entity.message.component;
 
+import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.api.entity.message.component.internal.SelectMenuBuilderDelegate;
 import org.javacord.api.util.internal.DelegateFactory;
-
 import java.util.List;
 
 public class SelectMenuBuilder implements LowLevelComponentBuilder {
@@ -16,6 +16,24 @@ public class SelectMenuBuilder implements LowLevelComponentBuilder {
     @Override
     public SelectMenuBuilderDelegate getDelegate() {
         return delegate;
+    }
+
+    /**
+     * Create a new SelectMenuBuilder.
+     *
+     * @param type     The type of SelectMenu to create.
+     * @param customId The custom id of the SelectMenu.
+     */
+    public SelectMenuBuilder(ComponentType type, String customId) {
+        if (!type.isSelectMenuType()) {
+            throw new IllegalArgumentException("Invalid SelectMenu type.");
+        }
+        delegate.setType(type);
+        delegate.setCustomId(customId);
+    }
+
+    private SelectMenuBuilder() {
+
     }
 
     /**
@@ -63,7 +81,35 @@ public class SelectMenuBuilder implements LowLevelComponentBuilder {
     }
 
     /**
+     * Add a channel type to the select menu.
+     * 
+     * <p>Only usable with {@link ComponentType#SELECT_MENU_CHANNEL}.
+     *
+     * @param channelType The channel type to add.
+     * @return The builder.
+     */
+    public SelectMenuBuilder addChannelType(ChannelType channelType) {
+        delegate.addChannelType(channelType);
+        return this;
+    }
+
+    /**
+     * Adds all given channel types to the select menu.
+     * 
+     * <p>Only usable with {@link ComponentType#SELECT_MENU_CHANNEL}.
+     *
+     * @param channelTypes The channel types to add.
+     * @return The builder.
+     */
+    public SelectMenuBuilder addChannelTypes(Iterable<ChannelType> channelTypes) {
+        channelTypes.forEach(delegate::addChannelType);
+        return this;
+    }
+
+    /**
      * Add an option to the select menu.
+     * 
+     * <p>Only usable with {@link ComponentType#SELECT_MENU_STRING}.
      *
      * @param selectMenuOption The option.
      * @return The builder.
@@ -75,6 +121,8 @@ public class SelectMenuBuilder implements LowLevelComponentBuilder {
 
     /**
      * Remove an option from the select menu.
+     * 
+     * <p>Only usable with {@link ComponentType#SELECT_MENU_STRING}.
      *
      * @param selectMenuOption The option.
      * @return The builder.
@@ -86,6 +134,8 @@ public class SelectMenuBuilder implements LowLevelComponentBuilder {
 
     /**
      * Adds all given options to the select menu.
+     * 
+     * <p>Only usable with {@link ComponentType#SELECT_MENU_STRING}.
      *
      * @param selectMenuOptions The options.
      * @return The builder.
@@ -97,6 +147,8 @@ public class SelectMenuBuilder implements LowLevelComponentBuilder {
 
     /**
      * Removes all options from the select menu.
+     * 
+     * <p>Only usable with {@link ComponentType#SELECT_MENU_STRING}.
      *
      * @return The builder.
      */

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/component/internal/SelectMenuBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/component/internal/SelectMenuBuilderDelegate.java
@@ -1,5 +1,6 @@
 package org.javacord.api.entity.message.component.internal;
 
+import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.api.entity.message.component.ComponentType;
 import org.javacord.api.entity.message.component.SelectMenu;
 import org.javacord.api.entity.message.component.SelectMenuOption;
@@ -9,9 +10,16 @@ public interface SelectMenuBuilderDelegate extends ComponentBuilderDelegate {
     /**
      * Get the select menu's type.
      *
-     * @return Always {@link ComponentType#SELECT_MENU}
+     * @return The specific type of the select menu.
      */
     ComponentType getType();
+
+    /**
+     * Sets the type of this select menu.
+     *
+     * @param type The type of the select menu.
+     */
+    void setType(ComponentType type);
 
     /**
      * Copy a select menu's values into the builder.
@@ -20,6 +28,12 @@ public interface SelectMenuBuilderDelegate extends ComponentBuilderDelegate {
      */
     void copy(SelectMenu selectMenu);
 
+    /**
+     * Add a channel type to the select menu.
+     *
+     * @param channelType The channel type to add.
+     */
+    void addChannelType(ChannelType channelType);
 
     /**
      * Add an option to the select menu.
@@ -30,7 +44,7 @@ public interface SelectMenuBuilderDelegate extends ComponentBuilderDelegate {
 
     /**
      * Remove an option from the select menu.
-     * 
+     *
      * @param selectMenuOption The option to remove.
      */
     void removeOption(SelectMenuOption selectMenuOption);

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SelectMenuInteraction.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SelectMenuInteraction.java
@@ -1,6 +1,11 @@
 package org.javacord.api.interaction;
 
+import org.javacord.api.entity.Mentionable;
+import org.javacord.api.entity.channel.ServerChannel;
+import org.javacord.api.entity.message.component.ComponentType;
 import org.javacord.api.entity.message.component.SelectMenuOption;
+import org.javacord.api.entity.permission.Role;
+import org.javacord.api.entity.user.User;
 
 import java.util.List;
 import java.util.Optional;
@@ -8,7 +13,41 @@ import java.util.Optional;
 public interface SelectMenuInteraction extends MessageComponentInteraction {
 
     /**
+     * Gets the selected roles.
+     * Only available if the select menu is of type {@link ComponentType#SELECT_MENU_ROLE}.
+     *
+     * @return The selected roles.
+     */
+    List<Role> getSelectedRoles();
+
+    /**
+     * Gets the selected users.
+     * Only available if the select menu is of type {@link ComponentType#SELECT_MENU_USER}.
+     *
+     * @return The selected users.
+     */
+    List<User> getSelectedUsers();
+
+    /**
+     * Gets the selected channels.
+     * Only available if the select menu is of type {@link ComponentType#SELECT_MENU_CHANNEL}.
+     * If sent in a DM channel, this will always be empty.
+     *
+     * @return The selected channels.
+     */
+    List<ServerChannel> getSelectedChannels();
+
+    /**
+     * Gets the selected mentionables.
+     * Only available if the select menu is of type {@link ComponentType#SELECT_MENU_MENTIONABLE}.
+     *
+     * @return The selected mentionables.
+     */
+    List<Mentionable> getSelectedMentionables();
+
+    /**
      * Get the options the user was chosen.
+     * Only available when using a select menu of type {@link ComponentType#SELECT_MENU_STRING}.
      *
      * @return The options.
      */
@@ -16,6 +55,7 @@ public interface SelectMenuInteraction extends MessageComponentInteraction {
 
     /**
      * Get all options from the select menu.
+     * Only available when using a select menu of type {@link ComponentType#SELECT_MENU_STRING}.
      *
      * @return All options.
      */

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelImpl.java
@@ -205,11 +205,6 @@ public class ServerTextChannelImpl extends RegularServerChannelImpl
     }
 
     @Override
-    public String getMentionTag() {
-        return "<#" + getIdAsString() + ">";
-    }
-
-    @Override
     public void cleanup() {
         messageCache.cleanup();
     }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/component/internal/ActionRowBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/component/internal/ActionRowBuilderDelegateImpl.java
@@ -29,9 +29,10 @@ public class ActionRowBuilderDelegateImpl implements ActionRowBuilderDelegate {
                 ButtonBuilder builder = new ButtonBuilder();
                 builder.copy((Button) component);
                 components.add(builder.build());
-            } else if (component.getType() == ComponentType.SELECT_MENU) {
-                SelectMenuBuilder builder = new SelectMenuBuilder();
-                builder.copy((SelectMenu) component);
+            } else if (component.getType().isSelectMenuType()) {
+                SelectMenu sm = (SelectMenu) component;
+                SelectMenuBuilder builder = new SelectMenuBuilder(sm.getType(), sm.getCustomId());
+                builder.copy(sm);
                 components.add(builder.build());
             }
         });
@@ -53,7 +54,7 @@ public class ActionRowBuilderDelegateImpl implements ActionRowBuilderDelegate {
             if (componentBuilder.getType() == ComponentType.BUTTON) {
                 ButtonBuilder buttonBuilder = (ButtonBuilder) componentBuilder;
                 return buttonBuilder.getDelegate().getCustomId().equals(customId);
-            } else if (componentBuilder.getType() == ComponentType.SELECT_MENU) {
+            } else if (componentBuilder.getType().isSelectMenuType()) {
                 SelectMenuBuilder selectMenuBuilder = (SelectMenuBuilder) componentBuilder;
                 return selectMenuBuilder.getDelegate().getCustomId().equals(customId);
             }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/component/internal/SelectMenuBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/component/internal/SelectMenuBuilderDelegateImpl.java
@@ -1,5 +1,6 @@
 package org.javacord.core.entity.message.component.internal;
 
+import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.api.entity.message.component.ComponentType;
 import org.javacord.api.entity.message.component.SelectMenu;
 import org.javacord.api.entity.message.component.SelectMenuOption;
@@ -7,13 +8,16 @@ import org.javacord.api.entity.message.component.internal.SelectMenuBuilderDeleg
 import org.javacord.core.entity.message.component.SelectMenuImpl;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
 public class SelectMenuBuilderDelegateImpl implements SelectMenuBuilderDelegate {
-    private final ComponentType type = ComponentType.SELECT_MENU;
+    private ComponentType type = null;
 
     private List<SelectMenuOption> options = new ArrayList<>();
+
+    private EnumSet<ChannelType> channelTypes = EnumSet.noneOf(ChannelType.class);
 
     private String placeholder = null;
 
@@ -31,6 +35,11 @@ public class SelectMenuBuilderDelegateImpl implements SelectMenuBuilderDelegate 
     }
 
     @Override
+    public void setType(ComponentType type) {
+        this.type = type;
+    }
+
+    @Override
     public void copy(SelectMenu selectMenu) {
         Optional<String> placeholder = selectMenu.getPlaceholder();
         this.customId = selectMenu.getCustomId();
@@ -38,8 +47,15 @@ public class SelectMenuBuilderDelegateImpl implements SelectMenuBuilderDelegate 
         this.maximumValues = selectMenu.getMaximumValues();
         this.isDisabled = selectMenu.isDisabled();
         this.options = selectMenu.getOptions();
+        this.channelTypes = selectMenu.getChannelTypes();
+        this.type = selectMenu.getType();
 
         placeholder.ifPresent(this::setPlaceholder);
+    }
+
+    @Override
+    public void addChannelType(ChannelType channelType) {
+        channelTypes.add(channelType);
     }
 
     @Override
@@ -79,7 +95,8 @@ public class SelectMenuBuilderDelegateImpl implements SelectMenuBuilderDelegate 
 
     @Override
     public SelectMenu build() {
-        return new SelectMenuImpl(options, placeholder, customId, minimumValues, maximumValues, isDisabled);
+        return new SelectMenuImpl(type, options, placeholder, customId, minimumValues, maximumValues, isDisabled,
+                channelTypes);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SelectMenuInteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SelectMenuInteractionImpl.java
@@ -1,24 +1,40 @@
 package org.javacord.core.interaction;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.logging.log4j.Logger;
+import org.javacord.api.entity.Mentionable;
+import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.component.ComponentType;
 import org.javacord.api.entity.message.component.SelectMenuOption;
+import org.javacord.api.entity.permission.Role;
+import org.javacord.api.entity.user.User;
 import org.javacord.api.interaction.SelectMenuInteraction;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.entity.message.component.SelectMenuOptionImpl;
-
+import org.javacord.core.entity.server.ServerImpl;
+import org.javacord.core.entity.user.MemberImpl;
+import org.javacord.core.entity.user.UserImpl;
+import org.javacord.core.util.logging.LoggerUtil;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class SelectMenuInteractionImpl extends MessageComponentInteractionImpl implements SelectMenuInteraction {
+
+    private static final Logger logger = LoggerUtil.getLogger(SelectMenuInteractionImpl.class);
     private final List<SelectMenuOption> selectMenuOptions = new ArrayList<>();
     private final List<SelectMenuOption> chosenSelectMenuOption = new ArrayList<>();
+    private final List<ServerChannel> selectMenuChannels = new ArrayList<>();
+    private final List<User> selectMenuUsers = new ArrayList<>();
+    private final List<Role> selectMenuRoles = new ArrayList<>();
+    private final List<Mentionable> selectMenuMentionables = new ArrayList<>();
     private String placeholder;
     private int minimumValues;
     private int maximumValues;
+    private final ComponentType componentType;
 
     /**
      * Class constructor.
@@ -30,20 +46,23 @@ public class SelectMenuInteractionImpl extends MessageComponentInteractionImpl i
     public SelectMenuInteractionImpl(DiscordApiImpl api, TextChannel channel, JsonNode jsonData) {
         super(api, channel, jsonData);
 
+        this.componentType = ComponentType.fromId(jsonData.get("data").get("component_type").asInt());
+
         JsonNode messageObject = jsonData.get("message");
         JsonNode componentsObject = messageObject.get("components");
 
         JsonNode dataObject = jsonData.get("data");
-
         for (JsonNode actionRow : componentsObject) {
             for (JsonNode interaction : actionRow.get("components")) {
-                if (ComponentType.fromId(interaction.get("type").asInt()) == ComponentType.SELECT_MENU
+                if (componentType.isSelectMenuType()
                         && interaction.get("custom_id").asText().equals(dataObject.get("custom_id").asText())) {
                     placeholder = interaction.has("placeholder") ? interaction.get("placeholder").asText() : null;
                     maximumValues = interaction.has("max_value") ? interaction.get("max_value").asInt() : 1;
                     minimumValues = interaction.has("min_value") ? interaction.get("min_values").asInt() : 1;
-                    for (JsonNode optionObject : interaction.get("options")) {
-                        selectMenuOptions.add(new SelectMenuOptionImpl(optionObject));
+                    if (interaction.hasNonNull("options")) {
+                        for (JsonNode optionObject : interaction.get("options")) {
+                            selectMenuOptions.add(new SelectMenuOptionImpl(optionObject));
+                        }
                     }
                 }
             }
@@ -51,16 +70,106 @@ public class SelectMenuInteractionImpl extends MessageComponentInteractionImpl i
 
         JsonNode valuesArray = dataObject.get("values");
 
-        for (JsonNode jsonNode : valuesArray) {
-            chosenSelectMenuOption.addAll(selectMenuOptions.stream()
-                    .filter(option -> option.getValue().equals(jsonNode.asText())).collect(Collectors.toList()));
+        switch (componentType) {
+            case SELECT_MENU_CHANNEL:
+                selectMenuChannels.addAll(getSelectMenuChannels(valuesArray));
+                break;
+            case SELECT_MENU_ROLE:
+                selectMenuRoles.addAll(getSelectMenuRoles(valuesArray));
+                break;
+            case SELECT_MENU_USER:
+                selectMenuUsers.addAll(getSelectMenuUsers(dataObject));
+                break;
+            case SELECT_MENU_MENTIONABLE:
+                selectMenuMentionables.addAll(getSelectMenuRoles(valuesArray));
+                selectMenuMentionables.addAll(getSelectMenuUsers(dataObject));
+                break;
+            case SELECT_MENU_STRING:
+                for (JsonNode jsonNode : valuesArray) {
+                    chosenSelectMenuOption.addAll(selectMenuOptions.stream()
+                            .filter(option -> option.getValue().equals(jsonNode.asText()))
+                            .collect(Collectors.toList()));
+                }
+                break;
+            default:
+                logger.warn("Creating a SelectMenuInteractionImpl with an unhandled Select Menu component"
+                        + " type which is most likely not wanted!");
+                break;
+        }
+    }
+
+    private List<User> getSelectMenuUsers(JsonNode dataObject) {
+        List<User> usersList = new ArrayList<>();
+        JsonNode valuesArray = dataObject.get("values");
+        JsonNode resolved = dataObject.get("resolved");
+        JsonNode users = resolved.get("users");
+        JsonNode members = resolved.get("members");
+
+        for (JsonNode value : valuesArray) {
+            final long id = value.asLong();
+            Optional<User> optionalMember = getServer().flatMap(server -> server.getMemberById(id));
+            Optional<User> optionalUser = getApi().getCachedUserById(id);
+
+            if (optionalMember.isPresent()) {
+                usersList.add(optionalMember.orElseThrow(AssertionError::new));
+            } else if (optionalUser.isPresent()) {
+                usersList.add(optionalUser.orElseThrow(AssertionError::new));
+            } else if (members.has(value.asText())) {
+                getServer().ifPresent(server -> {
+                    usersList.add(new UserImpl(((DiscordApiImpl) getApi()), users.get(value.asText()),
+                            members.get(value.asText()),
+                            (ServerImpl) server));
+                });
+            } else if (users.has(value.asText())) {
+                usersList.add(new UserImpl(((DiscordApiImpl) getApi()),
+                        users.get(value.asText()), (MemberImpl) null, null));
+            }
         }
 
+        return usersList;
+    }
+
+    private List<ServerChannel> getSelectMenuChannels(JsonNode valuesArray) {
+        List<ServerChannel> channels = new ArrayList<>();
+        for (JsonNode jsonNode : valuesArray) {
+            getServer().flatMap(server -> server.getChannelById(jsonNode.asLong()))
+                    .ifPresent(channels::add);
+        }
+        return channels;
+    }
+
+    private List<Role> getSelectMenuRoles(JsonNode valuesArray) {
+        List<Role> roles = new ArrayList<>();
+        for (JsonNode jsonNode : valuesArray) {
+            getServer().flatMap(server -> server.getRoleById(jsonNode.asLong()))
+                    .ifPresent(roles::add);
+        }
+        return roles;
     }
 
     @Override
     public ComponentType getComponentType() {
-        return ComponentType.SELECT_MENU;
+        return componentType;
+    }
+
+    @Override
+    public List<Role> getSelectedRoles() {
+        return Collections.unmodifiableList(selectMenuRoles);
+    }
+
+    @Override
+    public List<User> getSelectedUsers() {
+        return Collections.unmodifiableList(selectMenuUsers);
+    }
+
+    @Override
+    public List<ServerChannel> getSelectedChannels() {
+        return Collections.unmodifiableList(selectMenuChannels);
+    }
+
+    @Override
+    public List<Mentionable> getSelectedMentionables() {
+        return Collections.unmodifiableList(selectMenuMentionables);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/interaction/InteractionCreateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/interaction/InteractionCreateHandler.java
@@ -98,23 +98,17 @@ public class InteractionCreateHandler extends PacketHandler {
                 }
                 break;
             case MESSAGE_COMPONENT:
-                int componentTypeId = packet.get("data").get("component_type").asInt();
+                final int componentTypeId = packet.get("data").get("component_type").asInt();
                 componentType = ComponentType.fromId(componentTypeId);
-                switch (componentType) {
-                    case BUTTON:
-                        interaction = new ButtonInteractionImpl(api, channel, packet);
-                        break;
-                    case ACTION_ROW:
-                        logger.warn("Received a message component interaction of type ACTION_ROW. This should not"
-                                + " be possible.");
-                        return;
-                    case SELECT_MENU:
-                        interaction = new SelectMenuInteractionImpl(api, channel, packet);
-                        break;
-                    default:
-                        logger.warn("Received message component interaction of unknown type <{}>. "
-                                + "Please contact the developer!", componentTypeId);
-                        return;
+
+                if (componentType == ComponentType.BUTTON) {
+                    interaction = new ButtonInteractionImpl(api, channel, packet);
+                } else if (componentType.isSelectMenuType()) {
+                    interaction = new SelectMenuInteractionImpl(api, channel, packet);
+                } else {
+                    logger.warn("Received message component interaction of unknown type <{}>. "
+                            + "Please contact the developer!", componentTypeId);
+                    return;
                 }
                 break;
             case APPLICATION_COMMAND_AUTOCOMPLETE:
@@ -195,29 +189,25 @@ public class InteractionCreateHandler extends PacketHandler {
                         interaction.getChannel().orElse(null),
                         interaction.getUser(),
                         messageComponentCreateEvent);
-                switch (componentType) {
-                    case BUTTON:
-                        ButtonClickEvent buttonClickEvent = new ButtonClickEventImpl(interaction);
-                        api.getEventDispatcher().dispatchButtonClickEvent(
-                                server == null ? api : server,
-                                messageId,
-                                server,
-                                interaction.getChannel().orElse(null),
-                                interaction.getUser(),
-                                buttonClickEvent);
-                        break;
-                    case SELECT_MENU:
-                        SelectMenuChooseEvent selectMenuChooseEvent = new SelectMenuChooseEventImpl(interaction);
-                        api.getEventDispatcher().dispatchSelectMenuChooseEvent(
-                                server == null ? api : server,
-                                messageId,
-                                server,
-                                interaction.getChannel().orElse(null),
-                                interaction.getUser(),
-                                selectMenuChooseEvent);
-                        break;
-                    default:
-                        break;
+
+                if (componentType == ComponentType.BUTTON) {
+                    ButtonClickEvent buttonClickEvent = new ButtonClickEventImpl(interaction);
+                    api.getEventDispatcher().dispatchButtonClickEvent(
+                            server == null ? api : server,
+                            messageId,
+                            server,
+                            interaction.getChannel().orElse(null),
+                            interaction.getUser(),
+                            buttonClickEvent);
+                } else if (componentType.isSelectMenuType()) {
+                    SelectMenuChooseEvent selectMenuChooseEvent = new SelectMenuChooseEventImpl(interaction);
+                    api.getEventDispatcher().dispatchSelectMenuChooseEvent(
+                            server == null ? api : server,
+                            messageId,
+                            server,
+                            interaction.getChannel().orElse(null),
+                            interaction.getUser(),
+                            selectMenuChooseEvent);
                 }
                 break;
             case APPLICATION_COMMAND_AUTOCOMPLETE:


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md).


<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
-->
## Changelog
- Add support for select menus v2
- Deprecated SelectMenu#create methods in favor of #createStringMenu

### Breaking Changes
- SelectMenuBuilder now requires a SELECT_MENU_* component type and a custom_id to be instantiated.

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description
Add support for the various new select menu types (channel, role, user, mentionable)

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: #1149

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.