### PR TITLE
Add getters for ActivityAssets image values

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/activity/ActivityAssets.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/activity/ActivityAssets.java
@@ -1,7 +1,6 @@
 package org.javacord.api.entity.activity;
 
 import org.javacord.api.entity.Icon;
-
 import java.util.Optional;
 
 /**
@@ -10,7 +9,23 @@ import java.util.Optional;
 public interface ActivityAssets {
 
     /**
+     * Gets the large image value of the asset.
+     * If the value is from a different platform like Spotify, YouTube, etc. you should try to get the image from
+     * one of their CDNs which can be:
+     * <ul>
+     *     <li>Spotify: {@code https://i.scdn.co/image/{cover_id}}</li>
+     *     <li>Youtube: {@code https://i.ytimg.com/vi/{video_id}/hqdefault_live.jpg}</li>
+     *     <li>Twitch: {@code https://static-cdn.jtvnw.net/previews-ttv/live_user_{user_id}.png}</li>
+     * </ul>
+     * but take these with a grain of salt as they can change at any time.
+     *
+     * @return The large image value of the asset.
+     */
+    Optional<String> getLargeImageValue();
+
+    /**
      * Gets the large image of the asset.
+     * Always empty for activities of other services like Spotify, YouTube, etc.
      *
      * @return The large image of the asset.
      */
@@ -24,7 +39,23 @@ public interface ActivityAssets {
     Optional<String> getLargeText();
 
     /**
+     * Gets the small image value of the asset.
+     * If the value is from a different platform like Spotify, Youtube, etc. you should try to get the image from
+     * one of their CDNs which can be:
+     * <ul>
+     *     <li>Spotify: {@code https://i.scdn.co/image/{cover_id}}</li>
+     *     <li>Youtube: {@code https://i.ytimg.com/vi/{video_id}/hqdefault_live.jpg}</li>
+     *     <li>Twitch: {@code https://static-cdn.jtvnw.net/previews-ttv/live_user_{user_id}.png}</li>
+     * </ul>
+     * but take these with a grain of salt as they can change at any time.
+     *
+     * @return The small image value of the asset.
+     */
+    Optional<String> getSmallImageValue();
+
+    /**
      * Gets the small image of the asset.
+     * Always empty for activities of other services like Spotify, YouTube, etc.
      *
      * @return The small image of the asset.
      */

--- a/javacord-core/src/main/java/org/javacord/core/entity/activity/ActivityAssetsImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/activity/ActivityAssetsImpl.java
@@ -5,7 +5,6 @@ import org.javacord.api.Javacord;
 import org.javacord.api.entity.Icon;
 import org.javacord.api.entity.activity.ActivityAssets;
 import org.javacord.core.entity.IconImpl;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Objects;
@@ -28,15 +27,20 @@ public class ActivityAssetsImpl implements ActivityAssets {
      * Creates a new activity assets object.
      *
      * @param activity The associated activity.
-     * @param data The json data of the assets party.
+     * @param data     The json data of the assets party.
      */
     public ActivityAssetsImpl(ActivityImpl activity, JsonNode data) {
         this.activity = activity;
 
-        this.largeImage = data.has("large_image") ? data.get("large_image").asText(null) : null;
-        this.largeText = data.has("large_text") ? data.get("large_text").asText(null) : null;
-        this.smallImage = data.has("small_image") ? data.get("small_image").asText(null) : null;
-        this.smallText = data.has("small_text") ? data.get("small_text").asText(null) : null;
+        this.largeImage = data.hasNonNull("large_image") ? data.get("large_image").asText() : null;
+        this.largeText = data.hasNonNull("large_text") ? data.get("large_text").asText() : null;
+        this.smallImage = data.hasNonNull("small_image") ? data.get("small_image").asText() : null;
+        this.smallText = data.hasNonNull("small_text") ? data.get("small_text").asText() : null;
+    }
+
+    @Override
+    public Optional<String> getLargeImageValue() {
+        return Optional.ofNullable(largeImage);
     }
 
     @Override
@@ -57,6 +61,11 @@ public class ActivityAssetsImpl implements ActivityAssets {
     @Override
     public Optional<String> getLargeText() {
         return Optional.ofNullable(largeText);
+    }
+
+    @Override
+    public Optional<String> getSmallImageValue() {
+        return Optional.ofNullable(smallImage);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/activity/ActivityImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/activity/ActivityImpl.java
@@ -10,7 +10,6 @@ import org.javacord.api.entity.activity.ActivityType;
 import org.javacord.api.entity.emoji.Emoji;
 import org.javacord.core.DiscordApiImpl;
 import org.javacord.core.entity.emoji.UnicodeEmojiImpl;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,15 +49,15 @@ public class ActivityImpl implements Activity {
     public ActivityImpl(DiscordApiImpl api, JsonNode data) {
         this.type = ActivityType.getActivityTypeById(data.get("type").asInt());
         this.name = data.get("name").asText();
-        this.streamingUrl = data.has("url") ? data.get("url").asText(null) : null;
-        this.details = data.has("details") ? data.get("details").asText(null) : null;
-        this.state = data.has("state") ? data.get("state").asText(null) : null;
-        this.party = data.has("party") ? new ActivityPartyImpl(data.get("party")) : null;
-        this.assets = data.has("assets") ? new ActivityAssetsImpl(this, data.get("assets")) : null;
-        this.secrets = data.has("secrets") ? new ActivitySecretsImpl(data.get("secrets")) : null;
-        this.applicationId = data.has("application_id") ? data.get("application_id").asLong() : null;
+        this.streamingUrl = data.hasNonNull("url") ? data.get("url").asText() : null;
+        this.details = data.hasNonNull("details") ? data.get("details").asText() : null;
+        this.state = data.hasNonNull("state") ? data.get("state").asText() : null;
+        this.party = data.hasNonNull("party") ? new ActivityPartyImpl(data.get("party")) : null;
+        this.assets = data.hasNonNull("assets") ? new ActivityAssetsImpl(this, data.get("assets")) : null;
+        this.secrets = data.hasNonNull("secrets") ? new ActivitySecretsImpl(data.get("secrets")) : null;
+        this.applicationId = data.hasNonNull("application_id") ? data.get("application_id").asLong() : null;
         this.createdAt = Instant.ofEpochMilli(data.get("created_at").asLong());
-        this.instance = data.has("instance") && data.get("instance").asBoolean();
+        this.instance = data.hasNonNull("instance") && data.get("instance").asBoolean();
 
         if (data.has("timestamps")) {
             JsonNode timestamps = data.get("timestamps");

--- a/javacord-core/src/main/java/org/javacord/core/entity/activity/ActivityPartyImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/activity/ActivityPartyImpl.java
@@ -21,7 +21,7 @@ public class ActivityPartyImpl implements ActivityParty {
      * @param data The json data of the activity party.
      */
     public ActivityPartyImpl(JsonNode data) {
-        this.id = data.has("id") ? data.get("id").asText(null) : null;
+        this.id = data.hasNonNull("id") ? data.get("id").asText() : null;
         if (data.has("size")) {
             // The size is an array with two integers
             this.currentSize = data.get("size").get(0).asInt();


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Added getters to get `ActivityAssets` image urls (`ActivityAssets#getLargeImage` only works for application assets from Discord (excludes Activities from other services like Spotify, YouTube etc.)).

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.