### PR TITLE
Added a way to set bot activity and custom status when creating bot

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -521,6 +521,15 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
     void updateActivity(ActivityType type, String name);
 
     /**
+     * Updates the activity of this bot with any type.
+     *
+     * @param type The type of the activity.
+     * @param name The name of the activity.
+     * @param state The state of the activity.
+     */
+    void updateActivity(ActivityType type, String name, String state);
+
+    /**
      * Updates the activity of this bot with a streaming url, represented as "Streaming Half-Life 3" for example.
      * The update might not be visible immediately as it's through the websocket and only a limited amount of
      * activity status changes is allowed per minute.
@@ -529,6 +538,17 @@ public interface DiscordApi extends GloballyAttachableListenerManager {
      * @param streamingUrl The streaming url of the activity.
      */
     void updateActivity(String name, String streamingUrl);
+
+    /**
+     * Updates the activity of this bot with a streaming url, represented as "Streaming Half-Life 3" for example.
+     * The update might not be visible immediately as it's through the websocket and only a limited amount of
+     * activity status changes is allowed per minute.
+     *
+     * @param name The name of the activity.
+     * @param streamingUrl The streaming url of the activity.
+     * @param state The state of the activity.
+     */
+    void updateActivity(String name, String streamingUrl, String state);
 
     /**
      * Unsets the activity of this bot.

--- a/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
@@ -1,5 +1,6 @@
 package org.javacord.api;
 
+import org.javacord.api.entity.activity.Activity;
 import org.javacord.api.entity.intent.Intent;
 import org.javacord.api.entity.message.MessageBuilder;
 import org.javacord.api.entity.message.mention.AllowedMentions;
@@ -230,6 +231,17 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
     }
 
     /**
+     * Sets the activity of the bot.
+     *
+     * @param activity The activity to set.
+     * @return The current instance in order to chain call methods.
+     */
+    public DiscordApiBuilder setActivity(Activity activity) {
+        delegate.setActivity(activity);
+        return this;
+    }
+
+    /**
      * Gets the token that will be used to login.
      *
      * @return The token.
@@ -237,6 +249,16 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
      */
     public Optional<String> getToken() {
         return delegate.getToken();
+    }
+
+    /**
+     * Gets the activity that will be used to log in.
+     *
+     * @return The activity.
+     * @see #setActivity(Activity) 
+     */
+    public Optional<Activity> getActivity() {
+        return delegate.getActivity();
     }
 
     /**

--- a/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/internal/DiscordApiBuilderDelegate.java
@@ -2,6 +2,7 @@ package org.javacord.api.internal;
 
 import org.javacord.api.DiscordApi;
 import org.javacord.api.DiscordApiBuilder;
+import org.javacord.api.entity.activity.Activity;
 import org.javacord.api.entity.intent.Intent;
 import org.javacord.api.entity.message.MessageBuilder;
 import org.javacord.api.entity.message.mention.AllowedMentions;
@@ -82,11 +83,25 @@ public interface DiscordApiBuilderDelegate {
     void setToken(String token);
 
     /**
+     * Sets the activity of the bot.
+     *
+     * @param activity The activity to set.
+     */
+    void setActivity(Activity activity);
+
+    /**
      * Gets the token.
      *
      * @return The token.
      */
     Optional<String> getToken();
+
+    /**
+     * Gets the activity of the bot.
+     *
+     * @return The activity of the bot.
+     */
+    Optional<Activity> getActivity();
 
     /**
      * Sets the total shards.

--- a/javacord-core/src/main/java/org/javacord/core/BotActivity.java
+++ b/javacord-core/src/main/java/org/javacord/core/BotActivity.java
@@ -1,0 +1,131 @@
+package org.javacord.core;
+
+import org.javacord.api.entity.activity.Activity;
+import org.javacord.api.entity.activity.ActivityType;
+import org.javacord.core.entity.activity.ActivityImpl;
+
+/**
+ * Used to set the activity of the bot.
+ */
+public class BotActivity {
+    /**
+     * Sets the activity of the bot to "Watching".
+     *
+     * @param name The name of the activity.
+     * @param url The url of the activity.
+     * @param state The state of the activity.
+     * @return The bots activity.
+     */
+    public static Activity watching(String name, String url, String state) {
+        return new ActivityImpl(ActivityType.WATCHING, name, url, state);
+    }
+
+    /**
+     * Sets the activity of the bot to "Watching".
+     *
+     * @param name The name of the activity.
+     * @param url The url of the activity.
+     * @return The bots activity.
+     */
+    public static Activity watching(String name, String url) {
+        return new ActivityImpl(ActivityType.WATCHING, name, url, null);
+    }
+
+    /**
+     * Sets the activity of the bot to "Playing".
+     *
+     * @param name The name of the activity.
+     * @param state The state of the activity.
+     * @return The bots activity.
+     */
+    public static Activity playing(String name, String state) {
+        return new ActivityImpl(ActivityType.PLAYING, name, null, state);
+    }
+
+    /**
+     * Sets the activity of the bot to "Playing".
+     *
+     * @param name The name of the activity.
+     * @return The bots activity.
+     */
+    public static Activity playing(String name) {
+        return new ActivityImpl(ActivityType.PLAYING, name, null, null);
+    }
+
+    /**
+     * Sets the activity of the bot to "Listening".
+     *
+     * @param name The name of the activity.
+     * @param state The state of the activity.
+     * @return The bots activity.
+     */
+    public static Activity listening(String name, String state) {
+        return new ActivityImpl(ActivityType.LISTENING, name, null, state);
+    }
+
+    /**
+     * Sets the activity of the bot to "Listening".
+     *
+     * @param name The name of the activity.
+     * @return The bots activity.
+     */
+    public static Activity listening(String name) {
+        return new ActivityImpl(ActivityType.LISTENING, name, null, null);
+    }
+
+    /**
+     * Sets the activity of the bot to "Streaming".
+     *
+     * @param name The name of the activity.
+     * @param url The url of the activity.
+     * @param state The state of the activity.
+     * @return The bots activity.
+     */
+    public static Activity streaming(String name, String url, String state) {
+        return new ActivityImpl(ActivityType.LISTENING, name, url, state);
+    }
+
+    /**
+     * Sets the activity of the bot to "Streaming".
+     *
+     * @param name The name of the activity.
+     * @param url The url of the activity.
+     * @return The bots activity.
+     */
+    public static Activity streaming(String name, String url) {
+        return new ActivityImpl(ActivityType.LISTENING, name, url, null);
+    }
+
+    /**
+     * Sets a custom activity.
+     *
+     * @param state The state of the activity.
+     * @return The bots activity.
+     */
+    public static Activity custom(String state) {
+        return new ActivityImpl(ActivityType.CUSTOM, state, null, null);
+    }
+
+    /**
+     * Sets a chosen type of activity.
+     *
+     * @param type The type of activity.
+     * @param name The name of the activity.
+     * @param state The state of the activity.
+     * @return The bots activity.
+     */
+    public static Activity of(ActivityType type, String name, String state) {
+        return new ActivityImpl(type, name, null, state);
+    }
+
+    /**
+     * Sets a chosen type of activity.
+     *
+     * @param type The type of activity.
+     * @param name The name of the activity.
+     * @return The bots activity.
+     */
+    public static Activity of(ActivityType type, String name) {
+        return new ActivityImpl(type, name, null, null);
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiBuilderDelegateImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiBuilderDelegateImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.CloseableThreadContext;
 import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.activity.Activity;
 import org.javacord.api.entity.intent.Intent;
 import org.javacord.api.entity.message.mention.AllowedMentions;
 import org.javacord.api.internal.DiscordApiBuilderDelegate;
@@ -188,6 +189,11 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
      */
     private volatile List<Function<DiscordApi,GloballyAttachableListener>> preparedUnspecifiedListeners;
 
+    /**
+     * The bots activity.
+     */
+    private volatile Activity activity = null;
+
 
     @Override
     public CompletableFuture<DiscordApi> login() {
@@ -204,7 +210,7 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
                     waitForServersOnStartup, waitForUsersOnStartup, registerShutdownHook, globalRatelimiter,
                     gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator, trustAllCertificates,
                     future, null, preparedListeners, preparedUnspecifiedListeners, userCacheEnabled, dispatchEvents,
-                    allowedMentions);
+                    allowedMentions, activity);
         }
         return future;
     }
@@ -324,8 +330,18 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
     }
 
     @Override
+    public void setActivity(Activity activity) {
+        this.activity = activity;
+    }
+
+    @Override
     public Optional<String> getToken() {
         return Optional.ofNullable(token);
+    }
+
+    @Override
+    public Optional<Activity> getActivity() {
+        return Optional.ofNullable(activity);
     }
 
     @Override
@@ -436,7 +452,7 @@ public class DiscordApiBuilderDelegateImpl implements DiscordApiBuilderDelegate 
     private void setRecommendedTotalShards(CompletableFuture<Void> future) {
         DiscordApiImpl api = new DiscordApiImpl(
                 token, globalRatelimiter, gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator,
-                trustAllCertificates);
+                trustAllCertificates, activity);
         RestRequest<JsonNode> botGatewayRequest = new RestRequest<>(api, RestMethod.GET, RestEndpoint.GATEWAY_BOT);
         botGatewayRequest
                 .execute(RestRequestResult::getJsonBody)

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -59,7 +59,6 @@ import org.javacord.api.util.event.ListenerManager;
 import org.javacord.api.util.ratelimit.LocalRatelimiter;
 import org.javacord.api.util.ratelimit.Ratelimiter;
 import org.javacord.core.audio.AudioConnectionImpl;
-import org.javacord.core.entity.activity.ActivityImpl;
 import org.javacord.core.entity.activity.ApplicationInfoImpl;
 import org.javacord.core.entity.emoji.CustomEmojiImpl;
 import org.javacord.core.entity.emoji.KnownCustomEmojiImpl;
@@ -433,12 +432,14 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * @param proxyAuthenticator         The authenticator that should be used to authenticate against proxies that
      *                                   require it.
      * @param trustAllCertificates       Whether to trust all SSL certificates.
+     * @param activity                   The activity of the bot.
      */
     public DiscordApiImpl(String token, Ratelimiter globalRatelimiter, Ratelimiter gatewayIdentifyRatelimiter,
                           ProxySelector proxySelector, Proxy proxy, Authenticator proxyAuthenticator,
-                          boolean trustAllCertificates) {
+                          boolean trustAllCertificates, Activity activity) {
         this(token, 0, 1, Collections.emptySet(), true, false, globalRatelimiter,
-                gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator, trustAllCertificates, null);
+                gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator, trustAllCertificates, null,
+                activity);
     }
 
     /**
@@ -463,6 +464,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * @param trustAllCertificates       Whether to trust all SSL certificates.
      * @param ready                      The future which will be completed when the connection to Discord was
      *                                   successful.
+     * @param activity                   The activity of the bot.
      */
     public DiscordApiImpl(
             String token,
@@ -477,11 +479,13 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             Proxy proxy,
             Authenticator proxyAuthenticator,
             boolean trustAllCertificates,
-            CompletableFuture<DiscordApi> ready
+            CompletableFuture<DiscordApi> ready,
+            Activity activity
     ) {
         this(token, currentShard, totalShards, intents, waitForServersOnStartup, waitForUsersOnStartup,
                 true, globalRatelimiter, gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator,
-                trustAllCertificates, ready, null, Collections.emptyMap(), Collections.emptyList(), false, true, null);
+                trustAllCertificates, ready, null, Collections.emptyMap(), Collections.emptyList(), false,
+                true, null, activity);
     }
 
     /**
@@ -508,6 +512,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      *                                   successful.
      * @param dns                        The DNS instance to use in the OkHttp client. This should only be used in
      *                                   testing.
+     * @param activity                   The activity of the bot.
      */
     private DiscordApiImpl(
             String token,
@@ -523,10 +528,12 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             Authenticator proxyAuthenticator,
             boolean trustAllCertificates,
             CompletableFuture<DiscordApi> ready,
-            Dns dns) {
+            Dns dns,
+            Activity activity) {
         this(token, currentShard, totalShards, intents, waitForServersOnStartup, waitForUsersOnStartup,
                 true, globalRatelimiter, gatewayIdentifyRatelimiter, proxySelector, proxy, proxyAuthenticator,
-                trustAllCertificates, ready, dns, Collections.emptyMap(), Collections.emptyList(), false, true, null);
+                trustAllCertificates, ready, dns, Collections.emptyMap(), Collections.emptyList(), false,
+                true, null, activity);
     }
 
     /**
@@ -559,6 +566,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
      * @param userCacheEnabled           Whether the user cache should be enabled.
      * @param dispatchEvents             Whether events can be dispatched.
      * @param defaultAllowedMentions     Controls who will be mentioned if mentions exist in a message.
+     * @param activity                   The activity of the bot.
      */
     @SuppressWarnings("unchecked")
     public DiscordApiImpl(
@@ -583,7 +591,8 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
             List<Function<DiscordApi, GloballyAttachableListener>> unspecifiedListeners,
             boolean userCacheEnabled,
             boolean dispatchEvents,
-            AllowedMentions defaultAllowedMentions
+            AllowedMentions defaultAllowedMentions,
+            Activity activity
     ) {
         this.token = token;
         this.currentShard = currentShard;
@@ -603,6 +612,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
                 (int) Math.round(Math.pow(x, 1.5) - (1 / (1 / (0.1 * x) + 1)) * Math.pow(x, 1.5));
         //Always add the GUILDS intent unless it is not required anymore for Javacord to be functional.
         this.intents = Stream.concat(intents.stream(), Stream.of(Intent.GUILDS)).collect(Collectors.toSet());
+        this.activity = activity;
 
         if ((proxySelector != null) && (proxy != null)) {
             throw new IllegalStateException("proxy and proxySelector must not be configured both");
@@ -622,6 +632,7 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
                 )
                 .proxyAuthenticator(new ProxyAuthenticator(proxyAuthenticator))
                 .proxy(proxy);
+
         if (proxySelector != null) {
             httpClientBuilder.proxySelector(proxySelector);
         }
@@ -1840,40 +1851,41 @@ public class DiscordApiImpl implements DiscordApi, DispatchQueueSelector {
     /**
      * Sets the current activity, along with type and streaming Url.
      *
-     * @param type         The activity's type.
-     * @param name         The name of the activity.
-     * @param streamingUrl The Url used for streaming.
+     * @param activity The activity to set.
      */
-    private void updateActivity(ActivityType type, String name, String streamingUrl) {
-        if (name == null) {
-            activity = null;
-        } else if (streamingUrl == null) {
-            activity = new ActivityImpl(type, name, null);
-        } else {
-            activity = new ActivityImpl(type, name, streamingUrl);
-        }
+    private void updateActivity(Activity activity) {
+        this.activity = activity;
         websocketAdapter.updateStatus();
     }
 
-
     @Override
     public void updateActivity(String name) {
-        updateActivity(ActivityType.PLAYING, name, null);
+        updateActivity(BotActivity.playing(name));
     }
 
     @Override
     public void updateActivity(ActivityType type, String name) {
-        updateActivity(type, name, null);
+        updateActivity(BotActivity.of(type, name));
+    }
+
+    @Override
+    public void updateActivity(ActivityType type, String name, String state) {
+        updateActivity(BotActivity.of(type, name, state));
     }
 
     @Override
     public void updateActivity(String name, String streamingUrl) {
-        updateActivity(ActivityType.STREAMING, name, streamingUrl);
+        updateActivity(BotActivity.streaming(name, streamingUrl));
+    }
+
+    @Override
+    public void updateActivity(String name, String streamingUrl, String state) {
+        updateActivity(BotActivity.streaming(name, streamingUrl, state));
     }
 
     @Override
     public void unsetActivity() {
-        updateActivity(null);
+        this.updateActivity((Activity) null);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/activity/ActivityImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/activity/ActivityImpl.java
@@ -17,6 +17,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * The implementation of {@link Activity}.
@@ -97,21 +98,38 @@ public class ActivityImpl implements Activity {
      * @param type         The type of the activity.
      * @param name         The name of the activity.
      * @param streamingUrl The streamingUrl of the activity.
+     * @param state        The user's party status.
      */
-    public ActivityImpl(ActivityType type, String name, String streamingUrl) {
+    public ActivityImpl(ActivityType type, String name, String streamingUrl, String state) {
+        final Pattern allowedStreamingUrls = Pattern.compile(
+                "https?://(www\\.)?(twitch\\.tv/|youtube\\.com/watch\\?v=).+", Pattern.CASE_INSENSITIVE);
+
+        if (name != null && name.length() > 128) {
+            throw new IllegalArgumentException("The name of the activity must not be longer than 128 characters!");
+        }
+
+        if (streamingUrl != null && !allowedStreamingUrls.matcher(streamingUrl).matches()) {
+            throw new IllegalArgumentException("The url must be a valid twitch or youtube url!");
+        }
+
+        if (state != null && state.length() > 128) {
+            throw new IllegalArgumentException(
+                    "The state of the activity must not be longer than 128 characters!");
+        }
+
         this.type = type;
         this.name = name;
         this.streamingUrl = streamingUrl;
+        this.state = state;
+        this.emoji = null;
         this.createdAt = null;
         this.details = null;
-        this.state = null;
         this.party = null;
         this.assets = null;
         this.secrets = null;
         this.applicationId = null;
         this.startTime = null;
         this.endTime = null;
-        this.emoji = null;
         this.instance = null;
     }
 

--- a/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
+++ b/javacord-core/src/test/groovy/org/javacord/core/DiscordApiImplTest.groovy
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletionException
 class DiscordApiImplTest extends Specification {
 
     @Subject
-    def api = new DiscordApiImpl(null, null, null, null, null, null, false)
+    def api = new DiscordApiImpl(null, null, null, null, null, null, false, null)
 
     def 'getAllServers returns all servers'() {
         given:
@@ -96,7 +96,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setHttpSystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, false)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, false, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -113,7 +113,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setHttpSystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -129,7 +129,7 @@ class DiscordApiImplTest extends Specification {
 
     def 'allowing man-in-the-middle attacks logs a warning on api instantiation'() {
         when:
-            new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
+            new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true, null)
 
         then:
             def expectedWarning = 'All SSL certificates are trusted when connecting to the Discord API and websocket.' +
@@ -146,7 +146,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setHttpSystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -167,7 +167,7 @@ class DiscordApiImplTest extends Specification {
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             def defaultProxySelector = ProxySelector.default
             ProxySelector.default = MockProxyManager.proxySelector
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -189,7 +189,7 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.mockProxy.when(
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -205,7 +205,7 @@ class DiscordApiImplTest extends Specification {
 
     def 'configuring proxy and proxySelector throws an IllegalStateException'() {
         when:
-            new DiscordApiImpl('fakeBotToken', null, null, Stub(ProxySelector), Proxy.NO_PROXY, null, true)
+            new DiscordApiImpl('fakeBotToken', null, null, Stub(ProxySelector), Proxy.NO_PROXY, null, true, null)
 
         then:
             IllegalStateException ise = thrown()
@@ -217,7 +217,7 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.mockProxy.when(
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
-            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.proxySelector, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.proxySelector, null, null, true, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -249,7 +249,7 @@ class DiscordApiImplTest extends Specification {
             Authenticator.default = Mock(Authenticator) {
                 (1.._) * getPasswordAuthentication() >> new PasswordAuthentication(username, password as char[])
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -284,7 +284,7 @@ class DiscordApiImplTest extends Specification {
             org.javacord.api.util.auth.Authenticator authenticator = Mock {
                 (1.._) * authenticate(_, _, _) >> [(HttpHeaderNames.PROXY_AUTHORIZATION as String): [null, credentials]]
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, authenticator, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, authenticator, true, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -317,7 +317,7 @@ class DiscordApiImplTest extends Specification {
 
         and:
             def api = new DiscordApiImpl('fakeBotToken', 0, 1, Collections.emptySet(), false, false, null, null, null, null,
-                    null, true, null, { [InetAddress.getLoopbackAddress()] })
+                    null, true, null, { [InetAddress.getLoopbackAddress()] }, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -346,7 +346,7 @@ class DiscordApiImplTest extends Specification {
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
             MockProxyManager.setSocks5SystemProperties()
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -374,7 +374,7 @@ class DiscordApiImplTest extends Specification {
             MockProxyManager.mockProxy.when(
                     HttpRequest.request()
             ) respond HttpResponse.response().withStatusCode(HttpURLConnection.HTTP_NOT_FOUND)
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.socksProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.socksProxy, null, true, null)
 
         and:
             def username = UUID.randomUUID().toString()
@@ -424,7 +424,7 @@ class DiscordApiImplTest extends Specification {
                 void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
                 }
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, null, true, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -462,7 +462,7 @@ class DiscordApiImplTest extends Specification {
                 void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
                 }
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.proxySelector, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, MockProxyManager.proxySelector, null, null, true, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -489,7 +489,7 @@ class DiscordApiImplTest extends Specification {
             System.properties.'https.proxyPort' = '1'
             def defaultProxySelector = ProxySelector.default
             ProxySelector.default = MockProxyManager.proxySelector
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, null, null, true, null)
 
         when:
             api.requestApplicationInfo().join()
@@ -528,7 +528,7 @@ class DiscordApiImplTest extends Specification {
             org.javacord.api.util.auth.Authenticator authenticator = Mock {
                 (1.._) * authenticate(_, _, _) >> [(HttpHeaderNames.PROXY_AUTHORIZATION as String): [null, credentials]]
             }
-            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, authenticator, true)
+            def api = new DiscordApiImpl('fakeBotToken', null, null, null, MockProxyManager.httpProxy, authenticator, true, null)
 
         when:
             api.requestApplicationInfo().join()


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Currently only activity can be set after bot has started.

### Breaking Changes

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description
Added ability to set activity as it starts.
```java
String token = "your token";

        DiscordApi api = new DiscordApiBuilder().setToken(token)
                .setActivity(BotActivity.playing("with Javacord")).login().join();

or for example
new DiscordApiBuilder().setToken(token)
                .setActivity(BotActivity.custom("with Javacord")).login().join();

or for example
new DiscordApiBuilder().setToken(token)
                .setActivity(BotActivity.playing("JavaCord", "in IDE")).login().join();

```

<img width="337" alt="image" src="https://github.com/Javacord/Javacord/assets/67903886/e7fbbb9e-610f-410f-be6a-709414ec3f90">

<img width="486" alt="image" src="https://github.com/Javacord/Javacord/assets/67903886/9b686a94-aea4-49b6-b9d6-a2720b97b577">

<img width="472" alt="image" src="https://github.com/Javacord/Javacord/assets/67903886/d7889576-72e6-44ea-bae7-98b7d037ad7b">



<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.