### PR TITLE
Add Bulk Ban Support

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/server/BulkBanResponse.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/BulkBanResponse.java
@@ -1,0 +1,23 @@
+package org.javacord.api.entity.server;
+
+import java.util.Collection;
+
+/**
+ * The response of a bulk ban request.
+ */
+public interface BulkBanResponse {
+
+    /**
+     * Gets the user ids that were banned successfully.
+     *
+     * @return The banned user ids.
+     */
+    Collection<Long> getBannedUserIds();
+
+    /**
+     * Gets the user ids that could not be banned.
+     *
+     * @return The failed user ids.
+     */
+    Collection<Long> getFailedUserIds();
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -67,6 +67,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 /**
  * The class represents a Discord server, sometimes also called guild.
@@ -2281,6 +2282,55 @@ public interface Server extends DiscordEntity, Nameable, Deletable, UpdatableFro
     default CompletableFuture<Void> banUser(long userId, Duration duration, String reason) {
         return banUser(Long.toUnsignedString(userId), duration, reason);
     }
+
+    /**
+     * Bans the given users from the server.
+     *
+     * @param userIds The ids of the users to ban.
+     * @return A future returning details about the bulk ban.
+     */
+    default CompletableFuture<BulkBanResponse> bulkBanUsers(long... userIds) {
+        return bulkBanUsers(
+                LongStream.of(userIds).mapToObj(Long::toUnsignedString).collect(Collectors.toList()),
+                0, TimeUnit.SECONDS, null);
+    }
+
+    /**
+     * Bans the given users from the server.
+     *
+     * @param userIds The ids of the users to ban.
+     * @return A future returning details about the bulk ban.
+     */
+    default CompletableFuture<BulkBanResponse> bulkBanUsers(String... userIds) {
+        return bulkBanUsers(Arrays.asList(userIds), 0, TimeUnit.SECONDS, null);
+    }
+
+    /**
+     * Bans the given users from the server.
+     *
+     * @param userIds               The ids of the users to ban.
+     * @param deleteMessageDuration The number of messages to delete within the duration.
+     *                              (Between 0 and 604800 seconds (7 days))
+     * @param unit                  The unit of time for the duration.
+     * @return A future returning details about the bulk ban.
+     */
+    default CompletableFuture<BulkBanResponse> bulkBanUsers(Collection<String> userIds, long deleteMessageDuration,
+                                                            TimeUnit unit) {
+        return bulkBanUsers(userIds, 0, TimeUnit.SECONDS, null);
+    }
+
+    /**
+     * Bans the given users from the server.
+     *
+     * @param userIds               The ids of the users to ban.
+     * @param deleteMessageDuration The number of messages to delete within the duration.
+     *                              (Between 0 and 604800 seconds (7 days))
+     * @param unit                  The unit of time for the duration.
+     * @param reason                The Audit Log reason for the bulk ban.
+     * @return A future returning details about the bulk ban.
+     */
+    CompletableFuture<BulkBanResponse> bulkBanUsers(Collection<String> userIds, long deleteMessageDuration,
+                                                    TimeUnit unit, String reason);
 
     /**
      * Unbans the given user from the server.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/Server.java
@@ -2172,7 +2172,7 @@ public interface Server extends DiscordEntity, Nameable, Deletable, UpdatableFro
      * @return A future to check if the ban was successful.
      */
     default CompletableFuture<Void> banUser(String userId) {
-        return banUser(userId, null);
+        return banUser(userId, Duration.ZERO);
     }
 
     /**

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/BulkBanResponseImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/BulkBanResponseImpl.java
@@ -1,0 +1,45 @@
+package org.javacord.core.entity.server;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.javacord.api.entity.server.BulkBanResponse;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class BulkBanResponseImpl implements BulkBanResponse {
+
+    /**
+     * The user ids that were banned successfully.
+     */
+    private final Set<Long> bannedUserIds;
+
+    /**
+     * The user ids that could not be banned.
+     */
+    private final Set<Long> failedUserIds;
+
+    /**
+     * Create a new BulkBanResponseImpl.
+     *
+     * @param data The json data about this response.
+     */
+    public BulkBanResponseImpl(JsonNode data) {
+        Set<Long> bannedUsers = new HashSet<>();
+        Set<Long> failedUsers = new HashSet<>();
+        data.get("banned_users").forEach(bannedUser -> bannedUsers.add(bannedUser.asLong()));
+        data.get("failed_users").forEach(failedUser -> failedUsers.add(failedUser.asLong()));
+        bannedUserIds = Collections.unmodifiableSet(bannedUsers);
+        failedUserIds = Collections.unmodifiableSet(failedUsers);
+    }
+
+    @Override
+    public Collection<Long> getBannedUserIds() {
+        return bannedUserIds;
+    }
+
+    @Override
+    public Collection<Long> getFailedUserIds() {
+        return failedUserIds;
+    }
+}

--- a/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/rest/RestEndpoint.java
@@ -43,6 +43,7 @@ public enum RestEndpoint {
     WEBHOOK_MESSAGE("/webhooks/%s/%s/messages/%s",0),
     INVITE("/invites/%s"),
     BAN("/guilds/%s/bans", 0),
+    BULK_BAN("/guilds/%s/bulk-ban", 0),
     CURRENT_USER("/users/@me"),
     AUDIT_LOG("/guilds/%s/audit-logs", 0),
     CUSTOM_EMOJI("/guilds/%s/emojis", 0),

--- a/javacord-core/src/main/java/org/javacord/core/util/rest/RestRequestResultErrorCode.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/rest/RestRequestResultErrorCode.java
@@ -244,7 +244,8 @@ public enum RestRequestResultErrorCode {
             "Webhooks posted to forum channels cannot have both a thread_name and thread_id"),
     WEBHOOKS_CAN_ONLY_CREATE_THREADS_IN_FORUM_CHANNELS(220003, "Webhooks can only create threads in forum channels"),
     WEBHOOK_SERVICES_CANNOT_BE_USED_IN_FORUM_CHANNELS(220004, "Webhook services cannot be used in forum channels"),
-    MESSAGE_BLOCKED_BY_HARMFUL_LINKS_FILTER(240000, "Message blocked by harmful links filter");
+    MESSAGE_BLOCKED_BY_HARMFUL_LINKS_FILTER(240000, "Message blocked by harmful links filter"),
+    FAILED_TO_BAN_USERS(500000, "Failed to ban users");
 
     /**
      * A map for retrieving the enum instances by code.


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Added bulk ban support
- Fixed NPE in default ban method

### Breaking Changes

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description

- https://github.com/discord/discord-api-docs/pull/6720
- Also fixes an NPE when calling `Server#banUser(String)`; this method would previously pass `null` as the `Duration` to the other overloads, which would then attempt to call `duration.getSeconds()`.

I'm not 100% confident that the `BulkBanResponse` I used is the way you generally want to approach such cases where an endpoint returns a special object that doesn't occur anywhere else, and I also wasn't quite sure where to put it; for now, I've put it next to the `Ban`  classes representing a single ban. Feedback appreciated.

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.