### PR TITLE
Add a dedicated listener for server thread joins

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/event/channel/thread/ThreadJoinEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/channel/thread/ThreadJoinEvent.java
@@ -1,0 +1,7 @@
+package org.javacord.api.event.channel.thread;
+
+import org.javacord.api.event.channel.server.ServerChannelEvent;
+
+public interface ThreadJoinEvent extends ServerChannelEvent {
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/channel/server/thread/ServerThreadChannelJoinListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/channel/server/thread/ServerThreadChannelJoinListener.java
@@ -1,0 +1,21 @@
+package org.javacord.api.listener.channel.server.thread;
+
+import org.javacord.api.event.channel.thread.ThreadJoinEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.channel.ServerThreadChannelAttachableListener;
+
+/**
+ * This listener listens to thread joins.
+ */
+@FunctionalInterface
+public interface ServerThreadChannelJoinListener extends GloballyAttachableListener,
+        ServerThreadChannelAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called every time a bot joins a thread.
+     *
+     * @param event The event.
+     */
+    void onThreadJoin(ThreadJoinEvent event);
+}

--- a/javacord-core/src/main/java/org/javacord/core/event/channel/thread/ThreadJoinEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/channel/thread/ThreadJoinEventImpl.java
@@ -1,0 +1,34 @@
+package org.javacord.core.event.channel.thread;
+
+import org.javacord.api.entity.channel.ServerThreadChannel;
+import org.javacord.api.entity.server.Server;
+import org.javacord.api.event.channel.thread.ThreadJoinEvent;
+import org.javacord.core.event.channel.server.ServerChannelEventImpl;
+
+public class ThreadJoinEventImpl extends ServerChannelEventImpl implements ThreadJoinEvent {
+
+    /**
+     * The channel of the event.
+     */
+    private final ServerThreadChannel serverThreadChannel;
+
+    /**
+     * Creates a new thread join event.
+     *
+     * @param serverThreadChannel The channel of the event.
+     */
+    public ThreadJoinEventImpl(final ServerThreadChannel serverThreadChannel) {
+        super(serverThreadChannel);
+        this.serverThreadChannel = serverThreadChannel;
+    }
+
+    @Override
+    public ServerThreadChannel getChannel() {
+        return serverThreadChannel;
+    }
+
+    @Override
+    public Server getServer() {
+        return serverThreadChannel.getServer();
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/handler/channel/thread/ThreadCreateHandler.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/handler/channel/thread/ThreadCreateHandler.java
@@ -6,8 +6,10 @@ import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.api.entity.channel.ServerThreadChannel;
 import org.javacord.api.event.channel.thread.ThreadCreateEvent;
+import org.javacord.api.event.channel.thread.ThreadJoinEvent;
 import org.javacord.core.entity.server.ServerImpl;
 import org.javacord.core.event.channel.thread.ThreadCreateEventImpl;
+import org.javacord.core.event.channel.thread.ThreadJoinEventImpl;
 import org.javacord.core.util.event.DispatchQueueSelector;
 import org.javacord.core.util.gateway.PacketHandler;
 import org.javacord.core.util.logging.LoggerUtil;
@@ -52,10 +54,17 @@ public class ThreadCreateHandler extends PacketHandler {
         api.getPossiblyUnreadyServerById(serverId).ifPresent(server -> {
             final ServerThreadChannel serverThreadChannel =
                     ((ServerImpl) server).getOrCreateServerThreadChannel(channel);
-            final ThreadCreateEvent event = new ThreadCreateEventImpl(serverThreadChannel);
 
-            api.getEventDispatcher()
-                    .dispatchThreadCreateEvent((DispatchQueueSelector) server, serverThreadChannel, event);
+
+            if (channel.hasNonNull("newly_created") && channel.get("newly_created").asBoolean()) {
+                final ThreadCreateEvent event = new ThreadCreateEventImpl(serverThreadChannel);
+                api.getEventDispatcher()
+                        .dispatchThreadCreateEvent((DispatchQueueSelector) server, serverThreadChannel, event);
+            } else {
+                final ThreadJoinEvent event = new ThreadJoinEventImpl(serverThreadChannel);
+                api.getEventDispatcher()
+                        .dispatchThreadJoinEvent((DispatchQueueSelector) server, serverThreadChannel, event);
+            }
         });
     }
 }


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->

### Breaking Changes
- If you are using the `ServerThreadChannelCreateListener` to listen to thread joins, this will no longer work. Instead use the new `ServerThreadChannelJoinListener`

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: #1262

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.