### PR TITLE
Add missing check in VoiceStateUpdateHandler 

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/handler/guild/VoiceStateUpdateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/guild/VoiceStateUpdateHandler.java
@@ -71,7 +71,9 @@ public class VoiceStateUpdateHandler extends PacketHandler {
             }
         }
 
-        if (api.getYourself().getId() == userId) {
+        // Channel ID can be null in case the bot gets kicked.
+        // In that case the audio remove logic is executed in #handleServerVoiceChannel
+        if (api.getYourself().getId() == userId && packet.hasNonNull("channel_id")) {
             handleSelf(packet);
         }
     }


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Fixed VoiceStateUpdateHandler when the bot i.e. gets kicked resulting in a false positive warning that a channel is not cached

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.