### PR TITLE
Fix archived thread getters

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannel.java
@@ -191,7 +191,7 @@ public interface ServerTextChannel extends TextableRegularServerChannel, ServerT
      * Threads are ordered by archive_timestamp, in descending order.
      * Requires the READ_MESSAGE_HISTORY permission.
      *
-     * @param before Get public archived threads before the thread with this id.
+     * @param before Get public archived threads archived before this timestamp (in seconds).
      * @return The ArchivedThreads.
      */
     default CompletableFuture<ArchivedThreads> getPublicArchivedThreads(long before) {
@@ -223,7 +223,7 @@ public interface ServerTextChannel extends TextableRegularServerChannel, ServerT
      * Threads are ordered by archive_timestamp, in descending order.
      * Requires the READ_MESSAGE_HISTORY permission.
      *
-     * @param before Get public archived threads before the thread with this id.
+     * @param before Get public archived threads archived before this timestamp (in seconds).
      * @param limit  The maximum amount of public archived threads.
      * @return The ArchivedThreads.
      */
@@ -249,7 +249,7 @@ public interface ServerTextChannel extends TextableRegularServerChannel, ServerT
      * Threads are ordered by archive_timestamp, in descending order.
      * Requires both the READ_MESSAGE_HISTORY and MANAGE_THREADS permissions.
      *
-     * @param before Get private archived threads before the thread with this id.
+     * @param before Get private archived threads archived before this timestamp (in seconds).
      * @return The ArchivedThreads.
      */
     default CompletableFuture<ArchivedThreads> getPrivateArchivedThreads(long before) {
@@ -277,7 +277,7 @@ public interface ServerTextChannel extends TextableRegularServerChannel, ServerT
      * Threads are ordered by archive_timestamp, in descending order.
      * Requires both the READ_MESSAGE_HISTORY and MANAGE_THREADS permissions.
      *
-     * @param before Get private archived threads before the thread with this id.
+     * @param before Get private archived threads archived before this timestamp (in seconds).
      * @param limit  The maximum amount of private archived threads.
      * @return The ArchivedThreads.
      */

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/ServerTextChannel.java
@@ -3,6 +3,8 @@ package org.javacord.api.entity.channel;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.server.ArchivedThreads;
 import org.javacord.api.listener.channel.server.text.ServerTextChannelAttachableListenerManager;
+
+import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -191,10 +193,10 @@ public interface ServerTextChannel extends TextableRegularServerChannel, ServerT
      * Threads are ordered by archive_timestamp, in descending order.
      * Requires the READ_MESSAGE_HISTORY permission.
      *
-     * @param before Get public archived threads archived before this timestamp (in seconds).
+     * @param before Get public archived threads archived before this timestamp.
      * @return The ArchivedThreads.
      */
-    default CompletableFuture<ArchivedThreads> getPublicArchivedThreads(long before) {
+    default CompletableFuture<ArchivedThreads> getPublicArchivedThreads(Instant before) {
         return getPublicArchivedThreads(before, null);
     }
 
@@ -223,11 +225,11 @@ public interface ServerTextChannel extends TextableRegularServerChannel, ServerT
      * Threads are ordered by archive_timestamp, in descending order.
      * Requires the READ_MESSAGE_HISTORY permission.
      *
-     * @param before Get public archived threads archived before this timestamp (in seconds).
+     * @param before Get public archived threads archived before this timestamp.
      * @param limit  The maximum amount of public archived threads.
      * @return The ArchivedThreads.
      */
-    CompletableFuture<ArchivedThreads> getPublicArchivedThreads(Long before, Integer limit);
+    CompletableFuture<ArchivedThreads> getPublicArchivedThreads(Instant before, Integer limit);
 
     /**
      * Gets the private archived threads.
@@ -249,10 +251,10 @@ public interface ServerTextChannel extends TextableRegularServerChannel, ServerT
      * Threads are ordered by archive_timestamp, in descending order.
      * Requires both the READ_MESSAGE_HISTORY and MANAGE_THREADS permissions.
      *
-     * @param before Get private archived threads archived before this timestamp (in seconds).
+     * @param before Get private archived threads archived before this timestamp.
      * @return The ArchivedThreads.
      */
-    default CompletableFuture<ArchivedThreads> getPrivateArchivedThreads(long before) {
+    default CompletableFuture<ArchivedThreads> getPrivateArchivedThreads(Instant before) {
         return getPrivateArchivedThreads(before, null);
     }
 
@@ -277,11 +279,11 @@ public interface ServerTextChannel extends TextableRegularServerChannel, ServerT
      * Threads are ordered by archive_timestamp, in descending order.
      * Requires both the READ_MESSAGE_HISTORY and MANAGE_THREADS permissions.
      *
-     * @param before Get private archived threads archived before this timestamp (in seconds).
+     * @param before Get private archived threads archived before this timestamp.
      * @param limit  The maximum amount of private archived threads.
      * @return The ArchivedThreads.
      */
-    CompletableFuture<ArchivedThreads> getPrivateArchivedThreads(Long before, Integer limit);
+    CompletableFuture<ArchivedThreads> getPrivateArchivedThreads(Instant before, Integer limit);
 
     /**
      * Gets the joined private archived threads.

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelImpl.java
@@ -13,6 +13,9 @@ import org.javacord.core.util.rest.RestMethod;
 import org.javacord.core.util.rest.RestRequest;
 
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
@@ -57,12 +60,13 @@ public class ServerTextChannelImpl extends TextableRegularServerChannelImpl
     }
 
     @Override
-    public CompletableFuture<ArchivedThreads> getPublicArchivedThreads(Long before, Integer limit) {
+    public CompletableFuture<ArchivedThreads> getPublicArchivedThreads(Instant before, Integer limit) {
         RestRequest<ArchivedThreads> request =
                 new RestRequest<ArchivedThreads>(getApi(), RestMethod.GET, RestEndpoint.LIST_PUBLIC_ARCHIVED_THREADS)
                     .setUrlParameters(getIdAsString());
         if (before != null) {
-            request.addQueryParameter("before", Instant.ofEpochSecond(before).toString());
+            request.addQueryParameter("before",
+                    DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC)).format(before));
         }
         if (limit != null) {
             request.addQueryParameter("limit", limit.toString());
@@ -72,12 +76,13 @@ public class ServerTextChannelImpl extends TextableRegularServerChannelImpl
     }
 
     @Override
-    public CompletableFuture<ArchivedThreads> getPrivateArchivedThreads(Long before, Integer limit) {
+    public CompletableFuture<ArchivedThreads> getPrivateArchivedThreads(Instant before, Integer limit) {
         RestRequest<ArchivedThreads> request =
                 new RestRequest<ArchivedThreads>(getApi(), RestMethod.GET, RestEndpoint.LIST_PRIVATE_ARCHIVED_THREADS)
                     .setUrlParameters(getIdAsString());
         if (before != null) {
-            request.addQueryParameter("before", Instant.ofEpochSecond(before).toString());
+            request.addQueryParameter("before",
+                    DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC)).format(before));
         }
         if (limit != null) {
             request.addQueryParameter("limit", limit.toString());

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerTextChannelImpl.java
@@ -1,8 +1,6 @@
 package org.javacord.core.entity.channel;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.channel.ServerTextChannel;
 import org.javacord.api.entity.server.ArchivedThreads;
@@ -14,6 +12,7 @@ import org.javacord.core.util.rest.RestEndpoint;
 import org.javacord.core.util.rest.RestMethod;
 import org.javacord.core.util.rest.RestRequest;
 
+import java.time.Instant;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
@@ -59,51 +58,47 @@ public class ServerTextChannelImpl extends TextableRegularServerChannelImpl
 
     @Override
     public CompletableFuture<ArchivedThreads> getPublicArchivedThreads(Long before, Integer limit) {
-        final ObjectNode body = JsonNodeFactory.instance.objectNode();
+        RestRequest<ArchivedThreads> request =
+                new RestRequest<ArchivedThreads>(getApi(), RestMethod.GET, RestEndpoint.LIST_PUBLIC_ARCHIVED_THREADS)
+                    .setUrlParameters(getIdAsString());
         if (before != null) {
-            body.put("before", before);
+            request.addQueryParameter("before", Instant.ofEpochSecond(before).toString());
         }
         if (limit != null) {
-            body.put("limit", limit);
+            request.addQueryParameter("limit", limit.toString());
         }
-        return new RestRequest<ArchivedThreads>(getApi(), RestMethod.GET, RestEndpoint.LIST_PUBLIC_ARCHIVED_THREADS)
-                .setUrlParameters(getIdAsString())
-                .setBody(body)
-                .execute(result -> new ArchivedThreadsImpl((DiscordApiImpl) getApi(), (ServerImpl) getServer(),
-                        result.getJsonBody()));
+        return request.execute(result -> new ArchivedThreadsImpl((DiscordApiImpl) getApi(), (ServerImpl) getServer(),
+            result.getJsonBody()));
     }
 
     @Override
     public CompletableFuture<ArchivedThreads> getPrivateArchivedThreads(Long before, Integer limit) {
-        final ObjectNode body = JsonNodeFactory.instance.objectNode();
+        RestRequest<ArchivedThreads> request =
+                new RestRequest<ArchivedThreads>(getApi(), RestMethod.GET, RestEndpoint.LIST_PRIVATE_ARCHIVED_THREADS)
+                    .setUrlParameters(getIdAsString());
         if (before != null) {
-            body.put("before", before);
+            request.addQueryParameter("before", Instant.ofEpochSecond(before).toString());
         }
         if (limit != null) {
-            body.put("limit", limit);
+            request.addQueryParameter("limit", limit.toString());
         }
-        return new RestRequest<ArchivedThreads>(getApi(), RestMethod.GET, RestEndpoint.LIST_PRIVATE_ARCHIVED_THREADS)
-                .setUrlParameters(getIdAsString())
-                .setBody(body)
-                .execute(result -> new ArchivedThreadsImpl((DiscordApiImpl) getApi(), (ServerImpl) getServer(),
-                        result.getJsonBody()));
+        return request.execute(result -> new ArchivedThreadsImpl((DiscordApiImpl) getApi(), (ServerImpl) getServer(),
+            result.getJsonBody()));
     }
 
     @Override
     public CompletableFuture<ArchivedThreads> getJoinedPrivateArchivedThreads(Long before, Integer limit) {
-        final ObjectNode body = JsonNodeFactory.instance.objectNode();
+        RestRequest<ArchivedThreads> request = new RestRequest<ArchivedThreads>(
+                getApi(), RestMethod.GET, RestEndpoint.LIST_JOINED_PRIVATE_ARCHIVED_THREADS)
+                    .setUrlParameters(getIdAsString());
         if (before != null) {
-            body.put("before", before);
+            request.addQueryParameter("before", before.toString());
         }
         if (limit != null) {
-            body.put("limit", limit);
+            request.addQueryParameter("limit", limit.toString());
         }
-        return new RestRequest<ArchivedThreads>(getApi(), RestMethod.GET,
-                RestEndpoint.LIST_JOINED_PRIVATE_ARCHIVED_THREADS)
-                .setUrlParameters(getIdAsString())
-                .setBody(body)
-                .execute(result -> new ArchivedThreadsImpl((DiscordApiImpl) getApi(), (ServerImpl) getServer(),
-                        result.getJsonBody()));
+        return request.execute(result -> new ArchivedThreadsImpl((DiscordApiImpl) getApi(), (ServerImpl) getServer(),
+            result.getJsonBody()));
     }
 
     /**


### PR DESCRIPTION
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

## Changelog

### Breaking Changes
- Fixed not working parameters for `getPublicArchivedThreads`, `getPrivateArchivedThreads`, `getJoinedPrivateArchivedThreads` and changed from requiring a channel ID to an Instant

## Description
This PR changes the signature and behavior of the following methods:
- `ServerTextChannel.getPublicArchivedThreads(long before)`
- `ServerTextChannel.getPublicArchivedThreads(Long before, Integer limit)`
- `ServerTextChannel.getPrivateArchivedThreads(long before)`
- `ServerTextChannel.getPrivateArchivedThreads(Long before, Integer limit)`

It also changes the behavior of the following methods:
- `ServerTextChannel.getPublicArchivedThreads(int limit)`
- `ServerTextChannel.getPrivateArchivedThreads(int limit)`
- `ServerTextChannel.getJoinedPrivateArchivedThreads(long before)`
- `ServerTextChannel.getJoinedPrivateArchivedThreads(int limit)`
- `ServerTextChannel.getJoinedPrivateArchivedThreads(Long before, Integer limit)`

Although they never worked properly in the first place, so I don't know if that counts.

Closes: #1268

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.