### PR TITLE
Fix wrong implementation for Message#removeEmbeds

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/Message.java
@@ -509,7 +509,7 @@ public interface Message extends DiscordEntity, Deletable, Comparable<Message>, 
      * @return A future to check if the removal was successful.
      */
     default CompletableFuture<Message> removeEmbed() {
-        return new MessageUpdater(this).addEmbeds(Collections.emptyList()).applyChanges();
+        return new MessageUpdater(this).removeAllEmbeds().applyChanges();
     }
 
     /**


### PR DESCRIPTION
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).





## Changelog
- Fixed Message.removeEmbed() doesn't do anything #1227 


## Description
When calling the `Message.removeEmbeds()` nothing happened not even an exception/error.
Now the embeds get deleted when the method is called

Closes: #1227 

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.