### PR TITLE
Fix wrong initialization for SlashCommandOptionChoice#getLongValue

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionChoiceImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/interaction/SlashCommandOptionChoiceImpl.java
@@ -33,7 +33,7 @@ public class SlashCommandOptionChoiceImpl implements SlashCommandOptionChoice {
         } else {
             stringValue = null;
         }
-        if (data.get("value").isLong()) {
+        if (data.get("value").canConvertToLong()) {
             longValue = data.get("value").asLong();
         } else {
             longValue = null;


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Fixed SlashCommandOptionChoice#getLongValue not being initialized due to a wrongly used method of jackson to check for a long value

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: #1256 

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.