### PR TITLE
Add DiscordLocale enum value for Spanish LATAM

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/interaction/DiscordLocale.java
+++ b/javacord-api/src/main/java/org/javacord/api/interaction/DiscordLocale.java
@@ -14,6 +14,7 @@ public enum DiscordLocale {
     ENGLISH_UK("en-GB"),
     ENGLISH_US("en-US"),
     SPANISH("es-ES"),
+    SPANISH_LATAM("es-419"),
     FRENCH("fr"),
     CROATIAN("hr"),
     ITALIAN("it"),


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Add new DiscordLocale enum value for Spanish LATAM (es-419)

### Breaking Changes

None

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description

Locale for Spanish LATAM was added on [Discord API Locale Reference](https://discord.com/developers/docs/reference#locales) and already supports the language on the client [^2]

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.
[^2]: https://discord.com/blog/discord-update-december-13-2023-changelog