### PR TITLE
Add NSFW property to Application Command Updater

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
@@ -124,7 +124,7 @@ public abstract class ApplicationCommandUpdater<T extends ApplicationCommand,
     }
 
     /**
-     * Sets the slash command as nsfw.
+     * Sets whether the command is nsfw.
      *
      * @param nsfw Whether the command is nsfw.
      * @return The current instance in order to chain call methods.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/ApplicationCommandUpdater.java
@@ -124,6 +124,17 @@ public abstract class ApplicationCommandUpdater<T extends ApplicationCommand,
     }
 
     /**
+     * Sets the slash command as nsfw.
+     *
+     * @param nsfw Whether the command is nsfw.
+     * @return The current instance in order to chain call methods.
+     */
+    public B setNsfw(boolean nsfw) {
+        delegate.setNsfw(nsfw);
+        return (B) this;
+    }
+
+    /**
      * Updates a global application command.
      * When used to update multiple global application commands at once
      * {@link DiscordApi#bulkOverwriteGlobalApplicationCommands(Set)} should be used instead.

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandUpdaterDelegate.java
@@ -69,7 +69,7 @@ public interface ApplicationCommandUpdaterDelegate<T extends ApplicationCommand>
     void setEnabledInDms(boolean enabledInDms);
 
     /**
-     * Sets the slash command as nsfw.
+     * Sets whether the command is nsfw.
      *
      * @param nsfw Whether the command is nsfw.
      */

--- a/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/internal/ApplicationCommandUpdaterDelegate.java
@@ -69,6 +69,13 @@ public interface ApplicationCommandUpdaterDelegate<T extends ApplicationCommand>
     void setEnabledInDms(boolean enabledInDms);
 
     /**
+     * Sets the slash command as nsfw.
+     *
+     * @param nsfw Whether the command is nsfw.
+     */
+    void setNsfw(boolean nsfw);
+
+    /**
      * Performs the queued update.
      *
      * @param api The DiscordApi.

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
@@ -55,7 +55,8 @@ public abstract class ApplicationCommandImpl implements ApplicationCommand {
         defaultMemberPermission = defaultMemberPermissionsBitset != null
                 ? Arrays.stream(PermissionType.values())
                 .filter(type -> type.isSet(defaultMemberPermissionsBitset))
-                .collect(Collectors.toCollection(() -> EnumSet.noneOf(PermissionType.class))) : EnumSet.noneOf(PermissionType.class);
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(PermissionType.class)))
+                : EnumSet.noneOf(PermissionType.class);
         data.path("description_localizations").fields().forEachRemaining(e ->
                 descriptionLocalizations.put(DiscordLocale.fromLocaleCode(e.getKey()), e.getValue().asText()));
         serverId = data.has("guild_id")

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
@@ -111,7 +111,7 @@ public abstract class ApplicationCommandImpl implements ApplicationCommand {
 
     @Override
     public boolean isDisabledByDefault() {
-        return defaultMemberPermission.isEmpty();
+        return defaultMemberPermission != null && defaultMemberPermission.isEmpty();
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
@@ -111,7 +111,7 @@ public abstract class ApplicationCommandImpl implements ApplicationCommand {
 
     @Override
     public boolean isDisabledByDefault() {
-        return defaultMemberPermission != null && defaultMemberPermission.isEmpty();
+        return defaultMemberPermission.isEmpty();
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandImpl.java
@@ -55,7 +55,7 @@ public abstract class ApplicationCommandImpl implements ApplicationCommand {
         defaultMemberPermission = defaultMemberPermissionsBitset != null
                 ? Arrays.stream(PermissionType.values())
                 .filter(type -> type.isSet(defaultMemberPermissionsBitset))
-                .collect(Collectors.toCollection(() -> EnumSet.noneOf(PermissionType.class))) : null;
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(PermissionType.class))) : EnumSet.noneOf(PermissionType.class);
         data.path("description_localizations").fields().forEachRemaining(e ->
                 descriptionLocalizations.put(DiscordLocale.fromLocaleCode(e.getKey()), e.getValue().asText()));
         serverId = data.has("guild_id")

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandUpdaterDelegateImpl.java
@@ -27,6 +27,8 @@ public abstract class ApplicationCommandUpdaterDelegateImpl<T extends Applicatio
 
     protected Boolean dmPermission = null;
 
+    protected Boolean nsfw = false;
+
     @Override
     public void setName(String name) {
         this.name = name;
@@ -67,6 +69,11 @@ public abstract class ApplicationCommandUpdaterDelegateImpl<T extends Applicatio
         this.dmPermission = enabledInDms;
     }
 
+    @Override
+    public void setNsfw(boolean nsfw) {
+        this.nsfw = nsfw;
+    }
+
     protected void prepareBody(ObjectNode body) {
         if (name != null && !name.isEmpty()) {
             body.put("name", name);
@@ -97,5 +104,7 @@ public abstract class ApplicationCommandUpdaterDelegateImpl<T extends Applicatio
         if (dmPermission != null) {
             body.put("dm_permission", dmPermission);
         }
+
+        body.put("nsfw", nsfw);
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/ApplicationCommandUpdaterDelegateImpl.java
@@ -27,7 +27,7 @@ public abstract class ApplicationCommandUpdaterDelegateImpl<T extends Applicatio
 
     protected Boolean dmPermission = null;
 
-    protected Boolean nsfw = false;
+    protected Boolean nsfw = null;
 
     @Override
     public void setName(String name) {
@@ -105,6 +105,8 @@ public abstract class ApplicationCommandUpdaterDelegateImpl<T extends Applicatio
             body.put("dm_permission", dmPermission);
         }
 
-        body.put("nsfw", nsfw);
+        if (nsfw != null) {
+            body.put("nsfw", nsfw);
+        }
     }
 }


### PR DESCRIPTION

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Added NSFW property to Application Command Updater
- Check if defaultMemberPermission in ApplicationCommandImpl is null before accessing it

### Breaking Changes

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description
A recent PR added NSFW property to Application Command Builder, but it was missing from Updater, so this PR adds it to the Updater as well.

It also fixes a NullPointerException that I discovered accidentaly when I called ApplicationCommandImpl#isDisabledByDefault(), so I added a simple check before checking its emptiness.
<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.