### PR TITLE
feat: Add global name to user

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/user/User.java
@@ -50,6 +50,13 @@ public interface User extends DiscordEntity, Messageable, Nameable, Mentionable,
     }
 
     /**
+     * Gets the global name of the user.
+     *
+     * @return The global name of the user.
+     */
+    Optional<String> getGlobalName();
+
+    /**
      * Gets the discriminator of the user.
      *
      * @return The discriminator of the user.

--- a/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeGlobalNameEvent.java
+++ b/javacord-api/src/main/java/org/javacord/api/event/user/UserChangeGlobalNameEvent.java
@@ -1,0 +1,24 @@
+package org.javacord.api.event.user;
+
+import java.util.Optional;
+
+/**
+ * A user global name change event.
+ */
+public interface UserChangeGlobalNameEvent extends UserEvent {
+
+    /**
+     * Gets the new global name of the user.
+     *
+     * @return The new global name of the user.
+     */
+    Optional<String> getNewGlobalName();
+
+    /**
+     * Gets the old global name of the user.
+     *
+     * @return The new global name of the user.
+     */
+    Optional<String> getOldGlobalName();
+
+}

--- a/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangeGlobalNameListener.java
+++ b/javacord-api/src/main/java/org/javacord/api/listener/user/UserChangeGlobalNameListener.java
@@ -1,0 +1,22 @@
+package org.javacord.api.listener.user;
+
+import org.javacord.api.event.user.UserChangeGlobalNameEvent;
+import org.javacord.api.listener.GloballyAttachableListener;
+import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.listener.server.ServerAttachableListener;
+
+/**
+ * This listener listens to global name changes.
+ */
+@FunctionalInterface
+public interface UserChangeGlobalNameListener extends ServerAttachableListener, UserAttachableListener,
+                                                        GloballyAttachableListener, ObjectAttachableListener {
+
+    /**
+     * This method is called every time a user changed their global name.
+     *
+     * @param event The event.
+     */
+    void onUserChangeGlobalName(UserChangeGlobalNameEvent event);
+
+}

--- a/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/user/UserImpl.java
@@ -47,6 +47,7 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
     private final DiscordApiImpl api;
     private final Long id;
     private final String name;
+    private final String globalName;
     private final String discriminator;
     private final String avatarHash;
     private EnumSet<UserFlag> userFlags = EnumSet.noneOf(UserFlag.class);
@@ -66,6 +67,11 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
         this.api = api;
         id = data.get("id").asLong();
         name = data.get("username").asText();
+        if (data.hasNonNull("global_name")) {
+            globalName = data.get("global_name").asText();
+        } else {
+            globalName = null;
+        }
         discriminator = data.get("discriminator").asText();
         if (data.hasNonNull("avatar")) {
             avatarHash = data.get("avatar").asText();
@@ -101,6 +107,11 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
         this.api = api;
         id = data.get("id").asLong();
         name = data.get("username").asText();
+        if (data.hasNonNull("global_name")) {
+            globalName = data.get("global_name").asText();
+        } else {
+            globalName = null;
+        }
         discriminator = data.get("discriminator").asText();
         if (data.hasNonNull("avatar")) {
             avatarHash = data.get("avatar").asText();
@@ -120,11 +131,12 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
         member = new MemberImpl(api, server, memberJson, this);
     }
 
-    private UserImpl(DiscordApiImpl api, Long id, String name, String discriminator, String avatarHash, boolean bot,
-                     MemberImpl member) {
+    private UserImpl(DiscordApiImpl api, Long id, String name, String globalName,
+                     String discriminator, String avatarHash, boolean bot, MemberImpl member) {
         this.api = api;
         this.id = id;
         this.name = name;
+        this.globalName = globalName;
         this.discriminator = discriminator;
         this.avatarHash = avatarHash;
         this.bot = bot;
@@ -146,6 +158,12 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
             name = partialUserJson.get("username").asText();
         }
 
+        String globalName = this.globalName;
+        if (partialUserJson.has("global_name")) {
+            JsonNode globalNameNode = partialUserJson.get("global_name");
+            globalName = globalNameNode.isNull() ? null : globalNameNode.asText();
+        }
+
         String discriminator = this.discriminator;
         if (partialUserJson.hasNonNull("discriminator")) {
             discriminator = partialUserJson.get("discriminator").asText();
@@ -156,7 +174,7 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
             avatarHash = partialUserJson.get("avatar").asText();
         }
 
-        return new UserImpl(api, id, name, discriminator, avatarHash, bot, member);
+        return new UserImpl(api, id, name, globalName, discriminator, avatarHash, bot, member);
     }
 
     /**
@@ -186,6 +204,11 @@ public class UserImpl implements User, InternalUserAttachableListenerManager {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public Optional<String> getGlobalName() {
+        return Optional.ofNullable(globalName);
     }
 
     @Override

--- a/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeGlobalNameEventImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/event/user/UserChangeGlobalNameEventImpl.java
@@ -1,0 +1,44 @@
+package org.javacord.core.event.user;
+
+import org.javacord.api.entity.user.User;
+import org.javacord.api.event.user.UserChangeGlobalNameEvent;
+
+import java.util.Optional;
+
+/**
+ * The implementation of {@link UserChangeGlobalNameEvent}.
+ */
+public class UserChangeGlobalNameEventImpl extends UserEventImpl implements UserChangeGlobalNameEvent {
+
+    /**
+     * The new global name of the user.
+     */
+    private final String newGlobalName;
+    /**
+     * The old global name of the user.
+     */
+    private final String oldGlobalName;
+
+    /**
+     * Creates a new user global name change event.
+     *
+     * @param user The user of the event.
+     * @param newGlobalName The new global name of the user.
+     * @param oldGlobalName The old global name of the user.
+     */
+    public UserChangeGlobalNameEventImpl(User user, String newGlobalName, String oldGlobalName) {
+        super(user);
+        this.newGlobalName = newGlobalName;
+        this.oldGlobalName = oldGlobalName;
+    }
+
+    @Override
+    public Optional<String> getNewGlobalName() {
+        return Optional.ofNullable(newGlobalName);
+    }
+
+    @Override
+    public Optional<String> getOldGlobalName() {
+        return Optional.ofNullable(oldGlobalName);
+    }
+}


### PR DESCRIPTION
## Checklist
- [x] I have tested this PR[^1].
- [x] I have read the [contributing guidelines](https://github.com/Javacord/Javacord/blob/master/.github/CONTRIBUTING.md).

## Changelog
- [feat: Add global name to user](https://github.com/Javacord/Javacord/commit/052f5ad250a8382548f92c7c347326633c0735fe)

### Breaking Changes
None.

## Description
- Added global name as a private final field on UserImpl.
- Added getGlobalName() to User.
- Created UserChangeGlobalName Event, EventImpl, and Listener.
- Added "global_name" check and dispatchUserChangeGlobalNameEvent in GuildMemberUpdateHandler.java.
- Added `GLOBAL_NAME` enum to audit log.

### Tested by ensuring:
- Event fires only once, even if user and bot share multiple servers.
- Global name changes:
  1. `null` to `"someName"`
  2. `"someName"` to `"someOtherName"`
  3. `"someOtherName"` to `null`
  4. `"someOtherName"` to `"null"`
  5. `"null"` to `null`


Closes: #1309 

[^1]: At least started a running bot instance with your changes and triggered an event so your changed code gets executed.