### PR TITLE
Remove and add missing Enum values

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 # the whole org.gradle.jvmargs line can be removed after that is fixed
 org.gradle.jvmargs = -Duser.language=en -Xmx512m -XX:MaxMetaspaceSize=256m
 org.gradle.caching = true
-version = 3.8.1-SNAPSHOT
+version = 3.9.0-SNAPSHOT

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerThreadChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerThreadChannel.java
@@ -64,7 +64,7 @@ public interface ServerThreadChannel extends ServerChannel, TextChannel, Mention
     default boolean canAttachFiles(User user) {
         return canWrite(user) && getParent().hasAnyPermission(user,
                 PermissionType.ADMINISTRATOR,
-                PermissionType.ATTACH_FILE);
+                PermissionType.ATTACH_FILES);
     }
 
     @Override

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerVoiceChannel.java
@@ -218,7 +218,7 @@ public interface ServerVoiceChannel extends RegularServerChannel, VoiceChannel, 
      */
     default boolean canUseVoiceActivation(User user) {
         return hasAnyPermission(user, PermissionType.ADMINISTRATOR)
-                || hasPermissions(user, PermissionType.USE_VOICE_ACTIVITY, PermissionType.CONNECT);
+                || hasPermissions(user, PermissionType.USE_VAD, PermissionType.CONNECT);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/TextableRegularServerChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/TextableRegularServerChannel.java
@@ -63,7 +63,7 @@ public interface TextableRegularServerChannel extends TextChannel, Mentionable, 
     default boolean canAttachFiles(User user) {
         return asRegularServerChannel().map(regularServerChannel ->
                 regularServerChannel.hasPermission(user, PermissionType.ADMINISTRATOR)
-                        || (regularServerChannel.hasPermission(user, PermissionType.ATTACH_FILE)
+                        || (regularServerChannel.hasPermission(user, PermissionType.ATTACH_FILES)
                         && canWrite(user))).orElse(false);
     }
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/MessageType.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/MessageType.java
@@ -36,6 +36,14 @@ public enum MessageType {
     THREAD_STARTER_MESSAGE(21),
     GUILD_INVITE_REMINDER(22),
     CONTEXT_MENU_COMMAND(23),
+    AUTO_MODERATION_ACTION(24),
+    ROLE_SUBSCRIPTION_PURCHASE(25),
+    INTERACTION_PREMIUM_UPSELL(26),
+    STAGE_START(27),
+    STAGE_END(28),
+    STAGE_SPEAKER_JOIN(29),
+    STAGE_TOPIC_CHANGE(31),
+    SERVER_APPLICATION_PREMIUM_SUBSCRIPTION(32),
 
     /**
      * An unknown message type.
@@ -64,48 +72,15 @@ public enum MessageType {
      * @return The message type.
      */
     public static MessageType byType(int type, boolean webhook) {
-        switch (type) {
-            case 0:
-                return webhook ? NORMAL_WEBHOOK : NORMAL;
-            case 1:
-                return RECIPIENT_ADD;
-            case 2:
-                return RECIPIENT_REMOVE;
-            case 3:
-                return CALL;
-            case 4:
-                return CHANNEL_NAME_CHANGE;
-            case 5:
-                return CHANNEL_ICON_CHANGE;
-            case 6:
-                return CHANNEL_PINNED_MESSAGE;
-            case 7:
-                return SERVER_MEMBER_JOIN;
-            case 8:
-                return USER_PREMIUM_SERVER_SUBSCRIPTION;
-            case 9:
-                return USER_PREMIUM_SERVER_SUBSCRIPTION_TIER_1;
-            case 10:
-                return USER_PREMIUM_SERVER_SUBSCRIPTION_TIER_2;
-            case 11:
-                return USER_PREMIUM_SERVER_SUBSCRIPTION_TIER_3;
-            case 12:
-                return CHANNEL_FOLLOW_ADD;
-            case 14:
-                return SERVER_DISCOVERY_DISQUALIFIED;
-            case 15:
-                return SERVER_DISCOVERY_REQUALIFIED;
-            case 16:
-                return SERVER_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING;
-            case 17:
-                return SERVER_DISCOVERY_GRACE_PERIOD_FINAL_WARNING;
-            case 19:
-                return REPLY;
-            case 20:
-                return SLASH_COMMAND;
-            default:
-                return UNKNOWN;
+        if (type == 0 && webhook) {
+            return NORMAL_WEBHOOK;
         }
+        for (MessageType value : values()) {
+            if (value.type == type) {
+                return value;
+            }
+        }
+        return UNKNOWN;
     }
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/PermissionType.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/PermissionType.java
@@ -5,55 +5,183 @@ package org.javacord.api.entity.permission;
  */
 public enum PermissionType {
 
-    // general
-    CREATE_INSTANT_INVITE(0x0000000001L),
-    KICK_MEMBERS(0x0000000002L),
-    BAN_MEMBERS(0x0000000004L),
-    ADMINISTRATOR(0x0000000008L),
-    MANAGE_CHANNELS(0x0000000010L),
-    MANAGE_SERVER(0x0000000020L),
-    ADD_REACTIONS(0x0000000040L),
-    VIEW_AUDIT_LOG(0x0000000080L),
-    VIEW_SERVER_INSIGHTS(0x0000080000L), //VIEW_GUILD_INSIGHTS
-
-    // chat
-    VIEW_CHANNEL(0x0000000400L),
-    SEND_MESSAGES(0x0000000800L),
-    SEND_TTS_MESSAGES(0x0000001000L),
-    MANAGE_MESSAGES(0x0000002000L),
-    EMBED_LINKS(0x0000004000L),
-    ATTACH_FILE(0x0000008000L),
-    READ_MESSAGE_HISTORY(0x0000010000L),
-    MENTION_EVERYONE(0x0000020000L),
-    USE_EXTERNAL_EMOJIS(0x0000040000L),
-    USE_EXTERNAL_STICKERS(0x2000000000L),
-
-    // voice
-    CONNECT(0x0000100000L),
-    SPEAK(0x0000200000L),
-    MUTE_MEMBERS(0x0000400000L),
-    DEAFEN_MEMBERS(0x0000800000L),
-    MOVE_MEMBERS(0x0001000000L),
-    USE_VOICE_ACTIVITY(0x0002000000L), //USE_VAD
-    PRIORITY_SPEAKER(0x0000000100L),
-    STREAM(0x0000000200L),
-    REQUEST_TO_SPEAK(0x0100000000L),
-    START_EMBEDDED_ACTIVITIES(0x8000000000L),
-
-    //threads
-    MANAGE_THREADS(0x0400000000L),
-    CREATE_PUBLIC_THREADS(0x0800000000L),
-    CREATE_PRIVATE_THREADS(0x1000000000L),
-    SEND_MESSAGES_IN_THREADS(0x4000000000L),
-
-    // misc
-    CHANGE_NICKNAME(0x0004000000L),
-    MANAGE_NICKNAMES(0x0008000000L),
-    MANAGE_ROLES(0x0010000000L),
-    MANAGE_WEBHOOKS(0x0020000000L),
-    MANAGE_EMOJIS(0x0040000000L), //MANAGE_EMOJIS_AND_STICKERS
-    USE_APPLICATION_COMMANDS(0x0080000000L),
-    MODERATE_MEMBERS(0x0000010000000000L);
+    /**
+     * Allows creation of instant invites.
+     */
+    CREATE_INSTANT_INVITE(1L << 0),
+    /**
+     * Allows kicking members.
+     */
+    KICK_MEMBERS(1L << 1),
+    /**
+     * Allows banning members.
+     */
+    BAN_MEMBERS(1L << 2),
+    /**
+     * Allows all permissions and bypasses channel permission overwrites.
+     */
+    ADMINISTRATOR(1L << 3),
+    /**
+     * Allows management and editing of channels.
+     */
+    MANAGE_CHANNELS(1L << 4),
+    /**
+     * Allows management and editing of the server.
+     */
+    MANAGE_SERVER(1L << 5),
+    /**
+     * Allows for the addition of reactions to messages.
+     */
+    ADD_REACTIONS(1L << 6),
+    /**
+     * Allows for viewing of audit logs.
+     */
+    VIEW_AUDIT_LOG(1L << 7),
+    /**
+     * Allows for using priority speaker in a voice channel.
+     */
+    PRIORITY_SPEAKER(1L << 8),
+    /**
+     * Allows the user to go live.
+     */
+    STREAM(1L << 9),
+    /**
+     * Allows server members to view a channel,
+     * which includes reading messages in text channels and joining voice channels.
+     */
+    VIEW_CHANNEL(1L << 10),
+    /**
+     * Allows for sending messages in a channel and creating threads in a forum
+     * (does not allow sending messages in threads).
+     */
+    SEND_MESSAGES(1L << 11),
+    /**
+     * Allows for sending of /tts messages.
+     */
+    SEND_TTS_MESSAGES(1L << 12),
+    /**
+     * Allows for deletion of other users messages.
+     */
+    MANAGE_MESSAGES(1L << 13),
+    /**
+     * Links sent by users with this permission will be auto-embedded.
+     */
+    EMBED_LINKS(1L << 14),
+    /**
+     * Allows for uploading images and files.
+     */
+    ATTACH_FILES(1L << 15),
+    /**
+     * Allows for reading of message history.
+     */
+    READ_MESSAGE_HISTORY(1L << 16),
+    /**
+     * Allows for using the @everyone tag to notify all users in a channel,
+     * and the @here tag to notify all online users in a channel.
+     */
+    MENTION_EVERYONE(1L << 17),
+    /**
+     * Allows the usage of custom emojis from other servers.
+     */
+    USE_EXTERNAL_EMOJIS(1L << 18),
+    /**
+     * Allows for viewing server insights.
+     */
+    VIEW_SERVER_INSIGHTS(1L << 19),
+    /**
+     * Allows for joining of a voice channel.
+     */
+    CONNECT(1L << 20),
+    /**
+     * Allows for speaking in a voice channel.
+     */
+    SPEAK(1L << 21),
+    /**
+     * Allows for muting members in a voice channel.
+     */
+    MUTE_MEMBERS(1L << 22),
+    /**
+     * Allows for deafening of members in a voice channel.
+     */
+    DEAFEN_MEMBERS(1L << 23),
+    /**
+     * Allows for moving of members between voice channels.
+     */
+    MOVE_MEMBERS(1L << 24),
+    /**
+     * Allows for using voice-activity-detection in a voice channel.
+     */
+    USE_VAD(1L << 25),
+    /**
+     * Allows for modification of own nickname.
+     */
+    CHANGE_NICKNAME(1L << 26),
+    /**
+     * Allows for modification of other users nicknames.
+     */
+    MANAGE_NICKNAMES(1L << 27),
+    /**
+     * Allows management and editing of roles.
+     */
+    MANAGE_ROLES(1L << 28),
+    /**
+     * Allows management and editing of webhooks.
+     */
+    MANAGE_WEBHOOKS(1L << 29),
+    /**
+     * Allows management and editing of emojis, stickers, and soundboard sounds.
+     */
+    MANAGE_SERVER_EXPRESSIONS(1L << 30),
+    /**
+     * Allows members to use application commands, including slash commands and context menu commands..
+     */
+    USE_APPLICATION_COMMANDS(1L << 31),
+    /**
+     * Allows for requesting to speak in stage channels.
+     * (This permission is under active development and may be changed or removed.).
+     */
+    REQUEST_TO_SPEAK(1L << 32),
+    /**
+     * Allows for creating, editing, and deleting scheduled events.
+     */
+    MANAGE_EVENTS(1L << 33),
+    /**
+     * Allows for deleting and archiving threads, and viewing all private threads.
+     */
+    MANAGE_THREADS(1L << 34),
+    /**
+     * Allows for creating public and announcement threads.
+     */
+    CREATE_PUBLIC_THREADS(1L << 35),
+    /**
+     * Allows for creating private threads.
+     */
+    CREATE_PRIVATE_THREADS(1L << 36),
+    /**
+     * Allows the usage of custom stickers from other servers.
+     */
+    USE_EXTERNAL_STICKERS(1L << 37),
+    /**
+     * Allows for sending messages in threads.
+     */
+    SEND_MESSAGES_IN_THREADS(1L << 38),
+    /**
+     * Allows for using Activities (applications with the EMBEDDED flag) in a voice channel.
+     */
+    USE_EMBEDDED_ACTIVITIES(1L << 39),
+    /**
+     * Allows for timing out users to prevent them from sending or reacting to messages in chat and threads,
+     * and from speaking in voice and stage channels.
+     */
+    MODERATE_MEMBERS(1L << 40),
+    /**
+     * Allows for viewing role subscription insights.
+     */
+    VIEW_CREATOR_MONETIZATION_ANALYTICS(1L << 41),
+    /**
+     * Allows for using soundboard in a voice channel.
+     */
+    USE_SOUNDBOARD(1L << 42);
 
     /**
      * The value of the permission. A long where only one bit is set (e.g. <code>0b1000</code>).
@@ -91,7 +219,7 @@ public enum PermissionType {
     /**
      * Sets or unsets the type for the given long.
      *
-     * @param l The long to change.
+     * @param l   The long to change.
      * @param set Whether the type should be set or not.
      * @return The changed long.
      */

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -3167,7 +3167,7 @@ public interface Server extends DiscordEntity, Nameable, Deletable, UpdatableFro
     default boolean canManageEmojis(User user) {
         return hasAnyPermission(user,
                 PermissionType.ADMINISTRATOR,
-                PermissionType.MANAGE_EMOJIS);
+                PermissionType.MANAGE_SERVER_EXPRESSIONS);
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/ServerFeature.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/ServerFeature.java
@@ -6,9 +6,21 @@ package org.javacord.api.entity.server;
 public enum ServerFeature {
 
     /**
+     * Server has access to set an animated server banner image.
+     */
+    ANIMATED_BANNER,
+    /**
      * Server has access to set an animated Server icon.
      */
     ANIMATED_ICON,
+    /**
+     * Server is using the old permissions configuration behavior.
+     */
+    APPLICATION_COMMAND_PERMISSIONS_V2,
+    /**
+     * Server has set up auto moderation rules.
+     */
+    AUTO_MODERATION,
     /**
      * Server has access to set a Server banner image.
      */
@@ -18,6 +30,18 @@ public enum ServerFeature {
      */
     COMMUNITY,
     /**
+     * Server has enabled monetization.
+     */
+    CREATOR_MONETIZABLE_PROVISIONAL,
+    /**
+     * Server has enabled the role subscription promo page.
+     */
+    CREATOR_STORE_PAGE,
+    /**
+     * Server has been set as a support server on the App Directory.
+     */
+    DEVELOPER_SUPPORT_SERVER,
+    /**
      * Server is able to be discovered in the directory.
      */
     DISCOVERABLE,
@@ -26,13 +50,21 @@ public enum ServerFeature {
      */
     FEATURABLE,
     /**
+     * Server has paused invites, preventing new users from joining.
+     */
+    INVITES_DISABLED,
+    /**
      * Server has access to set an invite splash background.
      */
     INVITE_SPLASH,
     /**
-     * Server has enabled <a href="https://discord.com/developers/docs/resources/guild#membership-screening-object">Membership Screening</a>.
+     * Server has enabled <a href="https://discord.com/developers/docs/resources/#membership-screening-object">Membership Screening</a>.
      */
     MEMBER_VERIFICATION_GATE_ENABLED,
+    /**
+     * Server has increased custom sticker slots.
+     */
+    MORE_STICKERS,
     /**
      * Server has access to create news channels.
      */
@@ -45,6 +77,22 @@ public enum ServerFeature {
      * Server can be previewed before joining via Membership Screening or the directory.
      */
     PREVIEW_ENABLED,
+    /**
+     * Server is able to set role icons.
+     */
+    ROLE_ICONS,
+    /**
+     * Server has role subscriptions that can be purchased.
+     */
+    ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE,
+    /**
+     * Server has enabled role subscriptions.
+     */
+    ROLE_SUBSCRIPTIONS_ENABLED,
+    /**
+     * Server has enabled ticketed events.
+     */
+    TICKETED_EVENTS_ENABLED,
     /**
      * Server has access to set a vanity URL.
      */
@@ -61,33 +109,4 @@ public enum ServerFeature {
      * Server has enabled the welcome screen.
      */
     WELCOME_SCREEN_ENABLED,
-    /**
-     * Server has enabled ticketed events.
-     */
-    TICKETED_EVENTS_ENABLED,
-    /**
-     * Server has enabled monetization.
-     */
-    MONETIZATION_ENABLED,
-    /**
-     * Server has increased custom sticker slots.
-     */
-    MORE_STICKERS,
-    /**
-     * Server has access to create private threads.
-     */
-    PRIVATE_THREADS,
-    /**
-     * Server has access to set an animated guild banner image.
-     */
-    ANIMATED_BANNER,
-    /**
-     * Server has set up auto moderation rules.
-     */
-    AUTO_MODERATION,
-
-    /**
-     * Server has paused invites, preventing new users from joining.
-     */
-    INVITES_DISABLED,
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/SystemChannelFlag.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/SystemChannelFlag.java
@@ -20,7 +20,15 @@ public enum SystemChannelFlag {
     /**
      * Hide member join sticker reply buttons.
      */
-    SUPPRESS_JOIN_NOTIFICATION_REPLIES(1 << 3);
+    SUPPRESS_JOIN_NOTIFICATION_REPLIES(1 << 3),
+    /**
+     * Suppress role subscription purchase and renewal notifications.
+     */
+    SUPPRESS_ROLE_SUBSCRIPTION_PURCHASE_NOTIFICATIONS(1 << 4),
+    /**
+     * Hide role subscription sticker reply buttons.
+     */
+    SUPPRESS_ROLE_SUBSCRIPTION_PURCHASE_NOTIFICATION_REPLIES(1 << 5);
 
     private final int flag;
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/sticker/StickerFormatType.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/sticker/StickerFormatType.java
@@ -23,6 +23,11 @@ public enum StickerFormatType {
     LOTTIE(3),
 
     /**
+     * A GIF image.
+     */
+    GIF(4),
+
+    /**
      * An unknown image. Most likely something new added by Discord.
      */
     UNKNOWN(-1);

--- a/javacord-api/src/main/java/org/javacord/api/entity/user/UserFlag.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/UserFlag.java
@@ -16,7 +16,8 @@ public enum UserFlag {
     VERIFIED_BOT(1 << 16, "Verified Bot"),
     VERIFIED_DEVELOPER(1 << 17, "Early Verified Bot Developer"),
     CERTIFIED_MODERATOR(1 << 18, "Discord Certified Moderator"),
-    BOT_HTTP_INTERACTIONS(1 << 19, "Bot uses only HTTP interactions and is shown in the online member list");
+    BOT_HTTP_INTERACTIONS(1 << 19, "Bot uses only HTTP interactions and is shown in the online member list"),
+    ACTIVE_DEVELOPER(1 << 22, "User is an active Developer");
 
     private final int flag;
     private final String description;


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Added missing ServerFeature enum values
- Added missing SystemChannelFlag enum values
- Added missing MessageType enum values
- Added missing PermissionType enum values
- Added missing StickerFormatType enum values
- Added missing UserFlag enum values

### Breaking Changes
- Removed `MONETIZATION_ENABLED` and `PRIVATE_THREADS` ServerFeature enum values as they are no longer in use
- Renamed `PermissionType.MANAGE_EMOJI` to `MANAGE_SERVER_EXPRESSIONS` and `ATTACH_FILE` to `ATTACH_FILES` and `USE_VOICE_ACTIVITY` to `USE_VAD`


[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.