### PR TITLE
Parameterized type fix in RegularServerChannel and ServerChannel

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/RegularServerChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/RegularServerChannel.java
@@ -246,8 +246,8 @@ public interface RegularServerChannel extends ServerChannel, Comparable<RegularS
      * @return An updater for this channel.
      */
     @Override
-    default RegularServerChannelUpdater createUpdater() {
-        return new RegularServerChannelUpdater(this);
+    default RegularServerChannelUpdater<?> createUpdater() {
+        return new RegularServerChannelUpdater<>(this);
     }
 
     @Override

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerChannel.java
@@ -44,8 +44,8 @@ public interface ServerChannel extends Channel, Nameable, Deletable, ServerChann
      *
      * @return An updater for this channel.
      */
-    default ServerChannelUpdater createUpdater() {
-        return new ServerChannelUpdater(this);
+    default ServerChannelUpdater<?> createUpdater() {
+        return new ServerChannelUpdater<>(this);
     }
 
     /**


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Changed _RegularServerChannel.createUpdater()_ to return _RegularServerChannelUpdater<?>_ instead of _RegularServerChannelUpdater_
- Changed _ServerChannel.createUpdater()_ to return _ServerChannelUpdater<?>_ instead of _ServerChannelUpdater_

### Breaking Changes

- None

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description

It prevents the parameterized types from getting lost if any method of _RegularServerChannelUpdater_ and _ServerChannelUpdater_ is used with a following call to _update()_ that would return _CompletableFuture_ instead of _CompletableFuture<Void>_.
The _update()_ method will now correctly return _CompletableFuture<Void>_.

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.