### PR TITLE
Rename SlashCommandInteractionOptionsProvider methods

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
     `java-library`
     `maven-publish`
     signing
-    id("com.github.johnrengelman.shadow") version "2.0.4" apply false
-    id("net.researchgate.release") version "2.7.0" apply false
+    id("com.github.johnrengelman.shadow") version "7.1.2" apply false
+    id("net.researchgate.release") version "3.0.2" apply false
 }
 
 repositories {

--- a/javacord-api/build.gradle.kts
+++ b/javacord-api/build.gradle.kts
@@ -2,8 +2,8 @@ import java.time.Instant
 
 plugins {
     `java-library`
-    id("com.gorylenko.gradle-git-properties") version "2.4.0"
-    id("biz.aQute.bnd.builder") version "6.2.0"
+    id("com.gorylenko.gradle-git-properties") version "2.4.1"
+    id("biz.aQute.bnd.builder") version "6.3.1"
 }
 
 repositories {

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteraction.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteraction.java
@@ -1,18 +1,6 @@
 package org.javacord.api.interaction;
 
-import java.util.List;
-
 public interface SlashCommandInteraction extends ApplicationCommandInteraction, SlashCommandInteractionOptionsProvider {
-
-    /**
-     * Gets the arguments of this slash command if there are any.
-     *
-     * <p>This is a shorthand method to avoid checking for Subcommmands or SubcommandGroups
-     * to get the slash command arguments.
-     *
-     * @return The argument options.
-     */
-    List<SlashCommandInteractionOption> getArguments();
 
     /**
      * Gets the full command name of this slash command including the name of the Subcommand and SubcommandGroup.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteractionOptionsProvider.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/SlashCommandInteractionOptionsProvider.java
@@ -24,6 +24,16 @@ public interface SlashCommandInteractionOptionsProvider {
     List<SlashCommandInteractionOption> getOptions();
 
     /**
+     * Gets the arguments of this slash command if there are any.
+     *
+     * <p>This is a shorthand method to avoid checking for Subcommmands or SubcommandGroups
+     * to get the slash command arguments.
+     *
+     * @return The argument options.
+     */
+    List<SlashCommandInteractionOption> getArguments();
+
+    /**
      * Get an option having the specified name.
      *
      * @param name The name of the option to search for.
@@ -37,129 +47,143 @@ public interface SlashCommandInteractionOptionsProvider {
     }
 
     /**
-     * Gets the string representation value of an option having the specified name.
+     * Get an argument having the specified name.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return The argument with the specified name, if found; an empty Optional otherwise
      */
-    default Optional<String> getOptionStringRepresentationValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getStringRepresentationValue);
+    default Optional<SlashCommandInteractionOption> getArgumentByName(String name) {
+        return getArguments()
+                .stream()
+                .filter(option -> option.getName().equalsIgnoreCase(name))
+                .findAny();
     }
 
     /**
-     * Gets the string value of an option having the specified name.
+     * Gets the string representation value of an argument having the specified name.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return An Optional with the string representation value of such an argument, if the argument exists;
+     *         an empty Optional otherwise
      */
-    default Optional<String> getOptionStringValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getStringValue);
+    default Optional<String> getArgumentStringRepresentationValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::getStringRepresentationValue);
     }
 
     /**
-     * Gets the long value of an option having the specified name.
-     * This will be present if the option is of type {@link SlashCommandOptionType#LONG}.
+     * Gets the string value of an argument having the specified name.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the long value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return An Optional with the string value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Long> getOptionLongValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getLongValue);
+    default Optional<String> getArgumentStringValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::getStringValue);
     }
 
     /**
-     * Gets the boolean value of an option having the specified name.
+     * Gets the long value of an argument having the specified name.
+     * This will be present if the argument is of type {@link SlashCommandOptionType#LONG}.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the boolean value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return An Optional with the long value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Boolean> getOptionBooleanValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getBooleanValue);
+    default Optional<Long> getArgumentLongValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::getLongValue);
     }
 
     /**
-     * Gets the user value of an option having the specified name.
+     * Gets the boolean value of an argument having the specified name.
+     *
+     * @param name The name of the argument to search for.
+     * @return An Optional with the boolean value of such an argument if it exists; an empty Optional otherwise
+     */
+    default Optional<Boolean> getArgumentBooleanValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::getBooleanValue);
+    }
+
+    /**
+     * Gets the user value of an argument having the specified name.
      * Note: This method only respects cached users. To fetch the user from Discord if the user is not cached,
-     *     use {@code requestOptionUserValueByName()}.
+     * use {@code requestArgumentUserValueByName()}.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the user value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return An Optional with the user value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<User> getOptionUserValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getUserValue);
+    default Optional<User> getArgumentUserValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::getUserValue);
     }
 
     /**
-     * Gets the user value of an option having the specified name.
+     * Gets the user value of an argument having the specified name.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the user value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return An Optional with the user value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<CompletableFuture<User>> requestOptionUserValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::requestUserValue);
+    default Optional<CompletableFuture<User>> requestArgumentUserValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::requestUserValue);
     }
 
     /**
-     * Gets the channel value of an option having the specified name.
+     * Gets the channel value of an argument having the specified name.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the channel value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return An Optional with the channel value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<ServerChannel> getOptionChannelValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getChannelValue);
+    default Optional<ServerChannel> getArgumentChannelValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::getChannelValue);
     }
 
     /**
-     * Gets the role value of an option having the specified name.
+     * Gets the role value of an argument having the specified name.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the role value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return An Optional with the role value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Role> getOptionRoleValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getRoleValue);
+    default Optional<Role> getArgumentRoleValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::getRoleValue);
     }
 
     /**
-     * Gets the mentionable value of an option having the specified name which may be a user, channel or role.
+     * Gets the mentionable value of an argument having the specified name which may be a user, channel or role.
      * Note: This method only respects cached users if the ID of the Mentionable belongs to a user. To fetch the user
-     *     from Discord if the user is not cached,
-     *     use {@code requestOptionMentionableValueByName()}.
+     * from Discord if the user is not cached,
+     * use {@code requestArgumentMentionableValueByName()}.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the mentionable value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return An Optional with the mentionable value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Mentionable> getOptionMentionableValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getMentionableValue);
+    default Optional<Mentionable> getArgumentMentionableValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::getMentionableValue);
     }
 
     /**
-     * Gets the mentionable value of an option having the specified name which may be a user, channel or role.
+     * Gets the mentionable value of an argument having the specified name which may be a user, channel or role.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the mentionable value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return An Optional with the mentionable value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<CompletableFuture<Mentionable>> requestOptionMentionableValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::requestMentionableValue);
+    default Optional<CompletableFuture<Mentionable>> requestArgumentMentionableValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::requestMentionableValue);
     }
 
     /**
-     * Gets the double value of an option having the specified name.
+     * Gets the double value of an argument having the specified name.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the double value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return An Optional with the double value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Double> getOptionDecimalValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getDecimalValue);
+    default Optional<Double> getArgumentDecimalValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::getDecimalValue);
     }
 
     /**
-     * Gets the attachment value of an option having the specified name.
+     * Gets the attachment value of an argument having the specified name.
      *
-     * @param name The name of the option to search for.
-     * @return An Optional with the attachment value of such an option if it exists; an empty Optional otherwise
+     * @param name The name of the argument to search for.
+     * @return An Optional with the attachment value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Attachment> getOptionAttachmentValueByName(String name) {
-        return getOptionByName(name).flatMap(SlashCommandInteractionOption::getAttachmentValue);
+    default Optional<Attachment> getArgumentAttachmentValueByName(String name) {
+        return getArgumentByName(name).flatMap(SlashCommandInteractionOption::getAttachmentValue);
     }
 
     /**
@@ -176,128 +200,142 @@ public interface SlashCommandInteractionOptionsProvider {
     }
 
     /**
-     * Gets the string representation value of an option at the specified index.
+     * Gets the argument at the specified index, if present.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return The argument with the specified index, if found; an empty Optional otherwise
      */
-    default Optional<String> getOptionStringRepresentationValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getStringRepresentationValue);
+    default Optional<SlashCommandInteractionOption> getArgumentByIndex(int index) {
+        return getArguments()
+                .stream()
+                .skip(index)
+                .findFirst();
     }
 
     /**
-     * Gets the string value of an option at the specified index.
+     * Gets the string representation value of an argument at the specified index.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the string value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return An Optional with the string representation value of such an argument, if the argument exists;
+     *         an empty Optional otherwise
      */
-    default Optional<String> getOptionStringValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getStringValue);
+    default Optional<String> getArgumentStringRepresentationValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::getStringRepresentationValue);
     }
 
     /**
-     * Gets the long value of an option at the specified index.
-     * This will be present if the option is of type {@link SlashCommandOptionType#LONG}.
+     * Gets the string value of an argument at the specified index.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the long value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return An Optional with the string value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Long> getOptionLongValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getLongValue);
+    default Optional<String> getArgumentStringValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::getStringValue);
     }
 
     /**
-     * Gets the boolean value of an option at the specified index.
+     * Gets the long value of an argument at the specified index.
+     * This will be present if the argument is of type {@link SlashCommandOptionType#LONG}.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the boolean value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return An Optional with the long value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Boolean> getOptionBooleanValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getBooleanValue);
+    default Optional<Long> getArgumentLongValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::getLongValue);
     }
 
     /**
-     * Gets the user value of an option at the specified index.
+     * Gets the boolean value of an argument at the specified index.
+     *
+     * @param index The index of the argument to search for.
+     * @return An Optional with the boolean value of such an argument if it exists; an empty Optional otherwise
+     */
+    default Optional<Boolean> getArgumentBooleanValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::getBooleanValue);
+    }
+
+    /**
+     * Gets the user value of an argument at the specified index.
      * Note: This method only respects cached users. To fetch the user from Discord if the user is not cached,
-     *     use {@code requestOptionUserValueByIndex()}.
+     * use {@code requestArgumentUserValueByIndex()}.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the user value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return An Optional with the user value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<User> getOptionUserValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getUserValue);
+    default Optional<User> getArgumentUserValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::getUserValue);
     }
 
     /**
-     * Gets the user value of an option at the specified index.
+     * Gets the user value of an argument at the specified index.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the user value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return An Optional with the user value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<CompletableFuture<User>> requestOptionUserValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::requestUserValue);
+    default Optional<CompletableFuture<User>> requestArgumentUserValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::requestUserValue);
     }
 
     /**
-     * Gets the channel value of an option at the specified index.
+     * Gets the channel value of an argument at the specified index.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the channel value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return An Optional with the channel value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<ServerChannel> getOptionChannelValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getChannelValue);
+    default Optional<ServerChannel> getArgumentChannelValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::getChannelValue);
     }
 
     /**
-     * Gets the role value of an option at the specified index.
+     * Gets the role value of an argument at the specified index.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the role value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return An Optional with the role value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Role> getOptionRoleValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getRoleValue);
+    default Optional<Role> getArgumentRoleValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::getRoleValue);
     }
 
     /**
-     * Gets the mentionable value of an option at the specified index which may be a user, channel or role.
+     * Gets the mentionable value of an argument at the specified index which may be a user, channel or role.
      * Note: This method only respects cached users if the ID of the Mentionable belongs to a user. To fetch the user
-     *     from Discord if the user is not cached,
-     *     use {@code requestOptionMentionableValueByIndex()}.
+     * from Discord if the user is not cached,
+     * use {@code requestArgumentMentionableValueByIndex()}.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the mentionable value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return An Optional with the mentionable value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Mentionable> getOptionMentionableValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getMentionableValue);
+    default Optional<Mentionable> getArgumentMentionableValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::getMentionableValue);
     }
 
     /**
-     * Gets the mentionable value of an option at the specified index which may be a user, channel or role.
+     * Gets the mentionable value of an argument at the specified index which may be a user, channel or role.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the mentionable value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return An Optional with the mentionable value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<CompletableFuture<Mentionable>> requestOptionMentionableValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::requestMentionableValue);
+    default Optional<CompletableFuture<Mentionable>> requestArgumentMentionableValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::requestMentionableValue);
     }
 
     /**
-     * Gets the double value of an option at the specified index.
+     * Gets the double value of an argument at the specified index.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the double value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return An Optional with the double value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Double> getOptionDecimalValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getDecimalValue);
+    default Optional<Double> getArgumentDecimalValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::getDecimalValue);
     }
 
     /**
-     * Gets the attachment value of an option at the specified index.
+     * Gets the attachment value of an argument at the specified index.
      *
-     * @param index The index of the option to search for.
-     * @return An Optional with the attachment value of such an option if it exists; an empty Optional otherwise
+     * @param index The index of the argument to search for.
+     * @return An Optional with the attachment value of such an argument if it exists; an empty Optional otherwise
      */
-    default Optional<Attachment> getOptionAttachmentValueByIndex(int index) {
-        return getOptionByIndex(index).flatMap(SlashCommandInteractionOption::getAttachmentValue);
+    default Optional<Attachment> getArgumentAttachmentValueByIndex(int index) {
+        return getArgumentByIndex(index).flatMap(SlashCommandInteractionOption::getAttachmentValue);
     }
 }

--- a/javacord-core/build.gradle.kts
+++ b/javacord-core/build.gradle.kts
@@ -2,7 +2,7 @@ import aQute.bnd.version.MavenVersion.parseMavenString
 
 plugins {
     `java-library`
-    id("biz.aQute.bnd.builder") version "6.2.0"
+    id("biz.aQute.bnd.builder") version "6.3.1"
 }
 
 repositories {

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandInteractionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandInteractionImpl.java
@@ -100,6 +100,8 @@ public class SlashCommandInteractionImpl extends ApplicationCommandInteractionIm
         return commandName;
     }
 
+    // TODO: Move the implementation to the SlashCommandInteractionOptionsProvider once we upgraded to Java 9+
+    // because interfaces currently do not support private methods
     @Override
     public List<SlashCommandInteractionOption> getArguments() {
         return getArgumentsRecursive(getOptions());

--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandInteractionOptionImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandInteractionOptionImpl.java
@@ -242,4 +242,21 @@ public class SlashCommandInteractionOptionImpl implements SlashCommandInteractio
     public List<SlashCommandInteractionOption> getOptions() {
         return Collections.unmodifiableList(options);
     }
+
+    // TODO: Move the implementation to the SlashCommandInteractionOptionsProvider once we upgraded to Java 9+
+    // because interfaces currently do not support private methods
+    @Override
+    public List<SlashCommandInteractionOption> getArguments() {
+        return getArgumentsRecursive(getOptions());
+    }
+
+    private List<SlashCommandInteractionOption> getArgumentsRecursive(List<SlashCommandInteractionOption> options) {
+        if (options.isEmpty()) {
+            return Collections.emptyList();
+        } else if (options.get(0).isSubcommandOrGroup()) {
+            return getArgumentsRecursive(options.get(0).getOptions());
+        } else {
+            return options;
+        }
+    }
 }


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
-->
## Changelog

### Breaking Changes
- Renamed SlashCommandOptionsProvider methods that are only usable for arguments of a slash command from `getOption*` to `getArgument*` and changed the implementation from getting the options from the option to getting always the command arguments if there are any

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description
See issue for more detailed thoughts on this

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: #1116 

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.