### PR TITLE
Fix migrated accounts default avatar URLs

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
@@ -225,7 +225,7 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
         StringBuilder url = new StringBuilder("https://" + Javacord.DISCORD_CDN_DOMAIN + "/");
         if (avatarHash == null) {
             url.append("embed/avatars/")
-                    .append(Integer.parseInt(discriminator) % 5)
+                    .append(discriminator.equals("0") ? (userId >> 22) % 6 : Integer.parseInt(discriminator) % 5)
                     .append(".png");
         } else {
             url.append("avatars/")


### PR DESCRIPTION
## Checklist
- [X] I have tested this PR
- [X] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

## Changelog
- Fix migrated accounts default avatar URLs

## Description
According [discord api docs](https://discord.com/developers/docs/change-log#unique-usernames-on-discord), migrated accounts will use `(userId >> 22) % 6` instead of `discriminator % 5`