### PR TITLE
Adds methods to update components in UncachedMessageUtil.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/UncachedMessageUtil.java
@@ -1,6 +1,7 @@
 package org.javacord.api.entity.message;
 
 import org.javacord.api.entity.emoji.Emoji;
+import org.javacord.api.entity.message.component.HighLevelComponent;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.listener.message.UncachedMessageAttachableListenerManager;
@@ -140,6 +141,17 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
     CompletableFuture<Message> edit(String channelId, String messageId, String content);
 
     /**
+     * Updates the content and components of the message.
+     *
+     * @param channelId     The id of the message's channel.
+     * @param messageId     The id of the message.
+     * @param content       The new content of the message.
+     * @param components    The new components of the message.
+     * @return A future to check if the update was successful.
+     */
+    CompletableFuture<Message> edit(long channelId, long messageId, String content, HighLevelComponent... components);
+
+    /**
      * Updates the embed of the message.
      *
      * @param channelId The id of the message's channel.
@@ -160,6 +172,32 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
      * @return A future to check if the update was successful.
      */
     CompletableFuture<Message> edit(long channelId, long messageId, List<EmbedBuilder> embeds);
+
+    /**
+     * Updates the embeds and components of the message.
+     *
+     * @param channelId     The id of the message's channel.
+     * @param messageId     The id of the message.
+     * @param embeds        The new embeds of the message.
+     * @param components    The new components of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(long channelId, long messageId, List<EmbedBuilder> embeds,
+                                            HighLevelComponent... components) {
+        return edit(channelId, messageId, embeds, Arrays.asList(components));
+    }
+
+    /**
+     * Updates the embeds and components of the message.
+     *
+     * @param channelId     The id of the message's channel.
+     * @param messageId     The id of the message.
+     * @param embeds        The new embeds of the message.
+     * @param components    The new components of the message.
+     * @return A future to check if the update was successful.
+     */
+    CompletableFuture<Message> edit(long channelId, long messageId, List<EmbedBuilder> embeds,
+                                    List<HighLevelComponent> components);
 
     /**
      * Updates the embed of the message.
@@ -222,6 +260,34 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
     }
 
     /**
+     * Updates the content, embeds and components of the message.
+     *
+     * @param channelId     The id of the message's channel.
+     * @param messageId     The id of the message.
+     * @param content   The new content of the message.
+     * @param embeds        The new embeds of the message.
+     * @param components    The new components of the message.
+     * @return A future to check if the update was successful.
+     */
+    default CompletableFuture<Message> edit(long channelId, long messageId, String content, List<EmbedBuilder> embeds,
+                                            HighLevelComponent... components) {
+        return edit(channelId, messageId, content, embeds, Arrays.asList(components));
+    }
+
+    /**
+     * Updates the content, embeds and components of the message.
+     *
+     * @param channelId     The id of the message's channel.
+     * @param messageId     The id of the message.
+     * @param content       The new content of the message.
+     * @param embeds        The new embeds of the message.
+     * @param components    The new components of the message.
+     * @return A future to check if the update was successful.
+     */
+    CompletableFuture<Message> edit(long channelId, long messageId, String content, List<EmbedBuilder> embeds,
+                                    List<HighLevelComponent> components);
+
+    /**
      * Updates the content and the embed of the message.
      *
      * @param channelId The id of the message's channel.
@@ -277,6 +343,23 @@ public interface UncachedMessageUtil extends UncachedMessageAttachableListenerMa
                                             EmbedBuilder embed, boolean updateEmbed) {
         return edit(channelId, messageId, content, updateContent, Collections.singletonList(embed), updateEmbed);
     }
+
+    /**
+     * Updates the content, the embed and the components of the message.
+     *
+     * @param channelId         The id of the message's channel.
+     * @param messageId         The id of the message.
+     * @param content           The new content of the message.
+     * @param updateContent     Whether to update or remove the content.
+     * @param embeds            An array of the new embeds of the message.
+     * @param updateEmbed       Whether to update or remove the embed.
+     * @param components        An array of the new components of the message.
+     * @param updateComponents  Whether to update or remove the components.
+     * @return A future to check if the update was successful.
+     */
+    CompletableFuture<Message> edit(long channelId, long messageId, String content,
+                                    boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed,
+                                    List<HighLevelComponent> components, boolean updateComponents);
 
     /**
      * Updates the content and the embed of the message.

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/UncachedMessageUtilImpl.java
@@ -10,9 +10,11 @@ import org.javacord.api.entity.emoji.CustomEmoji;
 import org.javacord.api.entity.emoji.Emoji;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.UncachedMessageUtil;
+import org.javacord.api.entity.message.component.HighLevelComponent;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.user.User;
 import org.javacord.core.DiscordApiImpl;
+import org.javacord.core.entity.message.component.ComponentImpl;
 import org.javacord.core.entity.message.embed.EmbedBuilderDelegateImpl;
 import org.javacord.core.entity.user.MemberImpl;
 import org.javacord.core.entity.user.UserImpl;
@@ -169,8 +171,22 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
     }
 
     @Override
+    public CompletableFuture<Message> edit(long channelId, long messageId, String content,
+                                           HighLevelComponent... components) {
+        return edit(channelId, messageId, content, true, Collections.emptyList(), false,
+                Arrays.asList(components), true);
+    }
+
+    @Override
     public CompletableFuture<Message> edit(long channelId, long messageId, List<EmbedBuilder> embeds) {
         return edit(channelId, messageId, null, false, embeds, true);
+    }
+
+    @Override
+    public CompletableFuture<Message> edit(long channelId, long messageId, List<EmbedBuilder> embeds,
+                                           List<HighLevelComponent> components) {
+        return edit(channelId, messageId, null, false, embeds, true,
+                components, true);
     }
 
     @Override
@@ -185,6 +201,13 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
     }
 
     @Override
+    public CompletableFuture<Message> edit(long channelId, long messageId, String content, List<EmbedBuilder> embeds,
+                                           List<HighLevelComponent> components) {
+        return edit(channelId, messageId, content, true, embeds, true,
+                components, true);
+    }
+
+    @Override
     public CompletableFuture<Message> edit(
             String channelId, String messageId, String content, List<EmbedBuilder> embeds) {
         return edit(channelId, messageId, content, true, embeds, true);
@@ -193,6 +216,13 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
     @Override
     public CompletableFuture<Message> edit(long channelId, long messageId, String content,
                                            boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed) {
+        return edit(channelId, messageId, content, updateContent, embeds, updateEmbed, Collections.emptyList(), false);
+    }
+
+    @Override
+    public CompletableFuture<Message> edit(long channelId, long messageId, String content,
+                                           boolean updateContent, List<EmbedBuilder> embeds, boolean updateEmbed,
+                                           List<HighLevelComponent> components, boolean updateComponents) {
         ObjectNode body = JsonNodeFactory.instance.objectNode();
         if (updateContent) {
             if (content == null || content.isEmpty()) {
@@ -200,6 +230,11 @@ public class UncachedMessageUtilImpl implements UncachedMessageUtil, InternalUnc
             } else {
                 body.put("content", content);
             }
+        }
+        if (updateComponents) {
+            ArrayNode componentsArray = body.putArray("components");
+            components.forEach(highLevelComponent -> componentsArray.add(((ComponentImpl) highLevelComponent)
+                    .toJsonNode()));
         }
         if (updateEmbed) {
             ArrayNode embedArray = body.putArray("embeds");


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Added methods that enable updating components using the `UncachedMessageUtil` class.

### Breaking Changes

## Description
`UncachedMessageUtil` is missing some additional functionality allowing developers with multi-node bots to edit messages with components, this pull request aims to add at least much of those possible. Although some convenience methods may be missing, but this should be most sufficient already for most.
<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.