### PR TITLE
Fix concurrency issues with voice- and thread members

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerThreadChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerThreadChannelImpl.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The implementation of {@link ServerThreadChannel}.
@@ -94,7 +95,7 @@ public class ServerThreadChannelImpl extends ServerChannelImpl implements Server
         lastMessageId = data.hasNonNull("last_message_id") ? data.get("last_message_id").asLong() : 0;
         rateLimitPerUser = data.get("rate_limit_per_user").asInt(0);
 
-        members = new HashSet<>();
+        members = ConcurrentHashMap.newKeySet();
         if (data.hasNonNull("member")) {
             // If userId is not included, that means this came from a GUILD_CREATE event
             // This means the userId is the bot's and the thread id is from this thread

--- a/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerVoiceChannelImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/channel/ServerVoiceChannelImpl.java
@@ -11,11 +11,11 @@ import org.javacord.core.entity.server.ServerImpl;
 import org.javacord.core.listener.channel.server.voice.InternalServerVoiceChannelAttachableListenerManager;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -37,7 +37,7 @@ public class ServerVoiceChannelImpl extends TextableRegularServerChannelImpl
     /**
      * The ids of the connected users of this server voice channel.
      */
-    private final Set<Long> connectedUsers = new HashSet<>();
+    private final Set<Long> connectedUsers = ConcurrentHashMap.newKeySet();
 
     /**
      * Creates a new server voice channel object.


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
Please try to begin your change with one of the following words: Added, Improved, Fixed, Changed, Removed, Deprecated 
-->
## Changelog
- Fix concurrency issues with voice- and thread members

### Breaking Changes

<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description
The `connectedUsers` of a voice channel can be updated by a gateway event handler at the same time as you're iterating over it in your client code, causing a ConcurrentModificationException as it wasn't using a thread-safe data structure before.

I've looked through all instances of `HashSet` and found the `members` property of a Thread channel to potentially have the same issue, as it can be updated by an event handler at the same time your client code handles it.

Other occurrences appear to be safe, same as with `HashMap` from what I could see.

<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.