### PR TITLE
Expose User ID in AuditLogEntry

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/auditlog/AuditLogEntry.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/auditlog/AuditLogEntry.java
@@ -20,6 +20,13 @@ public interface AuditLogEntry extends DiscordEntity {
     AuditLog getAuditLog();
 
     /**
+     * Gets the id of the user who made the changes.
+     *
+     * @return The id of the user who made the changes.
+     */
+    long getUserId();
+
+    /**
      * Gets the user who made the changes.
      *
      * @return The user who made the changes.

--- a/javacord-core/src/main/java/org/javacord/core/entity/auditlog/AuditLogEntryImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/auditlog/AuditLogEntryImpl.java
@@ -274,6 +274,11 @@ public class AuditLogEntryImpl implements AuditLogEntry {
     }
 
     @Override
+    public long getUserId() {
+        return userId;
+    }
+
+    @Override
     public CompletableFuture<User> getUser() {
         return getApi().getUserById(userId);
     }


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Added getter for User ID in AuditLogEntry

## Description
Previously, only `getUser()` was exposed, which fetches the full user object from Discord. If you only need to know the user's ID, for example to check if it's your own client ID, this would result in an unnecessary network call. So let's expose the raw ID!

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.