### PR TITLE
Use sets instead of lists for user roles collections in server updater

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerUpdaterDelegateImpl.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -57,7 +58,7 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
     /**
      * A map with all user roles to update.
      */
-    private final Map<User, Collection<Role>> userRoles = new HashMap<>();
+    private final Map<User, Set<Role>> userRoles = new HashMap<>();
 
     /**
      * A map with all user nicknames to update.
@@ -516,31 +517,31 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
 
     @Override
     public void addRoleToUser(User user, Role role) {
-        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
+        Set<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
         userRoles.add(role);
     }
 
     @Override
     public void addRolesToUser(User user, Collection<Role> roles) {
-        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
+        Set<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
         userRoles.addAll(roles);
     }
 
     @Override
     public void removeRoleFromUser(User user, Role role) {
-        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
+        Set<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
         userRoles.remove(role);
     }
 
     @Override
     public void removeRolesFromUser(User user, Collection<Role> roles) {
-        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
+        Set<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
         userRoles.removeAll(roles);
     }
 
     @Override
     public void removeAllRolesFromUser(User user) {
-        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
+        Set<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
         userRoles.clear();
     }
 
@@ -561,7 +562,7 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
             boolean patchMember = false;
             ObjectNode updateNode = JsonNodeFactory.instance.objectNode();
 
-            Collection<Role> roles = userRoles.get(member);
+            Set<Role> roles = userRoles.get(member);
             if (roles != null) {
                 ArrayNode rolesJson = updateNode.putArray("roles");
                 roles.stream()

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerUpdaterDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerUpdaterDelegateImpl.java
@@ -516,31 +516,31 @@ public class ServerUpdaterDelegateImpl implements ServerUpdaterDelegate {
 
     @Override
     public void addRoleToUser(User user, Role role) {
-        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new ArrayList<>(server.getRoles(u)));
+        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
         userRoles.add(role);
     }
 
     @Override
     public void addRolesToUser(User user, Collection<Role> roles) {
-        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new ArrayList<>(server.getRoles(u)));
+        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
         userRoles.addAll(roles);
     }
 
     @Override
     public void removeRoleFromUser(User user, Role role) {
-        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new ArrayList<>(server.getRoles(u)));
+        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
         userRoles.remove(role);
     }
 
     @Override
     public void removeRolesFromUser(User user, Collection<Role> roles) {
-        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new ArrayList<>(server.getRoles(u)));
+        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
         userRoles.removeAll(roles);
     }
 
     @Override
     public void removeAllRolesFromUser(User user) {
-        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new ArrayList<>(server.getRoles(u)));
+        Collection<Role> userRoles = this.userRoles.computeIfAbsent(user, u -> new HashSet<>(server.getRoles(u)));
         userRoles.clear();
     }
 


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- replaced internal collection type for user roles in the server updater with sets

### Breaking Changes

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description

if you add the same role twice to the server updater, Javacord will currently send it twice, causing this error:

```
{
   "message":"Invalid Form Body",
   "code":50035,
   "errors":{
      "roles":{
         "2":{
            "_errors":[
               {
                  "code":"SET_TYPE_ALREADY_CONTAINS_VALUE",
                  "message":"The set already contains this value"
               }
            ]
         }
      }
   }
}
```

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.