### PR TITLE
Do no include query param when sending an attachment

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/FileContainer.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/FileContainer.java
@@ -238,7 +238,10 @@ public class FileContainer {
         fileAsUrl = file;
         fileAsByteArray = null;
         fileAsInputStream = null;
-        fileTypeOrName = (isSpoiler ? "SPOILER_" : "") + new File(file.getFile()).getName();
+        fileTypeOrName = (isSpoiler ? "SPOILER_" : "")
+                + (null == file.getQuery()
+                ? new File(file.getFile()).getName()
+                : new File(file.getFile().replace("?" + file.getQuery(), "")).getName());
         fileDescription = description;
     }
 


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Fixed including query param when sending an attachment like: `messge.addAttachment(attachment.getUrl())`

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.