### PR TITLE
Changes to SlashCommand#getFullCommandName and getMentionTag

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommand.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommand.java
@@ -12,17 +12,32 @@ import java.util.stream.Collectors;
 
 public interface SlashCommand extends ApplicationCommand, Mentionable {
 
+    /**
+     * Gets the mention tag of this slash command with its base name.
+     *
+     * @return The mention tag of this slash command.
+     */
     @Override
     default String getMentionTag() {
-        return "</" + getFullCommandName() + ":" + getId() + ">";
+        return "</" + getName() + ":" + getId() + ">";
     }
 
     /**
-     * Gets the full command name.
+     * Gets all mention tags of this slash command taking the groups and subcommands into account.
      *
-     * @return The full command name.
+     * @return All mention tags of this slash command.
      */
-    String getFullCommandName();
+    default List<String> getMentionTags() {
+        return getFullCommandNames().stream().map(name -> "</" + name + ":" + getId() + ">")
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets the full command names.
+     *
+     * @return All command names for this slash command.
+     */
+    List<String> getFullCommandNames();
 
     /**
      * Gets all options (i.e., parameters) for this command.

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandImpl.java
@@ -17,7 +17,7 @@ public class SlashCommandImpl extends ApplicationCommandImpl implements SlashCom
     /**
      * Class constructor.
      *
-     * @param api The api instance.
+     * @param api  The api instance.
      * @param data The JSON data.
      */
     public SlashCommandImpl(DiscordApiImpl api, JsonNode data) {
@@ -36,16 +36,26 @@ public class SlashCommandImpl extends ApplicationCommandImpl implements SlashCom
     }
 
     @Override
-    public String getFullCommandName() {
-        return getName() + getNestedCommandNamesRecursive(getOptions());
+    public List<String> getFullCommandNames() {
+        final List<String> names = new ArrayList<>();
+        getNestedCommandNamesRecursive(getName(), getOptions(), names);
+        return names;
     }
 
-    private String getNestedCommandNamesRecursive(List<SlashCommandOption> options) {
-        if (!options.isEmpty() && options.get(0).isSubcommandOrGroup()) {
-            return " " + options.get(0).getName() + getNestedCommandNamesRecursive(options.get(0).getOptions());
+    private void getNestedCommandNamesRecursive(final String preName, final List<SlashCommandOption> options,
+                                                final List<String> names) {
+        if (options.isEmpty()) {
+            names.add(preName);
         } else {
-            return "";
+            for (final SlashCommandOption option : options) {
+                if (option.isSubcommandOrGroup()) {
+                    getNestedCommandNamesRecursive(preName + " " + option.getName(), option.getOptions(), names);
+                } else {
+                    names.add(preName);
+                }
+            }
         }
+
     }
 
     @Override


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
-->
## Changelog
- Added `SlashCommand#getMentionTags` to get all mention tags of all subcommands

### Breaking Changes
- `SlashCommand#getMentionTag` now returns the mention tag with only the base command
- Renamed `SlashCommand#getFullCommandName` to `#getFullCommandNames` and changed return type to `List<String>`

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description
The methods were not suited for `SlashCommand` but only the `SlashCommandInteraction` where the options contain only the invoked command instead of all possible options.

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.