### PR TITLE
Throw an exception when accessing the message content

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/MessageImpl.java
@@ -6,6 +6,7 @@ import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.emoji.CustomEmoji;
 import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.intent.Intent;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.MessageActivity;
 import org.javacord.api.entity.message.MessageAttachment;
@@ -170,7 +171,7 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
      * The sticker items in this message.
      */
     private final Set<StickerItem> stickerItems = new HashSet<>();
-        
+
     /**
      * The approximate position of the message in a thread.
      */
@@ -213,7 +214,7 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
         messageInteraction = data.hasNonNull("interaction")
             ? new MessageInteractionImpl(this, data.get("interaction"))
             : null;
-        
+
         position = data.hasNonNull("position") ? data.get("position").asInt() : null;
 
         setUpdatableFields(data);
@@ -387,7 +388,7 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
                 }
             });
         }
-        
+
         if (data.has("sticker_items")) {
             stickerItems.clear();
             for (JsonNode stickerItemJson : data.get("sticker_items")) {
@@ -441,7 +442,12 @@ public class MessageImpl implements Message, InternalMessageAttachableListenerMa
 
     @Override
     public String getContent() {
-        return content;
+        if (api.getIntents().contains(Intent.MESSAGE_CONTENT) || !content.isEmpty()) {
+            return content;
+        }
+        throw new IllegalStateException("The MESSAGE_CONTENT intent is required to receive the content of a message. "
+                + "Please see https://javacord.org/wiki/basic-tutorials/gateway-intents.html "
+                + "on how to enable this privileged intent.");
     }
 
     @Override


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
-->
## Changelog

### Breaking Changes
- Throw an exception when the content of a message is accessed without having the `MESSAGE_CONTENT` enabled

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description
The only purpose of this intent is to receive the content of a message. And since a lot of people are not aware that they have to enable this intent, it is better to directly throw an exception and let the user know that they are missing this intent before they need to ask for help on why this is not working.

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.