### PR TITLE
Deprecate ApplicationCommand delete methods

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommand.java
@@ -79,7 +79,7 @@ public interface ApplicationCommand extends DiscordEntity, Specializable<Applica
     boolean isDisabledByDefault();
 
     /**
-     * Gets whether this command is able to be used in DMs.
+     * Gets whether this command can be used in DMs.
      * Will always return {@code false} for server commands.
      *
      * @return Whether the command is enabled in DMs
@@ -113,10 +113,19 @@ public interface ApplicationCommand extends DiscordEntity, Specializable<Applica
     boolean isServerApplicationCommand();
 
     /**
-     * Deletes this application command globally.
+     * Deletes this application command.
      *
      * @return A future to check if the deletion was successful.
      */
+    CompletableFuture<Void> delete();
+
+    /**
+     * Deletes this application command globally.
+     *
+     * @return A future to check if the deletion was successful.
+     * @deprecated Use {@link #delete()} instead.
+     */
+    @Deprecated
     CompletableFuture<Void> deleteGlobal();
 
     /**
@@ -124,7 +133,9 @@ public interface ApplicationCommand extends DiscordEntity, Specializable<Applica
      *
      * @param server The server where the command should be deleted from.
      * @return A future to check if the deletion was successful.
+     * @deprecated Use {@link #delete()} instead.
      */
+    @Deprecated
     default CompletableFuture<Void> deleteForServer(Server server) {
         return deleteForServer(server.getId());
     }
@@ -134,6 +145,8 @@ public interface ApplicationCommand extends DiscordEntity, Specializable<Applica
      *
      * @param server The server where the command should be deleted from.
      * @return A future to check if the deletion was successful.
+     * @deprecated Use {@link #delete()} instead.
      */
+    @Deprecated
     CompletableFuture<Void> deleteForServer(long server);
 }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
@@ -138,6 +138,16 @@ public abstract class ApplicationCommandImpl implements ApplicationCommand {
     }
 
     @Override
+    public CompletableFuture<Void> delete() {
+        return (isGlobalApplicationCommand()
+                ? new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.APPLICATION_COMMANDS)
+                .setUrlParameters(String.valueOf(getApplicationId()), getIdAsString())
+                : new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.SERVER_APPLICATION_COMMANDS)
+                .setUrlParameters(String.valueOf(getApplicationId()), Long.toUnsignedString(serverId), getIdAsString()))
+                .execute(result -> null);
+    }
+
+    @Override
     public CompletableFuture<Void> deleteGlobal() {
         return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.APPLICATION_COMMANDS)
                 .setUrlParameters(String.valueOf(getApplicationId()), getIdAsString())


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
-->
## Changelog
- Deprecated `ApplicationCommand#deleteGlobal` and `deleteForServer` in favor of `delete`

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description
I don't know why this was changed back then to methods that specifically deleted them globally or on a server. But currently it doesn't make sense as an application commands only exists in either one of them if you have i.e. a `SlashCommand` instance. That means `deleteForServer` will never work if you call it on a global command you got with `DiscordApi#getGlobalSlashCommands` because if you create the exact same command as a server command they do not share the same id.

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.