### PR TITLE
Remove guild from unavailable guilds list on delete

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -1041,7 +1041,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      *
      * @param serverId The id of the server.
      */
-    private void removeUnavailableServerFromCache(long serverId) {
+    public void removeUnavailableServerFromCache(long serverId) {
         unavailableServers.remove(serverId);
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildDeleteHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/guild/GuildDeleteHandler.java
@@ -53,6 +53,7 @@ public class GuildDeleteHandler extends PacketHandler {
                 msg -> api.removeMessageFromCache(msg.getId())
         );
         api.removeServerFromCache(serverId);
+        api.removeUnavailableServerFromCache(serverId);
     }
 
 }


### PR DESCRIPTION
## Checklist
- [x] I have tested this PR[^1].
    - Technically not, since it's pretty hard to get a bot into this state. We didn't do a Beemo deploy just for this tiny change (aka testing in production) as we want to minimize its downtime. However, imo the logic checks out. Famous last words, I know.
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

## Changelog
- Fixed some unavailable guilds forever being stuck in the unavailable guilds list on deletion

## Description
It's possible for some guilds to never become available before a `GUILD_DELETE` event is received for them. This commonly happens to TnS-"deleted" (i.e. "hidden/archived") guilds. You may still get an initial unavailable guild object for them in the `READY` payload, but eventually they are `GUILD_DELETE`d without ever having become available.
Javacord however didn't remove a deleted guild from the unavailable guilds list, causing the list to contain guilds that should've been deleted from the list through those events, errorneously indicating an unusually high unavailalbe guild count.

I had to make the previously private method in `DiscordApiImpl` public for that; we can't put this in `removeServerFromCache` since that same method is used for actual unavailalbe guilds (i.e. those the bot is still in, and that should stay in the unavailable list).

Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.