### PR TITLE
fix: switch "nick" to "global_name" where applicable

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/user/MemberImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/MemberImpl.java
@@ -60,16 +60,16 @@ public final class MemberImpl implements Member {
         this.selfMuted = false;
         this.selfDeafened = false;
 
+        if (data.hasNonNull("user") && data.get("user").hasNonNull("global_name")) {
+            nickname = data.get("user").get("global_name").asText();
+        } else {
+            nickname = null;
+        }
+
         if (data.hasNonNull("user")) {
             this.user = new UserImpl(api, data.get("user"), this, null);
         } else {
             this.user = user;
-        }
-
-        if (data.hasNonNull("nick")) {
-            nickname = data.get("nick").asText();
-        } else {
-            nickname = null;
         }
 
         roleIds = new ArrayList<>();


### PR DESCRIPTION
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

## Changelog
- [fix: switch "nick" to "global_name" where applicable](https://github.com/Javacord/Javacord/commit/4cf6b27c4f5cab2eeef43ea345751f580ae27a65)

### Breaking Changes
I don't think so. Are some discord bots still receiving `nick` as a json field for global nickname? The official docs point towards no. Looking through issues & prs on the discord api docs also indicate no.

## Description
The Discord API phased out `nick` as the field for the nickname for `global_name`. The only thing that I kept `nick` is the updater as it is still indicated to be `nick` in the PATCH request. All data structures, methods, and so on keep the phrase Nickname as it would likely be an unnecessary breaking change. 
Closes: #1309

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.