### PR TITLE
EventDispatcherBase: Verify that remaining listener tasks exist

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/event/EventDispatcherBase.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/event/EventDispatcherBase.java
@@ -283,10 +283,14 @@ public abstract class EventDispatcherBase {
                             } catch (InterruptedException ignored) { }
                         }
                     }
+                    Runnable task = taskQueue.poll();
+                    if (task == null) {
+                        return;
+                    }
                     // Add the future to the list of active listeners
                     activeListeners.put(activeListener, new Object[]{System.nanoTime(), finalQueueSelector});
                     try {
-                        taskQueue.poll().run();
+                        task.run();
                     } catch (Throwable t) {
                         logger.error("Unhandled exception in {}!", () -> getThreadType(finalQueueSelector), () -> t);
                     }


### PR DESCRIPTION
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

## Changelog
- Fixed a rare NPE in EventDispatcherBase caused by the assumption that a remaining listener task always exists

## Description
There seems to have been previous efforts to fix this in #697 and #698 but evidently it wasn't fixed in all cases, as we still rarely (every few days; 6 times in the last 30 days) get this NPE in Beemo.

I initially suspected that it was caused by `checkRunningListenersAndStartIfPossible` being called multiple times with the same queue selector. Since `queue.isEmpty()` is called _before_ an executor service is queued that would actually pull the task from the queue, there might've been multiple executor submits  because each time it was assumed there was still an unhandled event left. If executor tasks were queued more often than tasks are actually in the queue, the remaining executors would find no more tasks to pull from the queue.

...But then I noticed that it also checks if a task is currently running for a given `finalQueueSelector`, which should prevent this issue from happening, so I don't actually have any idea why this happens. But evidently it does happen, albeit very rarely.

I suppose the most reliable way to fix this is to always verify that we actually have a task left to handle, instead of relying on outside behavior having checked for this at some point in the past. I don't trust multithreaded programs enough for that 😄

![chrome_2023-02-06_22-35-53](https://user-images.githubusercontent.com/10065021/217093316-17adf517-83b4-4b40-ae3e-417ce8d5d364.png)


[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.