### PR TITLE
Change how the delete_message_seconds field is set when banning a user

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1667,7 +1667,8 @@ public class ServerImpl implements Server, Cleanupable, InternalServerAttachable
         RestRequest<Void> request = new RestRequest<Void>(getApi(), RestMethod.PUT, RestEndpoint.BAN)
                 .setUrlParameters(getIdAsString(), userId);
         if (deleteMessageDuration > 0) {
-            request.addQueryParameter("delete_message_seconds", String.valueOf(unit.toSeconds(deleteMessageDuration)));
+            request.setBody(JsonNodeFactory.instance.objectNode()
+                    .put("delete_message_seconds", unit.toSeconds(deleteMessageDuration)));
         }
 
         if (reason != null) {


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md).


<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
-->
## Changelog
- Change how the delete_message_seconds field is set when banning a user from as query parameter to the request json body

This means that setting a delete message duration will now work

### Breaking Changes


<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description


<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.