### PR TITLE
Fix incorrect `is` methods in UserChangeDeafenedEventImpl and UserChangeMutedEventImpl

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeDeafenedEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeDeafenedEventImpl.java
@@ -25,12 +25,11 @@ public class UserChangeDeafenedEventImpl extends ServerUserEventImpl implements 
 
     @Override
     public boolean isNewDeafened() {
-        // TODO This is wrong.
-        return newMember.isSelfDeafened();
+        return newMember.isDeafened();
     }
 
     @Override
     public boolean isOldDeafened() {
-        return oldMember.isSelfDeafened();
+        return oldMember.isDeafened();
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeMutedEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeMutedEventImpl.java
@@ -25,11 +25,11 @@ public class UserChangeMutedEventImpl extends ServerUserEventImpl implements Use
 
     @Override
     public boolean isNewMuted() {
-        return newMember.getServer().isSelfMuted(newMember.getUser());
+        return newMember.isMuted();
     }
 
     @Override
     public boolean isOldMuted() {
-        return !isNewMuted();
+        return oldMember.isMuted();
     }
 }


### PR DESCRIPTION
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Changed `UserChangeDeafenedEventImpl`, `UserChangeMutedEventImpl` classes to return `member.isMuted()` & `member.isDeafened()` in `isNew___()` & `isOld__()` methods. 

### Breaking Changes
None
<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description
Both `UserChangeMutedEventImpl` and `UserChangeDeafenedEventImpl` were getting the self values for muted and deafened. So, server mutes or deafens would provide incorrect values on the event if the self values did not match.

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.