### PR TITLE
Convenient constructors and a static method for DiscordApiBuilder.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApiBuilder.java
@@ -33,6 +33,42 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
     private final DiscordApiBuilderDelegate delegate = DelegateFactory.createDiscordApiBuilderDelegate();
 
     /**
+     * Default no-argument constructor.
+     */
+    public DiscordApiBuilder() {
+    }
+
+    /**
+     * Constructor that sets the bot token.
+     *
+     * @param token The bot token.
+     */
+    public DiscordApiBuilder(String token) {
+        this.setToken(token);
+    }
+
+    /**
+     * Static method that accepts the bot token and returns DiscordApi, ready for use. This method sets no intent.
+     *
+     * @param token The bot token.
+     * @return Resulting DiscordApi.
+     */
+    public static DiscordApi login(String token) {
+        return new DiscordApiBuilder(token).login().join();
+    }
+
+    /**
+     * Static method that accepts the bot token and returns DiscordApi with specified intents.
+     *
+     * @param token   The bot token.
+     * @param intents Intents of the bot.
+     * @return Resulting DiscordApi.
+     */
+    public static DiscordApi login(String token, Intent... intents) {
+        return new DiscordApiBuilder(token).setIntents(intents).login().join();
+    }
+
+    /**
      * Login to the account with the given token.
      *
      * @return A {@link CompletableFuture} which contains the DiscordApi.
@@ -498,7 +534,7 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
 
     @Override
     public <T extends GloballyAttachableListener> DiscordApiBuilder addListener(
-                                            Class<T> listenerClass, Supplier<T> listenerSupplier) {
+            Class<T> listenerClass, Supplier<T> listenerSupplier) {
         delegate.addListener(listenerClass, listenerSupplier);
         return this;
     }
@@ -511,7 +547,7 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
 
     @Override
     public <T extends GloballyAttachableListener> DiscordApiBuilder addListener(
-                                Class<T> listenerClass, Function<DiscordApi, T> listenerFunction) {
+            Class<T> listenerClass, Function<DiscordApi, T> listenerFunction) {
         delegate.addListener(listenerClass, listenerFunction);
         return this;
     }
@@ -542,7 +578,7 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
 
     @Override
     public <T extends GloballyAttachableListener> DiscordApiBuilder removeListenerSupplier(
-                                                            Class<T> listenerClass, Supplier<T> listenerSupplier) {
+            Class<T> listenerClass, Supplier<T> listenerSupplier) {
         delegate.removeListenerSupplier(listenerClass, listenerSupplier);
         return this;
     }
@@ -555,7 +591,7 @@ public class DiscordApiBuilder implements ChainableGloballyAttachableListenerMan
 
     @Override
     public <T extends GloballyAttachableListener> DiscordApiBuilder removeListenerFunction(
-                                                    Class<T> listenerClass, Function<DiscordApi, T> listenerFunction) {
+            Class<T> listenerClass, Function<DiscordApi, T> listenerFunction) {
         delegate.removeListenerFunction(listenerClass, listenerFunction);
         return this;
     }


### PR DESCRIPTION
## Checklist
- [x] I have tested this PR.
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

### Breaking Changes

None.

## Description

Users may use new constructors or static method to more conveniently login and get DiscordApi. IDE also formatted the code to comply with the suggested 120 column limit as per the [Contributing Guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).