### PR TITLE
Fix some embed interfaces returning null instead of optional

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedImage.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedImage.java
@@ -6,6 +6,7 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -25,21 +26,21 @@ public interface EmbedImage {
      *
      * @return The proxy url of the image.
      */
-    URL getProxyUrl();
+    Optional<URL> getProxyUrl();
 
     /**
      * Gets the height of the image.
      *
      * @return The height of the image.
      */
-    int getHeight();
+    Optional<Integer> getHeight();
 
     /**
      * Gets the width of the image.
      *
      * @return The width of the image.
      */
-    int getWidth();
+    Optional<Integer> getWidth();
 
     /**
      * Downloads the image as a {@code BufferedImage}.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedProvider.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedProvider.java
@@ -1,19 +1,25 @@
 package org.javacord.api.entity.message.embed;
 
-import org.javacord.api.entity.Nameable;
-
 import java.net.URL;
+import java.util.Optional;
 
 /**
  * This interface represents an embed provider.
  */
-public interface EmbedProvider extends Nameable {
+public interface EmbedProvider {
+
+    /**
+     * Gets the name of the provider.
+     *
+     * @return The name of the provider.
+     */
+    Optional<String> getName();
 
     /**
      * Gets the url of the provider.
      *
      * @return The url of the provider.
      */
-    URL getUrl();
+    Optional<URL> getUrl();
 
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedThumbnail.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedThumbnail.java
@@ -6,6 +6,7 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -25,21 +26,21 @@ public interface EmbedThumbnail {
      *
      * @return The proxy url of the thumbnail.
      */
-    URL getProxyUrl();
+    Optional<URL> getProxyUrl();
 
     /**
      * Gets the height of the thumbnail.
      *
      * @return The height of the thumbnail.
      */
-    int getHeight();
+    Optional<Integer> getHeight();
 
     /**
      * Gets the width of the thumbnail.
      *
      * @return The width of the thumbnail.
      */
-    int getWidth();
+    Optional<Integer> getWidth();
 
     /**
      * Downloads the thumbnail as a {@code BufferedImage}.

--- a/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedVideo.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/message/embed/EmbedVideo.java
@@ -1,6 +1,7 @@
 package org.javacord.api.entity.message.embed;
 
 import java.net.URL;
+import java.util.Optional;
 
 /**
  * This interface represents an embed video.
@@ -12,20 +13,20 @@ public interface EmbedVideo {
      *
      * @return The url of the video.
      */
-    URL getUrl();
+    Optional<URL> getUrl();
 
     /**
      * Gets the height of the video.
      *
      * @return The height of the video.
      */
-    int getHeight();
+    Optional<Integer> getHeight();
 
     /**
      * Gets the width of the video.
      *
      * @return The width of the video.
      */
-    int getWidth();
+    Optional<Integer> getWidth();
 
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedImageImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedImageImpl.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -26,8 +27,8 @@ public class EmbedImageImpl implements EmbedImage {
 
     private final String url;
     private final String proxyUrl;
-    private final int height;
-    private final int width;
+    private final Integer height;
+    private final Integer width;
 
     /**
      * Creates a new embed image.
@@ -37,15 +38,12 @@ public class EmbedImageImpl implements EmbedImage {
     public EmbedImageImpl(JsonNode data) {
         url = data.has("url") ? data.get("url").asText() : null;
         proxyUrl = data.has("proxy_url") ? data.get("proxy_url").asText() : null;
-        height = data.has("height") ? data.get("height").asInt() : -1;
-        width = data.has("width") ? data.get("width").asInt() : -1;
+        height = data.hasNonNull("height") ? data.get("height").asInt() : null;
+        width = data.hasNonNull("width") ? data.get("width").asInt() : null;
     }
 
     @Override
     public URL getUrl() {
-        if (url == null) {
-            return null;
-        }
         try {
             return new URL(url);
         } catch (MalformedURLException e) {
@@ -55,26 +53,26 @@ public class EmbedImageImpl implements EmbedImage {
     }
 
     @Override
-    public URL getProxyUrl() {
+    public Optional<URL> getProxyUrl() {
         if (proxyUrl == null) {
-            return null;
+            return Optional.empty();
         }
         try {
-            return new URL(proxyUrl);
+            return Optional.of(new URL(proxyUrl));
         } catch (MalformedURLException e) {
             logger.warn("Seems like the proxy url of the embed image is malformed! Please contact the developer!", e);
-            return null;
+            return Optional.empty();
         }
     }
 
     @Override
-    public int getHeight() {
-        return height;
+    public Optional<Integer> getHeight() {
+        return Optional.ofNullable(height);
     }
 
     @Override
-    public int getWidth() {
-        return width;
+    public Optional<Integer> getWidth() {
+        return Optional.ofNullable(width);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedProviderImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedProviderImpl.java
@@ -7,6 +7,7 @@ import org.javacord.core.util.logging.LoggerUtil;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Optional;
 
 /**
  * The implementation of {@link EmbedProvider}.
@@ -28,24 +29,24 @@ public class EmbedProviderImpl implements EmbedProvider {
      */
     public EmbedProviderImpl(JsonNode data) {
         name = data.has("name") ? data.get("name").asText() : null;
-        url = data.has("url") && !data.get("url").isNull() ? data.get("url").asText() : null;
+        url = data.hasNonNull("url") ? data.get("url").asText() : null;
     }
 
     @Override
-    public String getName() {
-        return name;
+    public Optional<String> getName() {
+        return Optional.ofNullable(name);
     }
 
     @Override
-    public URL getUrl() {
+    public Optional<URL> getUrl() {
         if (url == null) {
-            return null;
+            return Optional.empty();
         }
         try {
-            return new URL(url);
+            return Optional.of(new URL(url));
         } catch (MalformedURLException e) {
             logger.warn("Seems like the url of the embed provider is malformed! Please contact the developer!", e);
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedThumbnailImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedThumbnailImpl.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -26,8 +27,8 @@ public class EmbedThumbnailImpl implements EmbedThumbnail {
 
     private final String url;
     private final String proxyUrl;
-    private final int height;
-    private final int width;
+    private final Integer height;
+    private final Integer width;
 
     /**
      * Creates a new embed thumbnail.
@@ -37,15 +38,12 @@ public class EmbedThumbnailImpl implements EmbedThumbnail {
     public EmbedThumbnailImpl(JsonNode data) {
         url = data.has("url") ? data.get("url").asText() : null;
         proxyUrl = data.has("proxy_url") ? data.get("proxy_url").asText() : null;
-        height = data.has("height") ? data.get("height").asInt() : -1;
-        width = data.has("width") ? data.get("width").asInt() : -1;
+        height = data.has("height") ? data.get("height").asInt() : null;
+        width = data.has("width") ? data.get("width").asInt() : null;
     }
 
     @Override
     public URL getUrl() {
-        if (url == null) {
-            return null;
-        }
         try {
             return new URL(url);
         } catch (MalformedURLException e) {
@@ -55,26 +53,26 @@ public class EmbedThumbnailImpl implements EmbedThumbnail {
     }
 
     @Override
-    public URL getProxyUrl() {
+    public Optional<URL> getProxyUrl() {
         if (proxyUrl == null) {
-            return null;
+            return Optional.empty();
         }
         try {
-            return new URL(proxyUrl);
+            return Optional.of(new URL(proxyUrl));
         } catch (MalformedURLException e) {
             logger.warn("Seems like the embed thumbnail's proxy url is malformed! Please contact the developer!", e);
-            return null;
+            return Optional.empty();
         }
     }
 
     @Override
-    public int getHeight() {
-        return height;
+    public Optional<Integer> getHeight() {
+        return Optional.ofNullable(height);
     }
 
     @Override
-    public int getWidth() {
-        return width;
+    public Optional<Integer> getWidth() {
+        return Optional.ofNullable(width);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedVideoImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/message/embed/EmbedVideoImpl.java
@@ -7,6 +7,7 @@ import org.javacord.core.util.logging.LoggerUtil;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Optional;
 
 /**
  * The implementation of {@link EmbedVideo}.
@@ -19,8 +20,8 @@ public class EmbedVideoImpl implements EmbedVideo {
     private static final Logger logger = LoggerUtil.getLogger(EmbedVideoImpl.class);
 
     private final String url;
-    private final int height;
-    private final int width;
+    private final Integer height;
+    private final Integer width;
 
     /**
      * Creates a new embed video.
@@ -29,31 +30,31 @@ public class EmbedVideoImpl implements EmbedVideo {
      */
     public EmbedVideoImpl(JsonNode data) {
         url = data.has("url") ? data.get("url").asText() : null;
-        height = data.has("height") ? data.get("height").asInt() : -1;
-        width = data.has("width") ? data.get("width").asInt() : -1;
+        height = data.has("height") ? data.get("height").asInt() : null;
+        width = data.has("width") ? data.get("width").asInt() : null;
     }
 
     @Override
-    public URL getUrl() {
+    public Optional<URL> getUrl() {
         if (url == null) {
-            return null;
+            return Optional.empty();
         }
         try {
-            return new URL(url);
+            return Optional.of(new URL(url));
         } catch (MalformedURLException e) {
             logger.warn("Seems like the url of the embed video is malformed! Please contact the developer!", e);
-            return null;
+            return Optional.empty();
         }
     }
 
     @Override
-    public int getHeight() {
-        return height;
+    public Optional<Integer> getHeight() {
+        return Optional.ofNullable(height);
     }
 
     @Override
-    public int getWidth() {
-        return width;
+    public Optional<Integer> getWidth() {
+        return Optional.ofNullable(width);
     }
 
 }


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog

### Breaking Changes
- Changed the return type of some embed related methods to return an optional as they can return null. (E.g. EmbedThumbnail#getProxyUrl)

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: #1281 
[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.