### PR TITLE
Add documentation for reserved role color

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/Role.java
@@ -196,6 +196,8 @@ public interface Role extends DiscordEntity, Mentionable, Nameable, Deletable, P
     /**
      * Updates the color of the role.
      *
+     * <p>{@link Color#BLACK} is reserved for the default role color.
+     *
      * <p>If you want to update several settings at once, it's recommended to use the
      * {@link RoleUpdater} from {@link #createUpdater()} which provides a better performance!
      *

--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/RoleBuilder.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/RoleBuilder.java
@@ -69,6 +69,8 @@ public class RoleBuilder {
     /**
      * Sets the color of the role.
      *
+     * <p>{@link Color#BLACK} is reserved for the default role color.
+     *
      * @param color The color of the role.
      * @return The current instance in order to chain call methods.
      */

--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/RoleUpdater.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/RoleUpdater.java
@@ -66,6 +66,8 @@ public class RoleUpdater {
     /**
      * Queues the color to be updated.
      *
+     * <p>{@link Color#BLACK} is reserved for the default role color.
+     *
      * @param color The new color of the role.
      * @return The current instance in order to chain call methods.
      */

--- a/javacord-api/src/main/java/org/javacord/api/entity/permission/internal/RoleUpdaterDelegate.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/permission/internal/RoleUpdaterDelegate.java
@@ -41,6 +41,8 @@ public interface RoleUpdaterDelegate {
     /**
      * Queues the color to be updated.
      *
+     * <p>{@link Color#BLACK} is reserved for the default role color.
+     *
      * @param color The new color of the role.
      */
     void setColor(Color color);


### PR DESCRIPTION
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

## Changelog
- Added reserved role color documentation

## Description

Adds Javadoc notes about `Color.BLACK` being reserved for the default role color.

I tested embeds as well and there doesn't appear to be a reserved color for embeds anymore.

Closes: #676 

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.