### PR TITLE
Fixes NullPointerException in TextInput when null is passed down from `TextInput`.

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/message/component/internal/TextInputBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/component/internal/TextInputBuilderDelegateImpl.java
@@ -53,7 +53,7 @@ public class TextInputBuilderDelegateImpl implements TextInputBuilderDelegate {
 
     @Override
     public void setValue(String value) {
-        this.value = value;
+        this.value = value == null ? "" : value;
     }
 
     @Override


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Fixed `NullPointerException` when passing down `null` in `TextInputBuilder#setValue`

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description
There was a recent encounter with a `NullPointerException` on Beemo that was caused by passing a nullable variable down to `TextInputBuilder().setValue(...)` (which totally accepted it) and tried to convert it to JSON but ended up failing down at that specific line when trying to do `isEmpty`.
(Stacktrace that depicts exact line of error)
![image](https://user-images.githubusercontent.com/69381903/211629519-d03af1d3-b28e-410e-833c-98c1e9f2b374.png)
<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.